### PR TITLE
Update libvirt requirement to 2.0.0+

### DIFF
--- a/rpm/eucalyptus.spec
+++ b/rpm/eucalyptus.spec
@@ -53,7 +53,7 @@ BuildRequires: java-1.8.0-openjdk-devel >= 1:1.8.0
 BuildRequires: jpackage-utils
 BuildRequires: json-c-devel
 BuildRequires: libuuid-devel
-BuildRequires: libvirt-devel >= 0.6
+BuildRequires: libvirt-devel >= 2.0.0
 BuildRequires: libxml2-devel
 BuildRequires: libxslt-devel
 BuildRequires: m2crypto
@@ -289,7 +289,7 @@ Requires:     kvm
 # Ceph support requires librados2, librbd1, and *also* qemu-kvm-rhev.
 Requires:     librados2%{?_isa}
 Requires:     librbd1%{?_isa}
-Requires:     libvirt
+Requires:     libvirt >= 2.0.0
 Requires:     libvirt-python
 Requires:     perl(Sys::Virt)
 Requires:     perl(Time::HiRes)
@@ -704,6 +704,9 @@ usermod -a -G libvirt eucalyptus || :
 
 
 %changelog
+* Thu May 10 2018 Steve Jones <steve.jones@appscale.com> - 4.4.4
+- Update libvirt requirement to 2.0.0+
+
 * Fri Mar  9 2018 Steve Jones <steve.jones@appscale.com> - 4.4.3
 - Build now handles rpm version
 


### PR DESCRIPTION
This pull request updates the node controllers libvirt dependency to 2.0.0 or higher ensuring that functionality we now use (as of 4.4.3) is available.

> If the interface type presented to the host is "file", then the source element may contain an optional attribute append that specifies whether or not the information in the file should be preserved on domain restart. Allowed values are "on" and "off" (default). Since 1.3.1. 

https://libvirt.org/formatdomain.html#elementsConsole

rpm with this pull request:

```
# rpm -q --requires eucalyptus-nc | grep ^libvirt
libvirt >= 2.0.0
libvirt-python
libvirt.so.0()(64bit)
libvirt.so.0(LIBVIRT_0.0.3)(64bit)
libvirt.so.0(LIBVIRT_0.1.0)(64bit)
libvirt.so.0(LIBVIRT_0.1.9)(64bit)
libvirt.so.0(LIBVIRT_0.2.1)(64bit)
libvirt.so.0(LIBVIRT_0.3.2)(64bit)
libvirt.so.0(LIBVIRT_0.7.3)(64bit)
#
#
# rpm -qa libvirt
libvirt-3.9.0-14.el7_5.2.x86_64
```

previously:

```
# rpm -q --requires eucalyptus-nc | grep ^libvirt
libvirt
libvirt-python
libvirt.so.0()(64bit)
libvirt.so.0(LIBVIRT_0.0.3)(64bit)
libvirt.so.0(LIBVIRT_0.1.0)(64bit)
libvirt.so.0(LIBVIRT_0.1.9)(64bit)
libvirt.so.0(LIBVIRT_0.2.1)(64bit)
libvirt.so.0(LIBVIRT_0.3.2)(64bit)
libvirt.so.0(LIBVIRT_0.7.3)(64bit)
#
#
# rpm -qa libvirt
libvirt-3.9.0-14.el7_5.2.x86_64
```

I think 2.0.0 was in the initial release of rhel 7.3 so this change is not expected to impact installs on any supported os (rhel/centos 7.3, 7.4)

Fixes Corymbia/eucalyptus#55