### PR TITLE
Node controller remove vlan utility functions and vconfig dependency

### DIFF
--- a/net/dev_handler.h
+++ b/net/dev_handler.h
@@ -188,16 +188,6 @@ int dev_rename(dev_handler *devh, const char *psDeviceName, const char *psNewDev
 //! @}
 
 //! @{
-//! @name APIs to work with VLAN on devices
-const char *dev_get_vlan_name(const char *psDeviceName, u16 vlan);
-int dev_get_vlan_id(const char *psDeviceName);
-boolean dev_has_vlan(const char *psDeviceName, u16 vlan);
-dev_entry *dev_create_vlan(dev_handler *devh, const char *psDeviceName, u16 vlan);
-int dev_remove_vlan(dev_handler *devh, const char *psDeviceName, u16 vlan);
-int dev_remove_vlan_interface(dev_handler *devh, const char *psVlanInterfaceName);
-//! @}
-
-//! @{
 //! @name APIs to work with bridge devices
 boolean dev_is_bridge(const char *psDeviceName);
 boolean dev_is_bridge_interface(const char *psDeviceName, const char *psBridgeName);

--- a/rpm/eucalyptus.spec
+++ b/rpm/eucalyptus.spec
@@ -323,7 +323,6 @@ Requires:     curl
 Requires:     e2fsprogs
 Requires:     file
 Requires:     parted
-Requires:     vconfig
 Requires:     util-linux
 Requires:     /usr/bin/which
 %{?systemd_requires}


### PR DESCRIPTION
Remove unused vlan utility functions and the corresponding `vconfig` (epel) rpm dependency.

Network modes using vlans were removed in 4.4 but these utility functions remained.