### PR TITLE
Fix ambiguous python shebangs

### DIFF
--- a/admin-tools/Makefile
+++ b/admin-tools/Makefile
@@ -39,6 +39,8 @@ build: eucalyptus_admin
 
 install: eucalyptus_admin
 	$(PYTHON) setup.py install --root=$(DESTDIR)
+	@sed --in-place '1s/python /python2 /' $(DESTDIR)/usr/bin/euctl
+	@sed --in-place '1s/python /python2 /' $(DESTDIR)/usr/bin/euserv-*
 
 clean:
 	@$(RM) -rf build dist

--- a/admin-tools/bin/euctl
+++ b/admin-tools/bin/euctl
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 
 import eucalyptus_admin.commands.properties.euctl
 

--- a/admin-tools/bin/euserv-deregister-service
+++ b/admin-tools/bin/euserv-deregister-service
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 
 import eucalyptus_admin.commands.bootstrap.deregisterservice
 

--- a/admin-tools/bin/euserv-describe-events
+++ b/admin-tools/bin/euserv-describe-events
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 
 import eucalyptus_admin.commands.bootstrap.describeevents
 

--- a/admin-tools/bin/euserv-describe-node-controllers
+++ b/admin-tools/bin/euserv-describe-node-controllers
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 
 import eucalyptus_admin.commands.bootstrap.describenodecontrollers
 

--- a/admin-tools/bin/euserv-describe-service-types
+++ b/admin-tools/bin/euserv-describe-service-types
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 
 import eucalyptus_admin.commands.bootstrap.describeavailableservicetypes
 

--- a/admin-tools/bin/euserv-describe-services
+++ b/admin-tools/bin/euserv-describe-services
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 
 import eucalyptus_admin.commands.bootstrap.describeservices
 

--- a/admin-tools/bin/euserv-migrate-instances
+++ b/admin-tools/bin/euserv-migrate-instances
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 
 import eucalyptus_admin.commands.ec2.migrateinstances
 

--- a/admin-tools/bin/euserv-modify-service
+++ b/admin-tools/bin/euserv-modify-service
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 
 import eucalyptus_admin.commands.bootstrap.modifyservice
 

--- a/admin-tools/bin/euserv-register-service
+++ b/admin-tools/bin/euserv-register-service
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 
 import eucalyptus_admin.commands.bootstrap.registerservice
 

--- a/node/libvirt-hooks/qemu
+++ b/node/libvirt-hooks/qemu
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt 
+#!/usr/bin/python2 -tt
 
 # Copyright 2016 Ent. Services Development Corporation LP
 #

--- a/tools/authorize-migration-keys
+++ b/tools/authorize-migration-keys
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 
 #
 # Copyright 2017 Ent. Services Development Corporation LP

--- a/tools/clcadmin-copy-keys
+++ b/tools/clcadmin-copy-keys
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 #
 # Copyright 2015-2016 Ent. Services Development Corporation LP
 #

--- a/tools/clcadmin-grant-admin-access
+++ b/tools/clcadmin-grant-admin-access
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 #
 # Copyright 2015-2017 Ent. Services Development Corporation LP
 #

--- a/tools/clcadmin-impersonate-user
+++ b/tools/clcadmin-impersonate-user
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 #
 # Copyright 2017 Ent. Services Development Corporation LP
 #

--- a/tools/clcadmin-initialize-cloud
+++ b/tools/clcadmin-initialize-cloud
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 #
 # Copyright 2015-2016 Ent. Services Development Corporation LP
 #

--- a/tools/clcadmin-release-credentials
+++ b/tools/clcadmin-release-credentials
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 #
 # Copyright 2018 AppScale Systems, Inc
 #

--- a/tools/clusteradmin-register-nodes
+++ b/tools/clusteradmin-register-nodes
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 #
 # Copyright 2015 Ent. Services Development Corporation LP
 #

--- a/tools/config-no-polkit
+++ b/tools/config-no-polkit
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 
 #
 # Copyright 2017 Ent. Services Development Corporation LP

--- a/tools/eucalyptus-backup-restore
+++ b/tools/eucalyptus-backup-restore
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 # Backup and restore a Eucalyptus Cloud Controller DB & Keys
 #

--- a/tools/imaging/Makefile
+++ b/tools/imaging/Makefile
@@ -41,6 +41,7 @@ build:
 install: build
 	@sed -e 's://*:/:g' setup.cfg.template > setup.cfg
 	$(PYTHON) setup.py install --root=$(DESTDIR)
+	@sed --in-place '1s/python$$/python2/' $(DESTDIR)/usr/libexec/eucalyptus/euca-run-workflow
 
 tags:
 	find bin -regex ".*\.\(h\|c\|py\|in\)" | xargs etags

--- a/tools/imaging/bin/euca-run-workflow
+++ b/tools/imaging/bin/euca-run-workflow
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 # Copyright 2009-2014 Ent. Services Development Corporation LP
 #

--- a/tools/imaging/eucatoolkit/__init__.py.in
+++ b/tools/imaging/eucatoolkit/__init__.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 # Copyright 2009-2013 Ent. Services Development Corporation LP
 #

--- a/tools/imaging/eucatoolkit/stages/__init__.py
+++ b/tools/imaging/eucatoolkit/stages/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 
 # Copyright 2011-2012 Ent. Services Development Corporation LP
 #

--- a/tools/imaging/eucatoolkit/stages/cryptoutils.py
+++ b/tools/imaging/eucatoolkit/stages/cryptoutils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 
 # Copyright 2011-2012 Ent. Services Development Corporation LP
 #

--- a/tools/imaging/eucatoolkit/stages/downloadimage.py
+++ b/tools/imaging/eucatoolkit/stages/downloadimage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 
 # Copyright 2011-2012 Ent. Services Development Corporation LP
 #

--- a/tools/imaging/eucatoolkit/stages/downloadmanifest.py
+++ b/tools/imaging/eucatoolkit/stages/downloadmanifest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 
 # Copyright 2011-2012 Ent. Services Development Corporation LP
 #

--- a/tools/imaging/eucatoolkit/stages/downloadpart.py
+++ b/tools/imaging/eucatoolkit/stages/downloadpart.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 
 # Copyright 2011-2012 Ent. Services Development Corporation LP
 #

--- a/tools/imaging/eucatoolkit/stages/processutils.py
+++ b/tools/imaging/eucatoolkit/stages/processutils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 
 # Copyright 2011-2012 Ent. Services Development Corporation LP
 #

--- a/tools/imaging/setup.py
+++ b/tools/imaging/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -tt
+#!/usr/bin/python2 -tt
 
 # Copyright 2011-2012 Ent. Services Development Corporation LP
 #

--- a/tools/status/sensor_utils.py
+++ b/tools/status/sensor_utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 # Copyright 2014 Ent. Services Development Corporation LP
 #


### PR DESCRIPTION
Fix ambiguous python shebangs as these can otherwise cause build failures.

Example packaging guidelines covering python 2 use:
https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#_multiple_python_runtimes

Build:  ocd/job/eucalyptus-internal-5-build-random-rpms/57/
QA run: ocd/job/eucalyptus-5-qa-suite/55/