### PR TITLE
CloudWatch put system metrics to consistent service

### DIFF
--- a/clc/modules/cloudwatch-common/src/main/java/com/eucalyptus/cloudwatch/common/internal/domain/listmetrics/ListMetricManager.java
+++ b/clc/modules/cloudwatch-common/src/main/java/com/eucalyptus/cloudwatch/common/internal/domain/listmetrics/ListMetricManager.java
@@ -314,6 +314,7 @@ public class ListMetricManager {
     // do db stuff in a certain number of operations per connection
     for (List<PrefetchFields> prefetchFieldsListPartial : Iterables.partition(dataBatchPrefetchMap.keySet(), LIST_METRIC_NUM_DB_OPERATIONS_PER_TRANSACTION)) {
       try (final TransactionResource db = Entities.transactionFor(ListMetric.class)) {
+        Entities.flushOnCommit(ListMetric.class);
         int numOperations = 0;
         for (PrefetchFields prefetchFields: prefetchFieldsListPartial) {
           // Prefetch all list metrics with same metric name/namespace/account id

--- a/clc/modules/cloudwatch-service/src/main/java/com/eucalyptus/cloudwatch/service/queue/listmetrics/ListMetricQueue.java
+++ b/clc/modules/cloudwatch-service/src/main/java/com/eucalyptus/cloudwatch/service/queue/listmetrics/ListMetricQueue.java
@@ -25,8 +25,10 @@ import com.eucalyptus.cloudwatch.common.internal.domain.metricdata.SimpleMetricE
 import com.eucalyptus.system.Threads;
 import com.eucalyptus.util.metrics.MonitoredAction;
 import com.eucalyptus.util.metrics.ThruputMetrics;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.google.common.primitives.Longs;
 
 import org.apache.log4j.Logger;
 
@@ -133,7 +135,15 @@ public class ListMetricQueue {
   }
 
   static {
-    dataFlushTimer.scheduleAtFixedRate(safeRunner, 0, 5, TimeUnit.MINUTES);
+    final String PROP_LIST_METRICS_FLUSH_INTERVAL = "com.eucalyptus.cloudwatch.listMetricsFlushInterval";
+    final long DEFAULT_LIST_METRICS_FLUSH_INTERVAL = 300L;
+    final long LIST_METRICS_FLUSH_INTERVAL = MoreObjects.firstNonNull(
+        Longs.tryParse(
+            System.getProperty(
+                PROP_LIST_METRICS_FLUSH_INTERVAL,
+                String.valueOf( DEFAULT_LIST_METRICS_FLUSH_INTERVAL ) ) ),
+            DEFAULT_LIST_METRICS_FLUSH_INTERVAL );
+    dataFlushTimer.scheduleAtFixedRate(safeRunner, 0, LIST_METRICS_FLUSH_INTERVAL, TimeUnit.SECONDS);
   }
 
   public void addAll(List<SimpleMetricEntity> dataBatch) {

--- a/clc/modules/cloudwatch-service/src/main/java/com/eucalyptus/cloudwatch/service/queue/metricdata/MetricDataQueue.java
+++ b/clc/modules/cloudwatch-service/src/main/java/com/eucalyptus/cloudwatch/service/queue/metricdata/MetricDataQueue.java
@@ -31,9 +31,11 @@ import com.eucalyptus.cloudwatch.service.queue.listmetrics.ListMetricQueue;
 import com.eucalyptus.system.Threads;
 import com.eucalyptus.util.metrics.MonitoredAction;
 import com.eucalyptus.util.metrics.ThruputMetrics;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.primitives.Longs;
 
 import org.apache.log4j.Logger;
 
@@ -102,7 +104,15 @@ public class MetricDataQueue {
   };
 
   static {
-    dataFlushTimer.scheduleAtFixedRate(safeRunner, 0, 1, TimeUnit.MINUTES);
+    final String PROP_METRICS_FLUSH_INTERVAL = "com.eucalyptus.cloudwatch.metricsFlushInterval";
+    final long DEFAULT_METRICS_FLUSH_INTERVAL = 60L;
+    final long METRICS_FLUSH_INTERVAL = MoreObjects.firstNonNull(
+        Longs.tryParse(
+            System.getProperty(
+                PROP_METRICS_FLUSH_INTERVAL,
+                String.valueOf( DEFAULT_METRICS_FLUSH_INTERVAL ) ) ),
+        DEFAULT_METRICS_FLUSH_INTERVAL );
+    dataFlushTimer.scheduleAtFixedRate(safeRunner, 0, METRICS_FLUSH_INTERVAL, TimeUnit.SECONDS);
   }
 
   public static List<SimpleMetricEntity> aggregate(List<SimpleMetricEntity> dataBatch) {

--- a/clc/modules/msgs/src/main/java/com/eucalyptus/entities/Entities.java
+++ b/clc/modules/msgs/src/main/java/com/eucalyptus/entities/Entities.java
@@ -80,6 +80,7 @@ import javax.annotation.Nullable;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.EntityTransaction;
+import javax.persistence.FlushModeType;
 import javax.persistence.LockModeType;
 import javax.persistence.NoResultException;
 import javax.persistence.NonUniqueResultException;
@@ -513,6 +514,15 @@ public class Entities {
 
   public static <T> void flushSession( final T object ) {
     getTransaction( object ).txState.getSession().flush( );
+  }
+
+  /**
+   * Set the flush mode to on-commit, avoiding any pre-query auto flushing
+   *
+   * @param object The object used to determine the transaction context
+   */
+  public static void flushOnCommit( final Object object ) {
+    getTransaction( object ).txState.getEntityManager( ).setFlushMode( FlushModeType.COMMIT );
   }
 
   public static <T> void clearSession( final T object ) {


### PR DESCRIPTION
CloudWatch metric puts are now sent to a consistent user facing service instance to reduce the chances of conflicts when flushing list metrics data.

Flush schedules are no longer hard-coded and could be changed via configuration if necessary.

This pull request fixes Corymbia/eucalyptus#10