### PR TITLE
Netty 3.6.9 from 3.6.10 due to dns udp listener issue

### DIFF
--- a/clc/modules/core/build.gradle
+++ b/clc/modules/core/build.gradle
@@ -91,7 +91,7 @@ dependencies {
   api 'io.netty:netty-codec:4.0.37.Final'
   api 'io.netty:netty-common:4.0.37.Final'
   api 'io.netty:netty-handler:4.0.37.Final'
-  api 'io.netty:netty:3.6.10.Final'
+  api 'io.netty:netty:3.6.9.Final'
   api 'io.netty:netty-transport:4.0.37.Final'
   api 'io.vavr:vavr:0.9.2'
   api 'io.vavr:vavr-jackson:0.9.2'


### PR DESCRIPTION
In master netty was upgraded to the last 3.6.x maintenance release. This 3.6.10 release causes an issue with our dns udp listener where dns becomes unresponsive. Moving back a release to 3.6.9 resolves the issue.