### PR TITLE
Node controller should allow grace period for termination

### DIFF
--- a/node/handlers.c
+++ b/node/handlers.c
@@ -1297,6 +1297,11 @@ static void refresh_instance_info(struct nc_state_t *nc, ncInstance * instance)
             }
 
             if (new_state == SHUTOFF || new_state == SHUTDOWN || new_state == CRASHED) {
+                if (instance->terminationRequestedTime > (time(NULL) - nc_state.shutdown_grace_period_sec)) {
+                    LOGINFO("[%s] ignoring hypervisor reported state %s for terminating domain during grace period (%d)\n",
+                            instance->instanceId, instance_state_names[new_state], nc_state.shutdown_grace_period_sec);
+                    break;
+                }
                 LOGWARN("[%s] hypervisor reported previously running domain as %s\n", instance->instanceId, instance_state_names[new_state]);
             }
             // change to state, whatever it happens to be

--- a/node/handlers_default.c
+++ b/node/handlers_default.c
@@ -101,7 +101,6 @@
 \*----------------------------------------------------------------------------*/
 
 #define VOL_RETRIES 3
-#define SHUTDOWN_GRACE_PERIOD_SEC 60
 
 /*----------------------------------------------------------------------------*\
  |                                                                            |
@@ -488,7 +487,7 @@ int shutdown_then_destroy_domain(const char *instanceId, boolean do_destroy)
         boolean failed_to_shutdown = FALSE;
 
         if (deadline == 0) {           // first time through the loop
-            deadline = time(NULL) + SHUTDOWN_GRACE_PERIOD_SEC;
+            deadline = time(NULL) + nc_state.shutdown_grace_period_sec;
 
             // give OS a chance to shut down cleanly
             LOGDEBUG("shutting down instance\n");


### PR DESCRIPTION
This pull request alters the node controllers monitoring thread behaviour so that an instance reported by libvirt as shutdown (etc) is ignored during an instances shutdown grace period. It is expected that during this time the terminating thread is active in `shutdown_then_destroy_domain` and will handle clean up for the instance.

If the monitoring thread processes the shutdown instance then artifacts can be left behind as libvirt is performing clean up while in this state.

With the fix in place the new INFO log message is seen during instance churn testing, but not the `failed to remove some artifacts` message:

```
2018-07-03 19:24:33  INFO | [i-58c5024b] ignoring hypervisor reported state Shutdown for terminating domain during grace period (60)
```

with context:

```
2018-07-03 19:24:31  INFO | [i-58c5024b] termination requested
2018-07-03 19:24:32  INFO | [i-58c5024b] assigning address: [0.0.0.0]
2018-07-03 19:24:33  INFO | [i-58c5024b] ignoring hypervisor reported state Shutdown for terminating domain during grace period (60)
2018-07-03 19:24:34  INFO | [i-58c5024b] instance terminated
2018-07-03 19:24:36  INFO | [i-58c5024b] assigning address: [192.168.181.47]
2018-07-03 19:24:40  INFO | [i-58c5024b] cleaning up state for instance
```