### PR TITLE
EC2 libvirt generation should set recommended rng device

### DIFF
--- a/tools/libvirt.xsl
+++ b/tools/libvirt.xsl
@@ -166,6 +166,10 @@ that describes a Eucalyptus instance to be launched.
                     </xsl:choose>
                 </xsl:if>
 
+                <rng model="virtio">
+                    <backend model="random">/dev/urandom</backend>
+                </rng>
+
                 <!-- disks or partitions (on Xen) from VBR -->
 
                 <xsl:for-each select="/instance/disks/diskPath">


### PR DESCRIPTION
Update libvirt.xsl to set the recommended rng device.

> the recommended source of entropy is /dev/urandom

https://libvirt.org/formatdomain.html#elementsRng

Fixes Corymbia/eucalyptus#127