### PR TITLE
EC2 node controller instance reboot handling

### DIFF
--- a/node/handlers.c
+++ b/node/handlers.c
@@ -184,7 +184,7 @@ bunchOfInstances *global_instances = NULL;  //!< pointer to the instance list
 bunchOfInstances *global_instances_copy = NULL; //!< pointer to the copied instance list
 
 const int default_staging_cleanup_threshold = 60 * 60 * 2;  //!< after this many seconds any STAGING domains will be cleaned up
-const int default_booting_cleanup_threshold = 60;   //!< after this many seconds any BOOTING domains will be cleaned up
+const int default_booting_cleanup_threshold = 60 + MONITORING_PERIOD;   //!< after this many seconds any BOOTING domains will be cleaned up
 const int default_booting_envwait_threshold = NETWORK_GATE_TIMEOUT_SEC;   //!< after this many seconds an instance will fail to boot unless network environment is ready
 const int default_bundling_cleanup_threshold = 60 * 60 * 2; //!< after this many seconds any BUNDLING domains will be cleaned up
 const int default_createImage_cleanup_threshold = 60 * 60 * 2;  //!< after this many seconds any CREATEIMAGE domains will be cleaned up
@@ -1074,8 +1074,8 @@ void change_state(ncInstance * instance, instance_states state)
 
     euca_strncpy(instance->stateName, instance_state_names[instance->stateCode], CHAR_BUFFER_SIZE);
     if (old_state != state) {
-        LOGDEBUG("[%s] state change for instance: %s -> %s (%s)\n",
-                 instance->instanceId, instance_state_names[old_state], instance_state_names[instance->state], instance_state_names[instance->stateCode]);
+        LOGINFO("[%s] state change for instance: %s -> %s (%s)\n",
+                instance->instanceId, instance_state_names[old_state], instance_state_names[instance->state], instance_state_names[instance->stateCode]);
     }
 }
 
@@ -1296,14 +1296,13 @@ static void refresh_instance_info(struct nc_state_t *nc, ncInstance * instance)
                 }
             }
 
-            // during reboot ensure that the domain enters reboot before setting instance back to Running
-            // and that we allow the instance to restart without detecting it as termination of the instance
+            // on reboot ensure the domain restarts without being detected as shutdown
             if ((old_state == BOOTING) && (
-                ((new_state == RUNNING) && (instance->bootTime > (time(NULL) - MONITORING_PERIOD))) ||
-                ((new_state == SHUTOFF || new_state == SHUTDOWN) && (instance->bootTime > (time(NULL) - nc_state.reboot_grace_period_sec)))
+                ((new_state == RUNNING || new_state == SHUTOFF || new_state == SHUTDOWN)
+                 && (instance->rebootTime > (time(NULL) - nc_state.reboot_grace_period_sec)))
                )) {
-                if (new_state != RUNNING) { // skip logging for running as this happens frequently on reboot
-                    LOGINFO("[%s] ignoring hypervisor reported state %s for booting domain during grace period (%d)\n",
+                if (new_state != RUNNING) { // running is reported while the instance is shutting down
+                    LOGINFO("[%s] ignoring hypervisor reported state %s for rebooting domain during grace period (%d)\n",
                             instance->instanceId, instance_state_names[new_state], nc_state.reboot_grace_period_sec);
                 }
                 break;
@@ -1314,7 +1313,8 @@ static void refresh_instance_info(struct nc_state_t *nc, ncInstance * instance)
                             instance->instanceId, instance_state_names[new_state], nc_state.shutdown_grace_period_sec);
                     break;
                 }
-                LOGWARN("[%s] hypervisor reported previously running domain as %s\n", instance->instanceId, instance_state_names[new_state]);
+                LOGWARN("[%s] hypervisor reported %s domain as %s\n", instance->instanceId,
+                        instance_state_names[old_state], instance_state_names[new_state]);
             }
             // change to state, whatever it happens to be
             change_state(instance, new_state);
@@ -2390,7 +2390,7 @@ static int init(void)
     GET_VAR_INT(nc_state.sc_request_timeout_sec, CONFIG_SC_REQUEST_TIMEOUT, 45);
     GET_VAR_INT(nc_state.concurrent_cleanup_ops, CONFIG_CONCURRENT_CLEANUP_OPS, 30);
     GET_VAR_INT(nc_state.disable_snapshots, CONFIG_DISABLE_SNAPSHOTS, 0);
-    GET_VAR_INT(nc_state.reboot_grace_period_sec, CONFIG_NC_REBOOT_GRACE_PERIOD_SEC, 30);
+    GET_VAR_INT(nc_state.reboot_grace_period_sec, CONFIG_NC_REBOOT_GRACE_PERIOD_SEC, 60 + MONITORING_PERIOD);
     GET_VAR_INT(nc_state.shutdown_grace_period_sec, CONFIG_SHUTDOWN_GRACE_PERIOD_SEC, 60);
 
     strcpy(nc_state.admin_user_id, EUCALYPTUS_ADMIN);

--- a/util/data.h
+++ b/util/data.h
@@ -387,6 +387,7 @@ typedef struct ncInstance_t {
     int launchTime;                    //!< timestamp of RunInstances request arrival
     int expiryTime;                    //!< timestamp of instance ->RUNNING expiration
     int bootTime;                      //!< timestamp of STAGING->BOOTING transition
+    int rebootTime;                    //!< timestamp of RUNNING->BOOTING transition (while active)
     int bundlingTime;                  //!< timestamp of ->BUNDLING transition
     int createImageTime;               //!< timestamp of ->CREATEIMAGE transition
     int terminationRequestedTime;      //!< timestamp of TerminateInstance request arrival


### PR DESCRIPTION
This pull request addresses issues with the current fix for corymbia/eucalyptus#117 and also ensures that we do not attempt concurrent reboots for an instance. The previous fix assumes instances are not in the `RUNNING` state during reboot, but this is not correct as `RUNNING` is the expected state while the instance is shutting down. There is only a short period in the `SHUTDOWN` state when the vm has exited and clean-up is being performed.

We now track a `rebootTime` for instances which is the time the instance was last transitioned to the `BOOTING` state. This allows the maintenance thread to determine if a reboot is in progress; previously this was not easily distinguished from the initial boot.

The default values for `NC_BOOTING_CLEANUP_THRESHOLD` and `NC_REBOOT_GRACE_PERIOD_SEC` are updated to 65 seconds. This is the shutdown timeout plus one maintenance period and ensures that the maintenance thread will not detect a failure while a reboot is in progress.

The rebooting thread clears the `rebootTime`  once the instance is running after reboot. This allows the monitoring thread to handle the `BOOTING` to `RUNNING` transition when next evaluated. Locking is modified in the rebooting thread to ensure that we separately acquire instance locks and hypervisor locks instead of acquiring both at once (which is deadlock prone)

The reboot request handler has additional checks to ensure we do not attempt to dereference a null instance and to ignore reboot requests when a reboot is in progress.

Instance state transitions are now logged at `INFO` level (was `DEBUG`), as these are important events for an instance.

This adds to the existing changes in 4.4.5 from corymbia/eucalyptus#121

Fixes corymbia/eucalyptus#5
Fixes corymbia/eucalyptus#117