### PR TITLE
S3 object listing v2 (4.4 backport)

### DIFF
--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/entities/ObjectEntity.java
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/entities/ObjectEntity.java
@@ -475,14 +475,16 @@ public class ObjectEntity extends S3AccessControlledEntity<ObjectState> implemen
    *
    * @return
    */
-  public ListEntry toListEntry() {
+  public ListEntry toListEntry(boolean includeOwner) {
     ListEntry e = new ListEntry();
     e.setEtag("\"" + this.geteTag() + "\"");
     e.setKey(this.getObjectKey());
     e.setLastModified(DateFormatter.dateToListingFormattedString(this.getObjectModifiedTimestamp()));
     e.setSize(this.getSize());
     e.setStorageClass(this.getStorageClass());
-    e.setOwner(new CanonicalUser(this.getOwnerCanonicalId(), this.getOwnerDisplayName()));
+    if (includeOwner) {
+      e.setOwner( new CanonicalUser( this.getOwnerCanonicalId( ), this.getOwnerDisplayName( ) ) );
+    }
     return e;
   }
 

--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/msgs/ObjectStorage.groovy
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/msgs/ObjectStorage.groovy
@@ -810,28 +810,44 @@ public class DeleteResponseType extends ObjectStorageResponseType {
 @ResourceType(PolicySpec.S3_RESOURCE_BUCKET)
 @RequiresACLPermission(object = [], bucket = [ObjectStorageProperties.Permission.READ])
 public class ListBucketType extends ObjectStorageRequestType {
-  String prefix;
-  String marker;
-  String maxKeys;
-  String delimiter;
+  String prefix
+  String maxKeys
+  String delimiter
+
+  // v1
+  String marker
+
+  // v2
+  String startAfter
+  String continuationToken
+  String fetchOwner
+  String listType
 
   def ListBucketType() {
-    prefix = "";
-    marker = "";
-    //delimiter = "";
+    prefix = ""
+    marker = ""
+    //delimiter = ""
   }
 }
 
 public class ListBucketResponseType extends ObjectStorageResponseType {
-  String name;
-  String prefix;
-  String marker;
-  String nextMarker;
-  int maxKeys;
-  String delimiter;
-  boolean isTruncated;
-  ArrayList<ListEntry> contents;
-  ArrayList<CommonPrefixesEntry> commonPrefixesList = new ArrayList<CommonPrefixesEntry>();
+  String name
+  String prefix
+  int maxKeys
+  String delimiter
+  boolean isTruncated
+  ArrayList<ListEntry> contents
+  ArrayList<CommonPrefixesEntry> commonPrefixesList = new ArrayList<CommonPrefixesEntry>()
+
+  // v1 listing
+  String marker
+  String nextMarker
+
+  // v2 listing
+  String startAfter
+  Integer keyCount
+  String continuationToken
+  String nextContinuationToken
 }
 
 /* GET /bucket?versions */

--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/util/ObjectStorageProperties.java
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/util/ObjectStorageProperties.java
@@ -477,7 +477,7 @@ public class ObjectStorageProperties {
   }
 
   public enum BucketParameter {
-    acl, location, prefix, maxkeys, delimiter, marker, torrent, logging, versioning, versions, versionidmarker, keymarker, cors, lifecycle, policy, notification, tagging, requestPayment, website, uploads, maxUploads, uploadIdMarker, delete
+    acl, location, prefix, maxkeys, delimiter, marker, torrent, logging, versioning, versions, versionidmarker, keymarker, cors, lifecycle, policy, notification, tagging, requestPayment, website, uploads, maxUploads, uploadIdMarker, delete, startafter, continuationtoken, fetchowner, listtype
   }
 
   public enum ObjectParameter {

--- a/clc/modules/object-storage-common/src/main/resources/osg-binding.xml
+++ b/clc/modules/object-storage-common/src/main/resources/osg-binding.xml
@@ -123,8 +123,12 @@
              class="com.eucalyptus.objectstorage.msgs.ListBucketResponseType">
         <value name="Name" field="name"/>
         <value name="Prefix" field="prefix"/>
-        <value name="Marker" field="marker"/>
+        <value name="Marker" field="marker" usage="optional"/>
         <value name="NextMarker" field="nextMarker" usage="optional"/>
+        <value name="StartAfter" field="startAfter" usage="optional"/>
+        <value name="ContinuationToken" field="continuationToken" usage="optional"/>
+        <value name="NextContinuationToken" field="nextContinuationToken" usage="optional"/>
+        <value name="KeyCount" field="keyCount" usage="optional"/>
         <value name="MaxKeys" field="maxKeys"/>
         <value name="Delimiter" field="delimiter" usage="optional"/>
         <value name="IsTruncated" field="isTruncated"/>

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageGateway.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageGateway.java
@@ -977,6 +977,13 @@ public class ObjectStorageGateway implements ObjectStorageService {
 
     // Get the listing from the back-end and copy results in.
     // return ospClient.listBucket(request);
+    final boolean v2 = "2".equals(request.getListType());
+    final String afterKey = v2 ?
+        request.getContinuationToken() != null ?
+            B64.standard.decString(request.getContinuationToken()) :
+            request.getStartAfter() :
+        request.getMarker();
+    final boolean includeOwner = !v2 || "true".equals(request.getFetchOwner());
     ListBucketResponseType reply = request.getReply();
     int maxKeys = 1000;
     try {
@@ -990,40 +997,57 @@ public class ObjectStorageGateway implements ObjectStorageService {
     reply.setMaxKeys(maxKeys);
     reply.setName(request.getBucket());
     reply.setDelimiter(request.getDelimiter());
-    reply.setMarker(request.getMarker());
+    if (v2) {
+      reply.setContinuationToken(request.getContinuationToken());
+      reply.setStartAfter(request.getStartAfter());
+    } else {
+      reply.setMarker(request.getMarker());
+    }
     reply.setPrefix(request.getPrefix());
     reply.setIsTruncated(false);
 
     PaginatedResult<ObjectEntity> result;
     try {
-      result = ObjectMetadataManagers.getInstance().listPaginated(bucket, maxKeys, request.getPrefix(), request.getDelimiter(), request.getMarker());
+      result = ObjectMetadataManagers.getInstance().listPaginated(bucket, maxKeys, request.getPrefix(), request.getDelimiter(), afterKey);
     } catch (Exception e) {
       LOG.error("Error getting object listing for bucket: " + request.getBucket(), e);
       throw new InternalErrorException(request.getBucket());
     }
 
     if (result != null) {
-      reply.setContents(new ArrayList<ListEntry>());
+      int keyCount = 0;
+      reply.setContents( new ArrayList<>( ));
 
       for (ObjectEntity obj : result.getEntityList()) {
-        reply.getContents().add(obj.toListEntry());
+        reply.getContents().add(obj.toListEntry(includeOwner));
+        keyCount++;
       }
 
       if (result.getCommonPrefixes() != null && result.getCommonPrefixes().size() > 0) {
-        reply.setCommonPrefixesList(new ArrayList<CommonPrefixesEntry>());
+        reply.setCommonPrefixesList( new ArrayList<>( ));
 
         for (String s : result.getCommonPrefixes()) {
           reply.getCommonPrefixesList().add(new CommonPrefixesEntry(s));
+          keyCount++;
         }
       }
       reply.setIsTruncated(result.isTruncated);
       if (result.isTruncated) {
+        String next;
         if (result.getLastEntry() instanceof ObjectEntity) {
-          reply.setNextMarker(((ObjectEntity) result.getLastEntry()).getObjectKey());
+          next = ((ObjectEntity) result.getLastEntry()).getObjectKey();
         } else {
           // If max-keys = 0, then last entry may be empty
-          reply.setNextMarker((result.getLastEntry() != null ? result.getLastEntry().toString() : ""));
+          next = (result.getLastEntry() != null ? result.getLastEntry().toString() : "");
         }
+        if (v2) {
+          reply.setNextContinuationToken(B64.standard.encString(next));
+        } else {
+          reply.setNextMarker(next);
+        }
+      }
+      if (v2) {
+        reply.setKeyCount(keyCount);
       }
     } else {
       // Do nothing

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/binding/ObjectStorageGETBinding.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/binding/ObjectStorageGETBinding.java
@@ -62,6 +62,10 @@ public class ObjectStorageGETBinding extends ObjectStorageRESTBinding {
     SUPPORTED_OPS.put(BUCKET + HttpMethod.GET.toString() + ObjectStorageProperties.BucketParameter.maxkeys.toString(), "ListBucket");
     SUPPORTED_OPS.put(BUCKET + HttpMethod.GET.toString() + ObjectStorageProperties.BucketParameter.marker.toString(), "ListBucket");
     SUPPORTED_OPS.put(BUCKET + HttpMethod.GET.toString() + ObjectStorageProperties.BucketParameter.delimiter.toString(), "ListBucket");
+    SUPPORTED_OPS.put(BUCKET + HttpMethod.GET.toString() + ObjectStorageProperties.BucketParameter.startafter.toString(), "ListBucket");
+    SUPPORTED_OPS.put(BUCKET + HttpMethod.GET.toString() + ObjectStorageProperties.BucketParameter.continuationtoken.toString(), "ListBucket");
+    SUPPORTED_OPS.put(BUCKET + HttpMethod.GET.toString() + ObjectStorageProperties.BucketParameter.fetchowner.toString(), "ListBucket");
+    SUPPORTED_OPS.put(BUCKET + HttpMethod.GET.toString() + ObjectStorageProperties.BucketParameter.listtype.toString(), "ListBucket");
     SUPPORTED_OPS.put(BUCKET + HttpMethod.GET.toString() + ObjectStorageProperties.BucketParameter.location.toString(), "GetBucketLocation");
 
     SUPPORTED_OPS.put(BUCKET + HttpMethod.GET.toString() + ObjectStorageProperties.BucketParameter.logging.toString(), "GetBucketLoggingStatus");


### PR DESCRIPTION
Backport S3 v2 listing support for 4. This allows listing of objects in buckets with more than the page size (default 1000) with tools that use the v2 action such as the awscli:

```
# aws --endpoint $S3_URL s3 ls s3://foo | wc -l
2500
```

We retain support for the v1 listing.

Fixes Corymbia/eucalyptus#116