### PR TITLE
Ceph / snapshot transfer resource handling

### DIFF
--- a/clc/modules/block-storage-common/src/main/java/com/eucalyptus/blockstorage/ceph/CanonicalRbdObject.java
+++ b/clc/modules/block-storage-common/src/main/java/com/eucalyptus/blockstorage/ceph/CanonicalRbdObject.java
@@ -10,50 +10,43 @@ import com.google.common.base.Strings;
 public class CanonicalRbdObject {
   private static final Logger LOG = Logger.getLogger(CanonicalRbdObject.class);
 
-  private String pool;
-  private String image;
-  private String snapshot;
+  private final String pool;
+  private final String image;
+  private final String snapshot;
 
   public String getPool() {
     return pool;
   }
 
-  public void setPool(String pool) {
-    this.pool = pool;
-  }
-
   public CanonicalRbdObject withPool(String pool) {
-    this.pool = pool;
-    return this;
+    return new CanonicalRbdObject( pool, this.image, this.snapshot );
   }
 
   public String getImage() {
     return image;
   }
 
-  public void setImage(String image) {
-    this.image = image;
-  }
-
   public CanonicalRbdObject withImage(String image) {
-    this.image = image;
-    return this;
+    return new CanonicalRbdObject( this.pool, image, this.snapshot );
   }
 
   public String getSnapshot() {
     return snapshot;
   }
 
-  public void setSnapshot(String snapshot) {
-    this.snapshot = snapshot;
-  }
-
   public CanonicalRbdObject withSnapshot(String snapshot) {
-    this.snapshot = snapshot;
-    return this;
+    return new CanonicalRbdObject( this.pool, this.image, snapshot );
   }
 
-  public CanonicalRbdObject() {}
+  public CanonicalRbdObject( ) {
+    this( null, null, null );
+  }
+
+  public CanonicalRbdObject( final String pool, final String image, final String snapshot ) {
+    this.pool = pool;
+    this.image = image;
+    this.snapshot = snapshot;
+  }
 
   @Override
   public String toString() {

--- a/clc/modules/block-storage-common/src/main/java/com/eucalyptus/blockstorage/ceph/CephRbdConnectionManager.java
+++ b/clc/modules/block-storage-common/src/main/java/com/eucalyptus/blockstorage/ceph/CephRbdConnectionManager.java
@@ -36,21 +36,25 @@ import com.eucalyptus.blockstorage.ceph.exceptions.EucalyptusCephException;
  */
 public class CephRbdConnectionManager implements AutoCloseable {
 
-  private static Logger LOG = Logger.getLogger(CephRbdConnectionManager.class);
+  private static final Logger LOG = Logger.getLogger(CephRbdConnectionManager.class);
   private static final String KEYRING = "keyring";
+  private static final Object connectionSync = new Object();
 
+  private final Object shutdownSync = new Object();
   private Rados rados;
   private IoCTX ioContext;
   private Rbd rbd;
   private String pool;
 
-  private CephRbdConnectionManager(CephRbdInfo config, String poolName) {
+  private CephRbdConnectionManager(final CephRbdInfo config, final String poolName) {
     try {
       LOG.trace("Opening a new connection to Ceph cluster pool=" + poolName);
       rados = new Rados(config.getCephUser());
       rados.confSet(KEYRING, config.getCephKeyringFile());
       rados.confReadFile(new File(config.getCephConfigFile()));
-      rados.connect();
+      synchronized ( connectionSync ) {
+        rados.connect();
+      }
       pool = poolName;
       ioContext = rados.ioCtxCreate(pool);
       rbd = new Rbd(ioContext);
@@ -82,14 +86,24 @@ public class CephRbdConnectionManager implements AutoCloseable {
   public void disconnect() {
     try {
       LOG.trace("Closing connection to Ceph cluster pool=" + pool);
-      if (rados != null && ioContext != null) {
-        rados.ioCtxDestroy(ioContext);
-        // Calling shutdown causes the following initialization of rados to seg-fault and crash the jvm. commenting it out
-        // rados.shutDown();
-        rados = null;
-        ioContext = null;
+      synchronized ( shutdownSync ) {
+        final Rados shutdownRados = rados;
+        final IoCTX shutdownIoContext = ioContext;
         rbd = null;
         pool = null;
+        rados = null;
+        ioContext = null;
+        if ( shutdownRados != null ) {
+          try {
+            if ( shutdownIoContext != null ) {
+              shutdownRados.ioCtxDestroy( shutdownIoContext );
+            }
+          } finally {
+            synchronized ( connectionSync ) {
+              shutdownRados.shutDown();
+            }
+          }
+        }
       }
     } catch (Exception e) {
       LOG.debug("Caught error during teardown", e);
@@ -101,7 +115,7 @@ public class CephRbdConnectionManager implements AutoCloseable {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close( ){
     disconnect();
   }
 }

--- a/clc/modules/block-storage-common/src/main/java/com/eucalyptus/blockstorage/ceph/CephRbdInputStream.java
+++ b/clc/modules/block-storage-common/src/main/java/com/eucalyptus/blockstorage/ceph/CephRbdInputStream.java
@@ -67,6 +67,7 @@ import java.io.InputStream;
 
 import org.apache.log4j.Logger;
 
+import com.ceph.rbd.RbdException;
 import com.ceph.rbd.RbdImage;
 import com.eucalyptus.blockstorage.ceph.entities.CephRbdInfo;
 
@@ -74,18 +75,24 @@ public class CephRbdInputStream extends InputStream {
 
   private static final Logger LOG = Logger.getLogger(CephRbdInputStream.class);
 
+  private final Object closeSync = new Object();
   private CephRbdConnectionManager conn;
   private RbdImage rbdImage;
   private long position;
   private boolean isOpen;
 
-  public CephRbdInputStream(String imageName, String poolName, CephRbdInfo info) throws IOException {
+  public CephRbdInputStream(
+      final String imageName,
+      final String poolName,
+      final CephRbdInfo info
+  ) throws IOException {
     try {
-      conn = CephRbdConnectionManager.getConnection(info, poolName);
+      conn = CephRbdConnectionManager.getConnection( info, poolName );
       rbdImage = conn.getRbd().open(imageName);
       isOpen = true;
       position = 0;
     } catch (Exception e) {
+      close( );
       throw new IOException("Failed to open CephInputStream for image " + imageName + " in pool " + poolName, e);
     }
   }
@@ -117,7 +124,7 @@ public class CephRbdInputStream extends InputStream {
 
     if (isOpen) {
       byte[] buffer = new byte[len];
-      int bytesRead = 0;
+      int bytesRead;
       if ((bytesRead = rbdImage.read(position, buffer, buffer.length)) > 0) { // something was read
         position += bytesRead;
         for (int i = 0; i < bytesRead; i++) {
@@ -141,20 +148,29 @@ public class CephRbdInputStream extends InputStream {
   }
 
   @Override
-  public void close() {
-    if (isOpen) {
-      try {
-        conn.getRbd().close(rbdImage);
-      } catch (Exception e) {
-
-      } finally {
+  public void close( ) {
+    synchronized ( closeSync ) {
+      if ( isOpen ) {
+        final CephRbdConnectionManager closeConn = conn;
+        final RbdImage closeRbdImage = rbdImage;
         isOpen = false;
-        conn.disconnect();
         conn = null;
         rbdImage = null;
+
+        if ( closeConn != null ) {
+          try {
+            if ( closeRbdImage != null ) {
+              closeConn.getRbd( ).close( closeRbdImage );
+            }
+          } catch ( final RbdException e ) {
+            LOG.error( "Error closing image " + closeRbdImage.getName( ), e );
+          } finally {
+            closeConn.close( );
+          }
+        }
+      } else {
+        // nothing to do here, stream is not open/already closed
       }
-    } else {
-      // nothing to do here, stream is not open/already closed
     }
   }
 }

--- a/clc/modules/block-storage-common/src/main/java/com/eucalyptus/blockstorage/ceph/CephRbdOutputStream.java
+++ b/clc/modules/block-storage-common/src/main/java/com/eucalyptus/blockstorage/ceph/CephRbdOutputStream.java
@@ -75,6 +75,7 @@ public class CephRbdOutputStream extends OutputStream {
 
   private static final Logger LOG = Logger.getLogger(CephRbdOutputStream.class);
 
+  private final Object closeSync = new Object();
   private CephRbdConnectionManager conn;
   private RbdImage rbdImage;
   private long position;
@@ -87,6 +88,7 @@ public class CephRbdOutputStream extends OutputStream {
       isOpen = true;
       position = 0;
     } catch (Exception e) {
+      close( );
       throw new IOException("Failed to open CephInputStream for image " + imageName + " in pool " + poolName, e);
     }
   }
@@ -141,19 +143,28 @@ public class CephRbdOutputStream extends OutputStream {
 
   @Override
   public void close() {
-    if (isOpen) {
-      try {
-        conn.getRbd().close(rbdImage);
-      } catch (Exception e) {
-
-      } finally {
+    synchronized ( closeSync ) {
+      if ( isOpen ) {
+        final CephRbdConnectionManager closeConn = conn;
+        final RbdImage closeRbdImage = rbdImage;
         isOpen = false;
-        conn.disconnect();
         conn = null;
         rbdImage = null;
+
+        if ( closeConn != null ) {
+          try {
+            if ( closeRbdImage != null ) {
+              closeConn.getRbd( ).close( closeRbdImage );
+            }
+          } catch ( final RbdException e ) {
+            LOG.error( "Error closing image " + closeRbdImage.getName( ), e );
+          } finally {
+            closeConn.close( );
+          }
+        }
+      } else {
+        // nothing to do here, stream is not open/already closed
       }
-    } else {
-      // nothing to do here, stream is not open/already closed
     }
   }
 }

--- a/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/S3SnapshotTransfer.java
+++ b/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/S3SnapshotTransfer.java
@@ -272,13 +272,14 @@ public class S3SnapshotTransfer implements SnapshotTransfer {
       Path zipFilePath = Files.createTempFile(Paths.get("/var/tmp"), keyName + '-', '-' + String.valueOf(partNumber));
       part = SnapshotPart.createPart(snapUploadInfo, zipFilePath.toString(), partNumber, readOffset);
 
-      InputStream inputStream = storageResource.getInputStream();
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
       GZIPOutputStream gzipStream = new GZIPOutputStream(baos);
       FileOutputStream outputStream = new FileOutputStream(zipFilePath.toString());
+      InputStream inputStream = null;
 
       try {
         LOG.debug("Reading snapshot " + snapshotId + " and compressing it to disk in chunks of size " + partSize + " bytes or greater");
+        inputStream = storageResource.getInputStream( );
         while ((len = inputStream.read(buffer)) > 0) {
           bytesRead += len;
           gzipStream.write(buffer, 0, len);


### PR DESCRIPTION
Ensure snapshot input stream closed on error. Shutdown rados on disconnect/close rather than waiting for finalization to do so and ensure rados init/shutdown is thread safe.

This pull request fixes Corymbia/eucalyptus#19 and EUCA-13199