### PR TITLE
EC2 fix subnet netmask to cidr prefix calculation for dns subnet check

### DIFF
--- a/clc/modules/msgs/src/main/java/com/eucalyptus/util/Subnets.java
+++ b/clc/modules/msgs/src/main/java/com/eucalyptus/util/Subnets.java
@@ -175,7 +175,7 @@ public class Subnets extends ServiceJarDiscovery {
       this.subnetMask = InetAddresses.coerceToInteger( netmask );
       this.networkId = InetAddresses.coerceToInteger( address ) & this.subnetMask;
       this.subnet = InetAddresses.fromInteger( networkId );
-      this.prefix = ( int ) Math.round( Math.log( Integer.lowestOneBit( this.subnetMask ) ) / Math.log( 2 ) );
+      this.prefix = 32 - (( int ) Math.round( Math.log( Integer.lowestOneBit( this.subnetMask ) ) / Math.log( 2 ) ) );
     }
     
     Subnet( InetAddress subnet, int prefix ) throws UnknownHostException {


### PR DESCRIPTION
Fixes recursive dns for cloud in a box deployments.

This pull request fixes Corymbia/eucalyptus#16