### PR TITLE
Node controller error logging when console.log not present

### DIFF
--- a/node/handlers_default.c
+++ b/node/handlers_default.c
@@ -548,13 +548,15 @@ int shutdown_then_destroy_domain(const char *instanceId, boolean do_destroy)
         char ipath[EUCA_MAX_PATH] = { 0 };
         if (get_instance_path(instanceId, ipath, sizeof(ipath)) != EUCA_OK || strlen(ipath) <= 0) {
             LOGERROR("Failed to find instance path for instance %s\n", instanceId);
-        } else {
+        } else if (check_path(ipath) == 0) {
             char log_path_current[EUCA_MAX_PATH] = { 0 };
             char log_path_new[EUCA_MAX_PATH] = { 0 };
             snprintf(log_path_current, (sizeof(log_path_current) - 1), "%s/console.log", ipath);
             snprintf(log_path_new,     (sizeof(log_path_new) - 1), "%s/console.log.old", ipath);
-            if (rename(log_path_current, log_path_new) == -1) {
-                LOGERROR("Failed to move console log file from %s to %s\n", log_path_current, log_path_new);
+            if (check_path(log_path_current) == 0) {
+                if (rename(log_path_current, log_path_new) == -1) {
+                    LOGERROR("Failed to move console log file from %s to %s\n", log_path_current, log_path_new);
+                }
             }
         }
     }


### PR DESCRIPTION
Node controller now checks paths before attempting to move the console log to avoid spurious error log messages.