### PR TITLE
Cloud network/region configuration should allow start of document and comments for YAML

### DIFF
--- a/clc/modules/compute-backend/src/main/java/com/eucalyptus/network/config/NetworkConfigurationApi.java
+++ b/clc/modules/compute-backend/src/main/java/com/eucalyptus/network/config/NetworkConfigurationApi.java
@@ -89,15 +89,14 @@ import io.vavr.jackson.datatype.VavrModule;
 public interface NetworkConfigurationApi {
 
   static NetworkConfiguration parse( final String config ) throws IOException {
-    try {
+    if ( Yaml.mightBeJson( config ) ) try {
       return parse( Mapping.mapper( ), config );
     } catch ( final JsonParseException e ) {
-      if ( Objects.toString( e.getMessage( ), "" ).startsWith( "Unrecognized token" ) ) {
-        return parse( Mapping.yamlMapper( ), config );
-      } else {
+      if ( !Objects.toString( e.getMessage( ), "" ).startsWith( "Unrecognized token" ) ) {
         throw e;
       }
     }
+    return parse( Mapping.yamlMapper( ), config );
   }
 
   static NetworkConfiguration parse( final ObjectMapper mapper, final String config ) throws IOException {

--- a/clc/modules/core/src/main/java/com/eucalyptus/util/Yaml.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/util/Yaml.java
@@ -72,6 +72,19 @@ public class Yaml {
       "str"
   ).map( Strings.prepend( "tag:yaml.org,2002:" ) ).toSet( );
 
+  /**
+   * Can JSON be ruled out? is the given text YAML rather than JSON?
+   *
+   * <p>This can be used before parsing to help eliminate JSON as a candidate
+   * format.</p>
+   *
+   * @param text The text to check
+   * @return False if the given text is (heuristically) YAML
+   */
+  public static boolean mightBeJson( final String text ) {
+    return text == null || !(text.startsWith("---") || text.startsWith("#"));
+  }
+
   public static JsonNode parse( final InputStream yamlStream ) throws IOException {
     return parse( reader, yamlStream );
   }

--- a/clc/modules/euare/src/main/java/com/eucalyptus/auth/euare/identity/region/RegionConfigurations.java
+++ b/clc/modules/euare/src/main/java/com/eucalyptus/auth/euare/identity/region/RegionConfigurations.java
@@ -109,15 +109,14 @@ public class RegionConfigurations {
   public static RegionConfiguration parse( final String configuration ) throws RegionConfigurationException {
     RegionConfiguration regionConfiguration;
     try {
-      try {
+      if ( Yaml.mightBeJson( configuration ) ) try {
         regionConfiguration = parse( new ObjectMapper( ), configuration );
       } catch ( final JsonParseException e ) {
-        if ( Objects.toString( e.getMessage( ), "" ).startsWith( "Unrecognized token" ) ) {
-          regionConfiguration = parse( Yaml.mapper( ), configuration );
-        } else {
+        if ( !Objects.toString( e.getMessage( ), "" ).startsWith( "Unrecognized token" ) ) {
           throw e;
         }
       }
+      regionConfiguration = parse( Yaml.mapper( ), configuration );
     } catch ( IOException e ) {
       throw new RegionConfigurationException( e.getMessage( ) );
     }


### PR DESCRIPTION
We now support YAML format for network and region cloud configuration properties but incorrectly reject the YAML start of document marker and a leading comment. One of the benefits of using YAML is that comments can be used so we should allow this.