### PR TITLE
EC2 node migration decrement outbound counter when not logging at debug

### DIFF
--- a/node/handlers_kvm.c
+++ b/node/handlers_kvm.c
@@ -704,7 +704,8 @@ out:
         unlock_hypervisor_conn();
 
     sem_p(inst_sem);
-    LOGDEBUG("%d outgoing migrations still active\n", --outgoing_migrations_in_progress);
+    outgoing_migrations_in_progress--;
+    LOGDEBUG("%d outgoing migrations still active\n", outgoing_migrations_in_progress);
     if (migration_error) {
         migration_rollback(instance);
     } else {


### PR DESCRIPTION
Decrement outgoing migration count outside of debug statement for correct value when using `INFO` level logging or higher.

Fixes corymbia/eucalyptus#142