### PR TITLE
S3 add connection close header for object gets

### DIFF
--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/handlers/ObjectStorageGETOutboundHandler.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/handlers/ObjectStorageGETOutboundHandler.java
@@ -192,6 +192,9 @@ public class ObjectStorageGETOutboundHandler extends ObjectStorageBasicOutboundH
             Channels.write(ctx, bodyWriteFuture, dataStream);
           }
         });
+        if ( !httpResponse.containsHeader( HttpHeaders.Names.CONNECTION ) ) {
+          httpResponse.addHeader( HttpHeaders.Names.CONNECTION, HttpHeaders.Values.CLOSE );
+        }
       } else {
         writeFuture.addListener(ChannelFutureListener.CLOSE);
       }


### PR DESCRIPTION
S3 GET responses now have a close header when the connection is being closed.

This pull request fixes Corymbia/eucalyptus#17