### PR TITLE
S3 close http connection when testing backend provider

### DIFF
--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/providers/s3/S3ProviderClient.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/providers/s3/S3ProviderClient.java
@@ -421,7 +421,7 @@ public class S3ProviderClient implements ObjectStorageProviderClient {
       throw new EucalyptusCloudException("S3 provider HEAD op code is not set");
     }
     try {
-      int headResponse = excuteHeadRequest(this.getUpstreamEndpoint());
+      int headResponse = executeHeadRequest(this.getUpstreamEndpoint());
       if (headResponse != expectedResponse) {
         LOG.warn("Connectivity check to S3 endpoint failed. Expected HEAD op against " + this.getUpstreamEndpoint() + " to return HTTP response "
             + expectedResponse + ", but got " + headResponse);
@@ -440,7 +440,7 @@ public class S3ProviderClient implements ObjectStorageProviderClient {
     }
   }
 
-  protected int excuteHeadRequest(URI targetURI) {
+  protected int executeHeadRequest(URI targetURI) {
     LOG.trace("Executing HEAD op on " + targetURI);
     HttpURLConnection connection = null;
     int code = 500;
@@ -448,12 +448,10 @@ public class S3ProviderClient implements ObjectStorageProviderClient {
       connection = (HttpURLConnection) targetURI.toURL().openConnection();
       connection.setRequestMethod("HEAD");
       connection.setUseCaches(false);
-      try {
-        connection.getInputStream();
-        code = connection.getResponseCode();
-      } catch (IOException ex) {
-        code = connection.getResponseCode();
-      }
+      connection.setConnectTimeout(15_000);
+      connection.setReadTimeout(15_000);
+      connection.setRequestProperty("Connection", "close");
+      code = connection.getResponseCode();
       LOG.trace("HEAD op response HTTP " + code);
       return code;
     } catch (Exception ex) {


### PR DESCRIPTION
S3 provider connection test should close the http connection to ensure data from a previous response is not read on later requests. This was causing a `-1` status code to be incorrectly reported for some S3 implementations.