### PR TITLE
Update kvm and python-argparse package dependencies

### DIFF
--- a/rpm/eucalyptus.spec
+++ b/rpm/eucalyptus.spec
@@ -225,7 +225,6 @@ Requires:     lvm2
 Requires:     perl(Getopt::Long)
 Requires:     postgresql
 Requires:     postgresql-server
-Requires:     python-argparse
 Requires:     rsync
 
 %description cloud
@@ -252,7 +251,6 @@ Requires:     iproute
 Requires:     iptables
 Requires:     iputils
 Requires:     libselinux-python
-Requires:     python-argparse
 Requires:     rsync
 Requires:     vconfig
 Requires:     /usr/bin/which
@@ -377,7 +375,6 @@ Requires:     %{name} = %{version}-%{release}
 Requires:     euca2ools >= 3.1
 Requires:     eucalyptus-selinux
 Requires:     pv
-Requires:     python-argparse
 Requires:     python-lxml
 Requires:     python-requests
 # The next seven come from storage/diskutil.c, which shells

--- a/rpm/eucalyptus.spec
+++ b/rpm/eucalyptus.spec
@@ -283,7 +283,6 @@ Requires:     eucalyptus-selinux > 0.2
 Requires:     eucanetd = %{version}-%{release}
 Requires:     httpd
 Requires:     iscsi-initiator-utils
-Requires:     kvm
 # Ceph support requires librados2, librbd1, and *also* qemu-kvm-rhev.
 Requires:     librados2%{?_isa}
 Requires:     librbd1%{?_isa}
@@ -293,6 +292,7 @@ Requires:     perl(Sys::Virt)
 Requires:     perl(Time::HiRes)
 Requires:     perl(XML::Simple)
 Requires:     qemu-kvm
+Requires:     qemu-system-x86
 # The next six come from storage/diskutil.c, which shells out to lots of stuff.
 Requires:     coreutils
 Requires:     curl


### PR DESCRIPTION
The `python-argparse` package is not needed with python 2.7+ and is provided by the python package in rhel/centos 7.x, dependencies on this package are removed.

The `kvm` package is provided by `qemu-system-x86`, so dependencies are updated accordingly.

```
#
# rpm -q --whatprovides python-argparse
python-2.7.5-69.el7_5.x86_64
#
#
# rpm -q --whatprovides kvm
qemu-system-x86-2.0.0-1.el7.6.x86_64
#
#
```