### PR TITLE
Object storage access denied on create error message updated

### DIFF
--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/exceptions/s3/S3Exceptions.groovy
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/exceptions/s3/S3Exceptions.groovy
@@ -159,6 +159,12 @@ class AccessDeniedException extends S3Exception {
   }
 }
 
+class AccessDeniedOnCreateException extends AccessDeniedException {
+  def AccessDeniedOnCreateException(String resource) {
+    super(resource, "Access denied due to permissions or limit exceeded");
+  }
+}
+
 class AccountProblemException extends S3Exception {
   def AccountProblemException() {
     super(S3ErrorCodeStrings.AccountProblem, "There is a problem with your Eucalyptus account that prevents the operation from completing successfully. Please use Contact Us.", HttpResponseStatus.FORBIDDEN);

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageGateway.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageGateway.java
@@ -82,6 +82,7 @@ import com.eucalyptus.objectstorage.exceptions.MetadataOperationFailureException
 import com.eucalyptus.objectstorage.exceptions.NoSuchEntityException;
 import com.eucalyptus.objectstorage.exceptions.ObjectStorageException;
 import com.eucalyptus.objectstorage.exceptions.s3.AccessDeniedException;
+import com.eucalyptus.objectstorage.exceptions.s3.AccessDeniedOnCreateException;
 import com.eucalyptus.objectstorage.exceptions.s3.AccountProblemException;
 import com.eucalyptus.objectstorage.exceptions.s3.BucketAlreadyExistsException;
 import com.eucalyptus.objectstorage.exceptions.s3.BucketNotEmptyException;
@@ -465,7 +466,7 @@ public class ObjectStorageGateway implements ObjectStorageService {
       ObjectEntity objectEntity = ObjectEntity.newInitializedForCreate(bucket, request.getKey(), objectSize, requestUser, request.getCopiedHeaders());
 
       if (!OsgAuthorizationHandler.getInstance().operationAllowed(request, bucket, objectEntity, objectSize)) {
-        throw new AccessDeniedException(request.getBucket());
+        throw new AccessDeniedOnCreateException(request.getBucket());
       }
 
       // Auth checks passed, check if 100-continue needs to be sent
@@ -693,7 +694,7 @@ public class ObjectStorageGateway implements ObjectStorageService {
       } else {
         LOG.error("CorrelationId: " + request.getCorrelationId() + " Create bucket " + request.getBucket()
             + " access is denied based on ACL and/or IAM policy");
-        throw new AccessDeniedException(request.getBucket());
+        throw new AccessDeniedOnCreateException(request.getBucket());
       }
     } catch (AccessDeniedException e) {
       LOG.debug("CorrelationId: " + Contexts.lookup().getCorrelationId() + " Responding to client with AccessDeniedException");
@@ -1677,7 +1678,7 @@ public class ObjectStorageGateway implements ObjectStorageService {
         return reply;
 
       } else {
-        throw new AccessDeniedException(destinationBucket + "/" + destinationKey);
+        throw new AccessDeniedOnCreateException(destinationBucket + "/" + destinationKey);
       }
     } else {
       throw new AccessDeniedException(sourceBucket + "/" + sourceKey);
@@ -2610,7 +2611,7 @@ public class ObjectStorageGateway implements ObjectStorageService {
         throw new InternalErrorException(partEntity.getResourceFullName(), e);
       }
     } else {
-      throw new AccessDeniedException(request.getBucket());
+      throw new AccessDeniedOnCreateException(request.getBucket());
     }
   }
 


### PR DESCRIPTION
This pull request updates the error message (error code is not changed) when access is denied on s3 resource creation. Determining if a denial is actually due to a quota being exceeded would be convoluted, so for now there is a hint that the error could be caused by a quota.