### PR TITLE
Format string clean up

### DIFF
--- a/cluster/handlers-state.c
+++ b/cluster/handlers-state.c
@@ -353,9 +353,9 @@ int doDescribeServices(ncMetadata * pMeta, serviceInfoType * serviceIds, int ser
                             }
                             myStatus->localEpoch = config->ccStatus.localEpoch;
                             sprintf(myStatus->serviceId.type, "node");
-                            sprintf(myStatus->serviceId.name, r->hostname);
-                            sprintf(myStatus->serviceId.partition, config->ccStatus.serviceId.partition);
-                            sprintf(myStatus->serviceId.uris[0], r->ncURL);
+                            sprintf(myStatus->serviceId.name, "%s", r->hostname);
+                            sprintf(myStatus->serviceId.partition, "%s", config->ccStatus.serviceId.partition);
+                            sprintf(myStatus->serviceId.uris[0], "%s", r->ncURL);
                             myStatus->serviceId.urisLen = 1;
                             LOGDEBUG("external services\t uri[%d]: %s %s %s %s %s\n",
                                      idIdx, myStatus->serviceId.type, myStatus->serviceId.partition, myStatus->serviceId.name, myStatus->localState, myStatus->serviceId.uris[0]);

--- a/cluster/handlers.c
+++ b/cluster/handlers.c
@@ -1999,7 +1999,7 @@ int doDescribeResources(ncMetadata * pMeta, virtualMachine ** ccvms, int vmLen, 
             euca_strncat(logStr, typeStr, 2047);
         }
         euca_strncat(logStr, "\n", 2047);
