### PR TITLE
EC2 allow instance meta-data access during stop/shutdown

### DIFF
--- a/clc/modules/compute-backend/src/main/java/com/eucalyptus/compute/metadata/VmMetadata.java
+++ b/clc/modules/compute-backend/src/main/java/com/eucalyptus/compute/metadata/VmMetadata.java
@@ -182,16 +182,17 @@ public class VmMetadata {
 
   private static Function<String,Optional<String>> resolveVm( ) {
     return new Function<String,Optional<String>>() {
+      private final VmInstance.VmStateSet stateSet = VmInstance.VmStateSet.NOT_TORNDOWN;
       @Nullable
       @Override
       public Optional<String> apply( final String requestIp  ) {
         VmInstance findVm = null;
         if ( !Databases.isVolatile() ) {
           try {
-            findVm = VmInstances.lookupByPublicIp( requestIp );
+            findVm = VmInstances.lookupByPublicIp( requestIp, stateSet );
           } catch ( Exception ex2 ) {
             try {
-              findVm = VmInstances.lookupByPrivateIp( requestIp );
+              findVm = VmInstances.lookupByPrivateIp( requestIp, stateSet );
             } catch ( Exception ex ) {
               Logs.exhaust().error( ex );
             }

--- a/clc/modules/compute-backend/src/main/java/com/eucalyptus/vm/VmInstances.java
+++ b/clc/modules/compute-backend/src/main/java/com/eucalyptus/vm/VmInstances.java
@@ -695,11 +695,15 @@ public class VmInstances extends com.eucalyptus.compute.common.internal.vm.VmIns
   }
   
   public static VmInstance lookupByPrivateIp( final String ip ) throws NoSuchElementException {
+    return lookupByPrivateIp( ip, VmStateSet.RUN );
+  }
+
+  public static VmInstance lookupByPrivateIp( final String ip, final VmStateSet stateSet ) throws NoSuchElementException {
     try ( TransactionResource db = Entities.transactionFor( VmInstance.class ) ) {
       VmInstance vmExample = VmInstance.exampleWithPrivateIp( ip );
       VmInstance vm = ( VmInstance ) Entities.createCriteriaUnique( VmInstance.class )
                                              .add( Example.create( vmExample ) )
-                                             .add( Restrictions.in( "state", new VmState[] { VmState.RUNNING, VmState.PENDING } ) )
+                                             .add( Restrictions.in( "state", stateSet.array( ) ) )
                                              .uniqueResult( );
       if ( vm == null ) {
         throw new NoSuchElementException( "VmInstance with private ip: " + ip );

--- a/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/vm/VmInstance.java
+++ b/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/vm/VmInstance.java
@@ -281,6 +281,7 @@ public class VmInstance extends UserMetadata<VmState> implements VmInstanceMetad
 
     },
     EXPECTING_TEARDOWN( VmState.STOPPING, VmState.SHUTTING_DOWN ),
+    NOT_TORNDOWN( VmState.PENDING, VmState.RUNNING, VmState.SHUTTING_DOWN, VmState.STOPPING ),
     TORNDOWN( VmState.STOPPED, VmState.TERMINATED, VmState.BURIED ),
     STOP( VmState.STOPPING, VmState.STOPPED ),
     NOT_RUNNING( VmState.STOPPING, VmState.STOPPED, VmState.SHUTTING_DOWN, VmState.TERMINATED, VmState.BURIED ),


### PR DESCRIPTION
EC2 instance meta-data should be available while the instance is in the shutting-down or stopping states. One example use is performing some clean-up using aws apis on instance termination using credentials from an instance profile.

Fixes Corymbia/eucalyptus#158