### PR TITLE
EC2 VPC implement CreateDefaultSubnet and CreateDefaultVpc actions

### DIFF
--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/backend/CreateDefaultSubnetResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/backend/CreateDefaultSubnetResponseType.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2018 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.compute.common.backend;
+
+public class CreateDefaultSubnetResponseType extends com.eucalyptus.compute.common.CreateDefaultSubnetResponseType implements ComputeBackendMessage {
+}

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/backend/CreateDefaultSubnetType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/backend/CreateDefaultSubnetType.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2018 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.compute.common.backend;
+
+public class CreateDefaultSubnetType extends com.eucalyptus.compute.common.CreateDefaultSubnetType implements ComputeBackendMessage {
+}

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/backend/CreateDefaultVpcResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/backend/CreateDefaultVpcResponseType.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2018 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.compute.common.backend;
+
+public class CreateDefaultVpcResponseType extends com.eucalyptus.compute.common.CreateDefaultVpcResponseType implements ComputeBackendMessage {
+}

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/backend/CreateDefaultVpcType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/backend/CreateDefaultVpcType.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2018 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.compute.common.backend;
+
+public class CreateDefaultVpcType extends com.eucalyptus.compute.common.CreateDefaultVpcType implements ComputeBackendMessage {
+}

--- a/clc/modules/compute-common-msgs/src/main/resources/ec2-vpc-16-11-15.xml
+++ b/clc/modules/compute-common-msgs/src/main/resources/ec2-vpc-16-11-15.xml
@@ -73,7 +73,7 @@
   <mapping name="CreateDefaultSubnetResponse" class="com.eucalyptus.compute.common.CreateDefaultSubnetResponseType"
            extends="com.eucalyptus.compute.common.ComputeMessage">
     <structure map-as="com.eucalyptus.compute.common.ComputeMessage"/>
-    <structure get-method="getSubnet" set-method="setSubnet" usage="optional" type="com.eucalyptus.compute.common.SubnetType" name="Subnet"/>
+    <structure get-method="getSubnet" set-method="setSubnet" usage="optional" type="com.eucalyptus.compute.common.SubnetType" name="subnet"/>
   </mapping>
   <mapping name="CreateDefaultVpc" class="com.eucalyptus.compute.common.CreateDefaultVpcType"
            extends="com.eucalyptus.compute.common.ComputeMessage">
@@ -82,7 +82,7 @@
   <mapping name="CreateDefaultVpcResponse" class="com.eucalyptus.compute.common.CreateDefaultVpcResponseType"
            extends="com.eucalyptus.compute.common.ComputeMessage">
     <structure map-as="com.eucalyptus.compute.common.ComputeMessage"/>
-    <structure get-method="getVpc" set-method="setVpc" usage="optional" type="com.eucalyptus.compute.common.VpcType" name="Vpc"/>
+    <structure get-method="getVpc" set-method="setVpc" usage="optional" type="com.eucalyptus.compute.common.VpcType" name="vpc"/>
   </mapping>
   <mapping name="CreateNetworkInterfacePermission" class="com.eucalyptus.compute.common.CreateNetworkInterfacePermissionType"
            extends="com.eucalyptus.compute.common.ComputeMessage">

--- a/clc/modules/compute-service/src/main/java/com/eucalyptus/compute/service/ComputeService.java
+++ b/clc/modules/compute-service/src/main/java/com/eucalyptus/compute/service/ComputeService.java
@@ -1850,18 +1850,6 @@ public class ComputeService {
     return request.getReply( );
   }
 
-  public CreateDefaultSubnetResponseType createDefaultSubnet(
-      CreateDefaultSubnetType request
-  ) {
-    return request.getReply( );
-  }
-
-  public CreateDefaultVpcResponseType createDefaultVpc(
-      CreateDefaultVpcType request
-  ) {
-    return request.getReply( );
-  }
-
   public CreateFleetResponseType createFleet(
       CreateFleetType request
   ) {


### PR DESCRIPTION
For `CreateDefaultSubnet` and `CreateDefaultVpc` actions, remove user facing service stub and add backend service messages and implementation.

Fixes corymbia/eucalyptus#119