### PR TITLE
IAM policy parser should allow hyphen in service name

### DIFF
--- a/clc/modules/core/src/main/java/com/eucalyptus/auth/policy/PolicySpec.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/auth/policy/PolicySpec.java
@@ -265,7 +265,7 @@ public class PolicySpec {
       .build();
 
   // Action syntax
-  public static final Pattern ACTION_PATTERN = Pattern.compile( "\\*|(?:([a-z0-9]+):(\\S+))" );
+  public static final Pattern ACTION_PATTERN = Pattern.compile( "\\*|(?:([a-z0-9-]+):(\\S+))" );
 
   // Wildcard
   public static final String ALL_RESOURCE = "*";

--- a/clc/modules/core/src/test/java/com/eucalyptus/auth/policy/PolicyParserTest.java
+++ b/clc/modules/core/src/test/java/com/eucalyptus/auth/policy/PolicyParserTest.java
@@ -191,6 +191,27 @@ public class PolicyParserTest {
         normalizedPolicyJson );
   }
 
+  @Test
+  public void testParseServiceHyphenPolicy( ) throws Exception {
+    String policyJson =
+        "{\n" +
+            "  \"Statement\": {\n" +
+            "    \"Effect\": \"Allow\",\n" +
+            "    \"Action\": \"aws-marketplace:ViewSubscriptions\",\n" +
+            "    \"Resource\": \"*\"\n" +
+            "  }\n" +
+            "}";
+
+    PolicyPolicy policy = PolicyParser.getInstance().parse( policyJson );
+    assertNotNull( "Policy null", policy );
+    assertNotNull( "Policy authorizations", policy.getAuthorizations() );
+    assertEquals( "Policy authorization count", 1, policy.getAuthorizations().size() );
+    Authorization authorization = policy.getAuthorizations().get( 0 );
+    assertNotNull( "Authorization null", authorization );
+    assertNull( "Authorization principal", authorization.getPrincipal( ) );
+    assertEquals( "Authorization actions", Sets.newHashSet( "aws-marketplace:viewsubscriptions" ), authorization.getActions() );
+  }
+
   @Test(expected = PolicyParseException.class )
   public void testParseUserPolicyMissingResource() throws Exception {
     String policyJson =


### PR DESCRIPTION
Update iam policy syntax checking to allow hyphen `-` in the service name prefix for actions.

Fixes Corymbia/eucalyptus#170