### PR TITLE
EC2 explicit libvirt append attribute due to rhel 7.4 default 

### DIFF
--- a/tools/libvirt.xsl
+++ b/tools/libvirt.xsl
@@ -312,6 +312,7 @@ that describes a Eucalyptus instance to be launched.
                 <xsl:when test="(/instance/hypervisor/@type = 'kvm' or /instance/hypervisor/@type = 'qemu')">
                     <serial type="file">
                         <source>
+                            <xsl:attribute name="append">on</xsl:attribute>
                             <xsl:attribute name="path">
                                 <xsl:value-of select="/instance/consoleLogPath"/>
                             </xsl:attribute>


### PR DESCRIPTION
EC2 add explicit libvirt append attribute due to change in the default value for rhel 7.4 libvirt.

This pull request fixes Corymbia/eucalyptus#7 and EUCA-13447