### PR TITLE
Node controller use configured NC_ADDR for node IP

### DIFF
--- a/util/eucalyptus.h
+++ b/util/eucalyptus.h
@@ -189,6 +189,7 @@
 #define CONFIG_NC_PORT                          "NC_PORT"
 #define CONFIG_NODES                            "NODES"
 #define CONFIG_HYPERVISOR                       "HYPERVISOR"
+#define CONFIG_NC_ADDR                          "NC_ADDR"
 #define CONFIG_NC_CACHE_SIZE                    "NC_CACHE_SIZE"
 #define CONFIG_NC_WORK_SIZE                     "NC_WORK_SIZE"
 #define CONFIG_NC_OVERHEAD_SIZE                 "NC_WORK_OVERHEAD_SIZE"


### PR DESCRIPTION
We added an `NC_ADDR` option for the node controller bind address in Corymbia/eucalyptus#161 . This change ensures that when an IP is configured (so not the `0.0.0.0` default) it is used as the node controllers IP in place of the current approach of detecting the IP to use via the hostname. 

In the default case behaviour is unchanged, the `NC_ADDR` will be absent or `0.0.0.0` and the node controllers IP will be detected.