### PR TITLE
Ensure ern builder is configured for principal unit test

### DIFF
--- a/clc/modules/msgs/src/test/java/com/eucalyptus/auth/principal/PrincipalTest.groovy
+++ b/clc/modules/msgs/src/test/java/com/eucalyptus/auth/principal/PrincipalTest.groovy
@@ -19,6 +19,10 @@
  ************************************************************************/
 package com.eucalyptus.auth.principal
 
+import com.eucalyptus.auth.policy.ern.Ern
+import com.eucalyptus.auth.policy.ern.EuareErnBuilder
+import org.junit.BeforeClass
+
 import static org.junit.Assert.*
 import org.junit.Test
 
@@ -28,6 +32,11 @@ import static com.eucalyptus.auth.principal.Principal.PrincipalType.AWS
  * 
  */
 class PrincipalTest {
+
+  @BeforeClass
+  static void beforeClass( ) {
+    Ern.registerServiceErnBuilder( new EuareErnBuilder( ) );
+  }
 
   @Test
   void testPrincipalMatcherConversion() {


### PR DESCRIPTION
Fix unit test that can fail depending on test execution order.