### PR TITLE
Set umask consistently for thread safety

### DIFF
--- a/node/xml.c
+++ b/node/xml.c
@@ -363,6 +363,7 @@ static int write_xml_file(const xmlDocPtr doc, const char *instanceId, const cha
     chmod(path, BACKING_FILE_PERM);    // ensure perms in case when XML file exists
     if ((ret = xmlSaveFormatFileEnc(path, doc, "UTF-8", 1)) > 0) {
         LOGTRACE("[%s] wrote %s XML to %s\n", instanceId, type, path);
+        chmod(path, BACKING_FILE_PERM);
     } else {
         LOGERROR("[%s] failed to write %s XML to %s\n", instanceId, type, path);
     }

--- a/node/xml.c
+++ b/node/xml.c
@@ -358,7 +358,7 @@ static int path_check(const char *path, const char *name)
 static int write_xml_file(const xmlDocPtr doc, const char *instanceId, const char *path, const char *type)
 {
     int ret = 0;
-    mode_t old_umask = umask(~BACKING_FILE_PERM);   // ensure the generated XML file has the right perms
+    umask(0022);   // ensure the generated XML file has the right perms
 
     chmod(path, BACKING_FILE_PERM);    // ensure perms in case when XML file exists
     if ((ret = xmlSaveFormatFileEnc(path, doc, "UTF-8", 1)) > 0) {
@@ -366,7 +366,6 @@ static int write_xml_file(const xmlDocPtr doc, const char *instanceId, const cha
     } else {
         LOGERROR("[%s] failed to write %s XML to %s\n", instanceId, type, path);
     }
-    umask(old_umask);
     return ((ret > 0) ? (EUCA_OK) : (EUCA_ERROR));
 }
 

--- a/storage/blobstore.c
+++ b/storage/blobstore.c
@@ -4046,9 +4046,8 @@ int blockblob_copy(blockblob * src_bb, unsigned long long src_offset_bytes, bloc
     // do the copy (with block devices dd will silently omit to copy bytes outside the block boundary, so we use paths for uncloned blobs)
     const char *src_path = (src_bb->snapshot_type == BLOBSTORE_SNAPSHOT_DM) ? (blockblob_get_dev(src_bb)) : (blockblob_get_file(src_bb));
     const char *dst_path = (dst_bb->snapshot_type == BLOBSTORE_SNAPSHOT_DM) ? (blockblob_get_dev(dst_bb)) : (blockblob_get_file(dst_bb));
-    mode_t old_umask = umask(~BLOBSTORE_FILE_PERM);
+    umask(0022);
     int error = diskutil_dd2(src_path, dst_path, granularity, copy_len_bytes / granularity, dst_offset_bytes / granularity, src_offset_bytes / granularity);
-    umask(old_umask);
     if (error) {
         ERR(BLOBSTORE_ERROR_INVAL, "failed to copy a section");
         return -1;

--- a/util/log.c
+++ b/util/log.c
@@ -341,7 +341,7 @@ static FILE *get_file_impl(const char *log_file, FILE * fp, ino_t * log_inop, bo
 retry:
     // open unless it is already is open
     if (fp == NULL) {
-        mode_t old_umask = umask(~LOG_FILE_PERM);
+        umask(0022);
         fp = fopen(log_file, "a+");
         if (fp != NULL) {
             fd = fileno(fp);
@@ -349,7 +349,6 @@ retry:
                 fcntl(fd, F_SETFD, FD_CLOEXEC);
             }
         }
-        umask(old_umask);
         if (fp == NULL) {
             return NULL;
         }

--- a/util/log.c
+++ b/util/log.c
@@ -347,6 +347,7 @@ retry:
             fd = fileno(fp);
             if (fd != -1) {
                 fcntl(fd, F_SETFD, FD_CLOEXEC);
+                fchmod(fd, LOG_FILE_PERM);
             }
         }
         if (fp == NULL) {


### PR DESCRIPTION
Node controller now uses a standard 0022 umask.

This pull request fixes Corymbia/eucalyptus#20