### PR TITLE
Node controller migration key EUCA_USER default

### DIFF
--- a/tools/generate-migration-keys.sh
+++ b/tools/generate-migration-keys.sh
@@ -148,7 +148,7 @@ if [ -r "$EUCA_CONF" ] ; then
     . $EUCA_CONF
 fi
 if [ -z "$EUCA_USER" ] ; then
-    EUCA_USER=root
+    EUCA_USER=eucalyptus
 fi
 chmod 700 /etc/pki/libvirt/private
 chmod 600 /etc/pki/libvirt/private/clientkey.pem  /etc/pki/libvirt/private/serverkey.pem


### PR DESCRIPTION
Node controller migration key generation script should default `EUCA_USER` to `eucalyptus` rather than `root`.