### PR TITLE
Polled notifications service excluded from access logging

### DIFF
--- a/clc/modules/msgs/src/main/java/com/eucalyptus/component/ComponentId.java
+++ b/clc/modules/msgs/src/main/java/com/eucalyptus/component/ComponentId.java
@@ -475,6 +475,13 @@ public abstract class ComponentId implements HasName<ComponentId>, HasFullName<C
   }
 
   /**
+   * Should access for this service be logged.
+   */
+  public boolean isRequestLogged( ) {
+    return true;
+  }
+
+  /**
    * Temporary work around allowing components to opt out of DNS.
    *
    * @deprecated

--- a/clc/modules/msgs/src/main/java/com/eucalyptus/ws/server/ServiceAccessLoggingHandler.java
+++ b/clc/modules/msgs/src/main/java/com/eucalyptus/ws/server/ServiceAccessLoggingHandler.java
@@ -72,7 +72,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
-
 import org.apache.log4j.Logger;
 import org.jboss.netty.channel.ChannelDownstreamHandler;
 import org.jboss.netty.channel.ChannelEvent;
@@ -83,7 +82,6 @@ import org.jboss.netty.channel.ExceptionEvent;
 import org.jboss.netty.channel.MessageEvent;
 import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpMethod;
-
 import com.eucalyptus.component.ComponentId;
 import com.eucalyptus.component.ComponentIds;
 import com.eucalyptus.component.ComponentMessages;
@@ -177,6 +175,9 @@ public enum ServiceAccessLoggingHandler implements ChannelUpstreamHandler, Chann
         try {
           final Class<? extends ComponentId> compMsg = ComponentMessages.lookup( ( BaseMessage ) replyObject );
           final ComponentId compId = ComponentIds.lookup( compMsg );
+          if ( !compId.isRequestLogged( ) ) {
+            return;
+          }
           componentName = compId.name( );
         } catch ( Exception e ) {
           //GRZE: this needs to be a separate logger to avoid hitting the configured category for this class.

--- a/clc/modules/simpleworkflow-common/src/main/java/com/eucalyptus/simpleworkflow/stateful/PolledNotifications.java
+++ b/clc/modules/simpleworkflow-common/src/main/java/com/eucalyptus/simpleworkflow/stateful/PolledNotifications.java
@@ -51,6 +51,11 @@ public class PolledNotifications extends ComponentId {
     return false;
   }
 
+  @Override
+  public boolean isRequestLogged() {
+    return false;
+  }
+
   /**
    * This forces the service to be co-located with the ENABLED cloud controller.
    */


### PR DESCRIPTION
Disable request logging for the internal polled notification service.

This pull request fixes Corymbia/eucalyptus#15