### PR TITLE
S3 objects are now flagged when they may require cleanup

### DIFF
--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/entities/ObjectEntity.java
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/entities/ObjectEntity.java
@@ -45,6 +45,7 @@ import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.PersistenceContext;
 import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 
@@ -119,6 +120,9 @@ public class ObjectEntity extends S3AccessControlledEntity<ObjectState> implemen
 
   @Column(name = "is_latest")
   private Boolean isLatest;
+
+  @Column(name = "is_cleanup_required")
+  private Boolean isCleanupRequired;
 
   @Column(name = "creation_expiration")
   private Long creationExpiration; // Expiration time in system/epoch time to guarantee monotonically increasing values
@@ -269,7 +273,7 @@ public class ObjectEntity extends S3AccessControlledEntity<ObjectState> implemen
     deleteMarker.setObjectModifiedTimestamp(new Date());
     deleteMarker.setIsDeleteMarker(true);
     deleteMarker.setSize(0L);
-    deleteMarker.setIsLatest(true);
+    deleteMarker.markLatest();
     return deleteMarker;
   }
 
@@ -350,8 +354,21 @@ public class ObjectEntity extends S3AccessControlledEntity<ObjectState> implemen
     return isLatest;
   }
 
+  public void markLatest() {
+    setIsLatest(Boolean.TRUE);
+    setCleanupRequired(Boolean.TRUE);
+  }
+
   public void setIsLatest(Boolean isLatest) {
     this.isLatest = isLatest;
+  }
+
+  public Boolean getCleanupRequired() {
+    return isCleanupRequired;
+  }
+
+  public void setCleanupRequired(final Boolean cleanupRequired) {
+    isCleanupRequired = cleanupRequired;
   }
 
   public boolean isNullVersioned() {
@@ -497,6 +514,14 @@ public class ObjectEntity extends S3AccessControlledEntity<ObjectState> implemen
     }
 
   }
+
+  @PreUpdate
+  protected void preUpdate() {
+    if (!Boolean.TRUE.equals(getIsLatest())) {
+      setCleanupRequired(null);
+    }
+  }
+
   // TODO: add delete marker support. Fix is to use super-type for versioning entry and sub-types for version vs deleteMarker
 
 }

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageGateway.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageGateway.java
@@ -1637,7 +1637,7 @@ public class ObjectStorageGateway implements ObjectStorageService {
         destObject.setSize(srcObject.getSize());
         destObject.setStorageClass(srcObject.getStorageClass());
         destObject.seteTag(srcObject.geteTag());
-        destObject.setIsLatest(Boolean.TRUE);
+        destObject.markLatest();
 
         // Prep the request to be sent to the backend
         request.setSourceObject(srcObject.getObjectUuid());

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/asynctask/BucketReaperTask.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/asynctask/BucketReaperTask.java
@@ -171,7 +171,7 @@ public class BucketReaperTask {
     LOG.trace("Cleaning object histories for bucket uuid " + b.getBucketUuid() + ", name " + b.getBucketName());
     do {
       try {
-        result = ObjectMetadataManagers.getInstance().listPaginated(b, chunkSize, null, null, nextKey);
+        result = ObjectMetadataManagers.getInstance().listForCleanupPaginated(b, chunkSize, null, null, nextKey);
       } catch (final Throwable f) {
         LOG.error("Could not get object listing for bucket " + b.getBucketName() + " with next marker: " + nextKey);
         break;

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/metadata/ObjectMetadataManager.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/metadata/ObjectMetadataManager.java
@@ -161,6 +161,20 @@ public interface ObjectMetadataManager {
       String startVersionId, boolean latestOnly) throws Exception;
 
   /**
+   * List the objects in the given bucket requiring cleanup
+   *
+   * @param bucket
+   * @param maxRecordCount
+   * @param prefix
+   * @param delimiter
+   * @param startKey
+   * @return
+   * @throws TransactionException
+   */
+  public PaginatedResult<ObjectEntity> listForCleanupPaginated(Bucket bucket, int maxRecordCount, String prefix, String delimiter, String startKey)
+      throws Exception;
+
+  /**
    * Delete the object entity
    * 
    * @param objectToDelete
@@ -212,17 +226,6 @@ public interface ObjectMetadataManager {
    * @throws Exception
    */
   public void flushUploads(Bucket bucket) throws Exception;
-
-  /**
-   * Similar to cleanupInvalidObjects but does not preserve the latest. Will set all 'null' versioned object records to 'deleting' state. This is
-   * intended for synchronous invocation during object creation to invalidate all extant 'null' versions of the object to make quota-enforcement
-   * feasible.
-   * 
-   * @param bucket
-   * @param objectKey
-   * @throws Exception
-   */
-  public void cleanupAllNullVersionedObjectRecords(Bucket bucket, String objectKey) throws Exception;
 
   /**
    * Returns objects stuck in 'creating' state that are determined to be failed. Failure detection is based on timestamp comparision is limited by the

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/metadata/ObjectStateTransitions.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/metadata/ObjectStateTransitions.java
@@ -126,7 +126,7 @@ public class ObjectStateTransitions {
             updatingEntity.setState(ObjectState.extant);
             updatingEntity.setCreationExpiration(null);
             updatingEntity.setObjectModifiedTimestamp(entity.getObjectModifiedTimestamp());
-            updatingEntity.setIsLatest(true);
+            updatingEntity.markLatest();
             updatingEntity.seteTag(entity.geteTag());
             updatingEntity.setSize(entity.getSize());
             updatingEntity.setStoredHeaders(entity.getStoredHeaders());


### PR DESCRIPTION
This pull request adds a new flag to s3 object entities to indicate when version clean up may be needed. When an object version is set as the latest (i.e. version added or removed) we now also set the "cleanup required" flag. The clean up flag is only meaningful on the latest version of an object.

The bucket reaper task now performs version clean up only for these flagged objects rather than all objects in a bucket. This task clears the clean up flag after processing an object, allowing progress to be made even when there are many objects to be checked.

It is generally the case that periodic clean up is not required, as clean up is performed when updates to an object are made. Having a flag allows for manual triggering of object version clean up (via database change) should it ever be necessary.