### PR TITLE
Remove incorrect and unnecessary ant and postgresql version checks

### DIFF
--- a/clc/modules/postgresql/conf/scripts/setup_db.groovy
+++ b/clc/modules/postgresql/conf/scripts/setup_db.groovy
@@ -232,10 +232,6 @@ class PostgresqlBootstrapper extends Bootstrapper.Simple implements DatabaseBoot
     try {
       kernelParametersCheck( )
       
-      if ( !versionCheck( ) ){
-        throw new RuntimeException("Postgres versions less than 9.1.X are not supported")
-      }
-      
       if ( !initDatabase( ) ) {
         throw new RuntimeException("Unable to initialize the postgres database")
       }
@@ -300,18 +296,6 @@ class PostgresqlBootstrapper extends Bootstrapper.Simple implements DatabaseBoot
       }
     }  catch ( Exception e ) {
       LOG.error("Error checking kernel parameters: " + e.message )
-    }
-  }
-  
-  // Version check to ensure only Postgres 9.X creates the db.
-  private boolean versionCheck( ) {
-    try {
-      String cmd = newCommands.initdb + " --version"
-      def pattern = ~/.*\s+9\.[1-9]\d*(\.\d+)*$/
-      pattern.matcher( cmd.execute( ).text.trim( ) ).matches( )
-    } catch ( Exception e ) {
-      LOG.fatal("Unable to find the initdb command")
-      false
     }
   }
   

--- a/configure.ac
+++ b/configure.ac
@@ -193,12 +193,6 @@ if test ! -e $JAVA_HOME/include/jni.h ; then
         AC_MSG_ERROR([Cannot find jni.h in $JAVA_HOME: do you have a JDK installed?])
 fi
 
-ant_version=`$ANT -version 2>&1 | grep "Ant.* version" | \
-        sed -e 's/.*Ant.* version \([[0-9.]]*\).*/\1/'`
-goodversion=`expr $ant_version ">=" $ant_min_version`
-if test $goodversion -eq 0; then
-        AC_MSG_ERROR([Eucalyptus needs at least ANT version $ant_min_version])
-fi
 # some version of ant picks up the wrong java
 java_version=`JAVA_HOME=$JAVA_HOME $ANT -diagnostics 2>&1 | grep ^java.version | \
         sed -e 's/java.* \([[0-9.]]*\).*/\1/'`


### PR DESCRIPTION
CentOS/RHEL 7 include ant 1.9.2 and postgres 9.2 which satisfy version requirements. 

The way these version checks are implemented prevents use of more recent compatible versions. Since there are no incompatible versions available from a supported os, the checks are removed rather than fixed.