### PR TITLE
Allow generation of correctly named https certificate

### DIFF
--- a/clc/modules/msgs/src/main/java/com/eucalyptus/crypto/CertificateProvider.java
+++ b/clc/modules/msgs/src/main/java/com/eucalyptus/crypto/CertificateProvider.java
@@ -45,6 +45,7 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.X509Certificate;
 import java.util.Date;
+import java.util.Set;
 
 import javax.security.auth.x500.X500Principal;
 
@@ -67,6 +68,7 @@ public interface CertificateProvider extends BaseSecurityProvider {
    */
   public abstract X509Certificate generateCertificate( KeyPair keys, X500Principal subjectDn, X500Principal signer, PrivateKey signingKey );
   public abstract X509Certificate generateCertificate( KeyPair keys, X500Principal subjectDn, X500Principal signer, PrivateKey signingKey, Date notAfter );
+  public abstract X509Certificate generateCertificate( KeyPair keys, X500Principal subjectDn, X500Principal signer, PrivateKey signingKey, Date notAfter, Set<String> alternativeNames );
   public abstract X509Certificate generateCertificate( PublicKey key, X500Principal subjectDn, X500Principal signer, PrivateKey signingKey, Date notAfter );
   public abstract X509Certificate generateCertificate( KeyPair keys, String userName );
   public abstract X509Certificate generateCertificate( KeyPair keys, X500Principal subjectDn );
@@ -75,5 +77,6 @@ public interface CertificateProvider extends BaseSecurityProvider {
    * Mechanically identical to the above, but signed by the root cert.
    */
   public abstract X509Certificate generateServiceCertificate( KeyPair keys, String userName );
+  public abstract X509Certificate generateServiceCertificate( KeyPair keys, String userName, Set<String> alternativeNames );
 
 }

--- a/clc/modules/msgs/src/main/java/com/eucalyptus/crypto/Certs.java
+++ b/clc/modules/msgs/src/main/java/com/eucalyptus/crypto/Certs.java
@@ -45,6 +45,7 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.X509Certificate;
 import java.util.Date;
+import java.util.Set;
 
 import javax.security.auth.x500.X500Principal;
 
@@ -117,7 +118,15 @@ public class Certs {
   public static X509Certificate generateServiceCertificate( final KeyPair keys, final String userName ) {
     return Crypto.getCertificateProvider( ).generateServiceCertificate( keys, userName );
   }
-  
+
+  public static X509Certificate generateServiceCertificate(
+      final KeyPair keys,
+      final String userName,
+      final Set<String> alternativeNames
+  ) {
+    return Crypto.getCertificateProvider( ).generateServiceCertificate( keys, userName, alternativeNames );
+  }
+
   public static String getFingerPrint( Key privKey ) {
     return Crypto.getCertificateProvider( ).getFingerPrint( privKey );
   }


### PR DESCRIPTION
This pull request simplifies generating an https certificate for web services that contains the correct metadata for the endpoints/buckets in use. If such a certificate is configured for trust then https can be used without also needing special configuration for the mismatched host name.

This support for the subject alternative names extension is not used by default, no change is expected in the default behaviour due to this pull request.