-        LOGDEBUG(logStr);
+        LOGDEBUG("%s", logStr);
         /*
         if (vmLen >= 5) {
             LOGDEBUG("resources summary ({avail/max}): %s{%d/%d} %s{%d/%d} %s{%d/%d} %s{%d/%d} %s{%d/%d}\n", (*ccvms)[0].name,

--- a/cluster/server-marshal.c
+++ b/cluster/server-marshal.c
@@ -2062,7 +2062,7 @@ adb_MigrateInstancesResponse_t *MigrateInstancesMarshal(adb_MigrateInstances_t *
         }
     }
     if (ccMeta.replyString != NULL) {  // if replyString is set, we have a more detailed status/error message
-        snprintf(statusMessage, sizeof(statusMessage), ccMeta.replyString);
+        snprintf(statusMessage, sizeof(statusMessage), "%s", ccMeta.replyString);
         EUCA_FREE(ccMeta.replyString); // the caller must free
     }
 
@@ -2133,7 +2133,7 @@ adb_StartInstanceResponse_t *StartInstanceMarshal(adb_StartInstance_t * startIns
     }
 
     if (ccMeta.replyString != NULL) {  // if replyString is set, we have a more detailed status/error message
-        snprintf(statusMessage, sizeof(statusMessage), ccMeta.replyString);
+        snprintf(statusMessage, sizeof(statusMessage), "%s", ccMeta.replyString);
         EUCA_FREE(ccMeta.replyString); // the caller must free
     }
 
@@ -2200,7 +2200,7 @@ adb_StopInstanceResponse_t *StopInstanceMarshal(adb_StopInstance_t * stopInstanc
         }
     }
     if (ccMeta.replyString != NULL) {  // if replyString is set, we have a more detailed status/error message
-        snprintf(statusMessage, sizeof(statusMessage), ccMeta.replyString);
+        snprintf(statusMessage, sizeof(statusMessage), "%s", ccMeta.replyString);
         EUCA_FREE(ccMeta.replyString); // the caller must free
     }
 

--- a/net/ebt_handler.c
+++ b/net/ebt_handler.c
@@ -153,9 +153,9 @@ int ebt_handler_init(ebt_handler *ebth, const char *cmdprefix) {
     }
 
     if (ebth->init) {
-        snprintf(sTempFilterFile, EUCA_MAX_PATH, ebth->ebt_filter_file);
-        snprintf(sTempNatFile, EUCA_MAX_PATH, ebth->ebt_nat_file);
-        snprintf(sTempAscFile, EUCA_MAX_PATH, ebth->ebt_asc_file);
+        snprintf(sTempFilterFile, EUCA_MAX_PATH, "%s", ebth->ebt_filter_file);
+        snprintf(sTempNatFile, EUCA_MAX_PATH, "%s", ebth->ebt_nat_file);
+        snprintf(sTempAscFile, EUCA_MAX_PATH, "%s", ebth->ebt_asc_file);
 
         if (truncate_file(sTempFilterFile)) {            
             return (1);
@@ -209,9 +209,9 @@ int ebt_handler_init(ebt_handler *ebth, const char *cmdprefix) {
     bzero(ebth, sizeof(ebt_handler));
 
     // Copy names back into handler
-    snprintf(ebth->ebt_filter_file, EUCA_MAX_PATH, sTempFilterFile);
-    snprintf(ebth->ebt_nat_file, EUCA_MAX_PATH, sTempNatFile);
-    snprintf(ebth->ebt_asc_file, EUCA_MAX_PATH, sTempAscFile);
+    snprintf(ebth->ebt_filter_file, EUCA_MAX_PATH, "%s", sTempFilterFile);
+    snprintf(ebth->ebt_nat_file, EUCA_MAX_PATH, "%s", sTempNatFile);
+    snprintf(ebth->ebt_asc_file, EUCA_MAX_PATH, "%s", sTempAscFile);
 
     if (cmdprefix) {
         snprintf(ebth->cmdprefix, EUCA_MAX_PATH, "%s", cmdprefix);
@@ -473,7 +473,7 @@ int ebt_handler_add_table(ebt_handler *ebth, char *tablename) {
             exit(1);
         }
         bzero(&(ebth->tables[ebth->max_tables]), sizeof(ebt_table));
-        snprintf(ebth->tables[ebth->max_tables].name, 64, tablename);
+        snprintf(ebth->tables[ebth->max_tables].name, 64, "%s", tablename);
         ebth->max_tables++;
     }
 

--- a/net/euca_gni.c
+++ b/net/euca_gni.c
@@ -2244,7 +2244,7 @@ int gni_populate_gnidata(globalNetworkInfo *gni, xmlNodePtr xmlnode, xmlXPathCon
         rc += evaluate_xpath_property(ctxptr, doc, xmlnode, expression, &results, &max_results);
         for (i = 0; i < max_results; i++) {
             LOGTRACE("after function: %d: %s\n", i, results[i]);
-            snprintf(gni->sMode, NETMODE_LEN, results[i]);
+            snprintf(gni->sMode, NETMODE_LEN, "%s", results[i]);
             gni->nmCode = euca_netmode_atoi(gni->sMode);
             EUCA_FREE(results[i]);
         }
@@ -2824,7 +2824,7 @@ int gni_populate_interfaces(globalNetworkInfo *gni, gni_instance *instance, xmlN
                 //snprintf(gni->interfaces[gni->max_interfaces + i].instance_name.name, 1024, instance->name);
                 //gni_populate_instance_interface(&(gni->interfaces[gni->max_interfaces + i]), nodeset.nodeTab[i], ctxptr, doc);
                 gni->ifs[gni->max_ifs + i] = EUCA_ZALLOC_C(1, sizeof (gni_instance));
-                snprintf(gni->ifs[gni->max_ifs + i]->instance_name.name, 32, instance->name);
+                snprintf(gni->ifs[gni->max_ifs + i]->instance_name.name, 32, "%s", instance->name);
                 gni_populate_instance_interface(gni->ifs[gni->max_ifs + i], nodeset.nodeTab[i], ctxptr, doc);
                 instance->interfaces[i] = gni->ifs[gni->max_ifs + i];
                 //gni_instance_interface_print(gni->ifs[gni->max_ifs + i]), EUCA_LOG_INFO);

--- a/net/ips_handler.c
+++ b/net/ips_handler.c
@@ -150,7 +150,7 @@ int ips_handler_init(ips_handler *ipsh, const char *cmdprefix) {
     }
 
     if (ipsh->init) {
-        snprintf(sTempFileName, EUCA_MAX_PATH, ipsh->ips_file);
+        snprintf(sTempFileName, EUCA_MAX_PATH, "%s", ipsh->ips_file);
         if (truncate_file(sTempFileName)) {
             return (1);
         }
@@ -172,7 +172,7 @@ int ips_handler_init(ips_handler *ipsh, const char *cmdprefix) {
 
     bzero(ipsh, sizeof(ips_handler));
 
-    snprintf(ipsh->ips_file, EUCA_MAX_PATH, sTempFileName);
+    snprintf(ipsh->ips_file, EUCA_MAX_PATH, "%s", sTempFileName);
 
     if (cmdprefix) {
         snprintf(ipsh->cmdprefix, EUCA_MAX_PATH, "%s", cmdprefix);
@@ -361,7 +361,7 @@ int ips_handler_add_set(ips_handler *ipsh, char *setname) {
             exit(1);
         }
         bzero(&(ipsh->sets[ipsh->max_sets]), sizeof(ips_set));
-        snprintf(ipsh->sets[ipsh->max_sets].name, 64, setname);
+        snprintf(ipsh->sets[ipsh->max_sets].name, 64, "%s", setname);
         ipsh->sets[ipsh->max_sets].ref_count = 1;
         ipsh->max_sets++;
     }

--- a/net/ipt_handler.c
+++ b/net/ipt_handler.c
@@ -164,7 +164,7 @@ int ipt_handler_init(ipt_handler *pIpt, const char *psCmdPrefix, const char *psP
         //
         // Copy filename out of the current ipt_handler struct.
         //
-        snprintf(sTempFileName, EUCA_MAX_PATH, pIpt->ipt_file);
+        snprintf(sTempFileName, EUCA_MAX_PATH, "%s", pIpt->ipt_file);
         
         //  Truncate the file to ensure we're dealing with a clean slate.
         if (truncate_file(sTempFileName)){
@@ -195,7 +195,7 @@ int ipt_handler_init(ipt_handler *pIpt, const char *psCmdPrefix, const char *psP
     bzero(pIpt, sizeof(ipt_handler));
 
     // Populate the temporary filename
-    snprintf(pIpt->ipt_file, EUCA_MAX_PATH, sTempFileName);
+    snprintf(pIpt->ipt_file, EUCA_MAX_PATH, "%s", sTempFileName);
     
     // If we have a command prefix (like euca_rootwrap) set it
     pIpt->cmdprefix[0] = '\0';
@@ -483,7 +483,7 @@ int ipt_handler_add_table(ipt_handler *ipth, char *tablename) {
             exit(1);
         }
         bzero(&(ipth->tables[ipth->max_tables]), sizeof(ipt_table));
-        snprintf(ipth->tables[ipth->max_tables].name, 64, tablename);
+        snprintf(ipth->tables[ipth->max_tables].name, 64, "%s", tablename);
         ipth->max_tables++;
     }
 

--- a/storage/vbr.c
+++ b/storage/vbr.c
@@ -368,7 +368,7 @@ static int prep_location(virtualBootRecord * vbr, ncMetadata * pMeta, const char
                 //Anything other than storage/ebs
                 char *l = vbr->resourceLocation + (strlen(typeName) + 3);   // +3 for "://", so 'l' points past, e.g., "objectstorage:"
                 snprintf(vbr->preparedResourceLocation, sizeof(vbr->preparedResourceLocation), "%s/%s", service->uris[0], l);   //! @TODO for now we just pick the first one
-                snprintf(vbr->resourceLocation, sizeof(vbr->resourceLocation), vbr->preparedResourceLocation);  //! @TODO trying this out
+                snprintf(vbr->resourceLocation, sizeof(vbr->resourceLocation), "%s", vbr->preparedResourceLocation);  //! @TODO trying this out
             } else {
                 //For storage, just copy the url for the SC into the preparedResourceLocation slot
                 snprintf(vbr->preparedResourceLocation, sizeof(vbr->preparedResourceLocation), "%s", service->uris[0]); //! @TODO for now we just pick the first one

--- a/util/log.c
+++ b/util/log.c
@@ -1012,9 +1012,9 @@ int logprintfl(const char *func, const char *file, int line, log_level_e level, 
             l = LOG_INFO;
 
         if (custom_spec)
-            syslog(l, buf);
+            syslog(l, "%s", buf);
         else
-            syslog(l, buf + offset);
+            syslog(l, "%s", buf + offset);
     }
 
     if (is_corrid && log_file_path_req_track != NULL) {


### PR DESCRIPTION
Some calls are missing a format string. I do not think any of these are vulnerabilities but it is a simple fix.

https://en.wikipedia.org/wiki/Uncontrolled_format_string
https://www.owasp.org/index.php/Format_string_attack