### PR TITLE
Key store / PEM utility method updates for certificate chains

### DIFF
--- a/clc/modules/core/src/main/java/com/eucalyptus/component/auth/SystemCredentials.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/component/auth/SystemCredentials.java
@@ -423,6 +423,15 @@ public class SystemCredentials {
       RestrictSize.INSTANCE.apply( privateKey );
       super.addKeyPair( alias, cert, privateKey, keyPassword );
     }
+
+    @Override
+    public final void addKeyPair( String alias, X509Certificate[] certs, PrivateKey privateKey, String keyPassword ) throws IOException, GeneralSecurityException {
+      for ( final X509Certificate cert : certs ) {
+        RestrictSize.INSTANCE.apply( cert.getPublicKey( ) );
+      }
+      RestrictSize.INSTANCE.apply( privateKey );
+      super.addKeyPair( alias, certs, privateKey, keyPassword );
+    }
   }
   
   public static final KeyStore getKeyStore( ) {

--- a/clc/modules/core/src/main/java/com/eucalyptus/crypto/KeyStore.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/crypto/KeyStore.java
@@ -52,38 +52,40 @@ import java.util.List;
 
 public interface KeyStore {
   
-  public abstract KeyPair getKeyPair( final String alias, final String password ) throws GeneralSecurityException;
+  KeyPair getKeyPair( final String alias, final String password ) throws GeneralSecurityException;
   
-  public abstract boolean check( ) throws GeneralSecurityException;
+  boolean check( ) throws GeneralSecurityException;
   
-  public abstract boolean containsEntry( final String alias );
+  boolean containsEntry( final String alias );
 
-  public abstract X509Certificate getCertificate( final String alias ) throws GeneralSecurityException;
+  X509Certificate getCertificate( final String alias ) throws GeneralSecurityException;
 
-  public abstract List<X509Certificate> getCertificateChain( final String alias ) throws GeneralSecurityException;
+  List<X509Certificate> getCertificateChain( final String alias ) throws GeneralSecurityException;
   
-  public abstract Key getKey( final String alias, final String password ) throws GeneralSecurityException;
+  Key getKey( final String alias, final String password ) throws GeneralSecurityException;
   
-  public abstract String getCertificateAlias( final String certPem ) throws GeneralSecurityException;
+  String getCertificateAlias( final String certPem ) throws GeneralSecurityException;
   
-  public abstract String getCertificateAlias( final X509Certificate cert ) throws GeneralSecurityException;
+  String getCertificateAlias( final X509Certificate cert ) throws GeneralSecurityException;
   
-  public abstract void addCertificate( final String alias, final X509Certificate cert ) throws IOException, GeneralSecurityException;
+  void addCertificate( final String alias, final X509Certificate cert ) throws IOException, GeneralSecurityException;
   
-  public abstract void addKeyPair( final String alias, final X509Certificate cert, final PrivateKey privateKey, final String keyPassword ) throws IOException, GeneralSecurityException;
+  void addKeyPair( final String alias, final X509Certificate cert, final PrivateKey privateKey, final String keyPassword ) throws IOException, GeneralSecurityException;
+
+  void addKeyPair( final String alias, final X509Certificate[] certs, final PrivateKey privateKey, final String keyPassword ) throws IOException, GeneralSecurityException;
+
+  void store( ) throws IOException, GeneralSecurityException;
   
-  public abstract void store( ) throws IOException, GeneralSecurityException;
+  List<String> getAliases( ) throws KeyStoreException;
   
-  public abstract List<String> getAliases( ) throws KeyStoreException;
+  String getFileName( );
   
-  public abstract String getFileName( );
+  void remove( final String alias );
   
-  public abstract void remove( final String alias );
+  void remove( );
   
-  public abstract void remove( );
+  InputStream getAsInputStream( ) throws FileNotFoundException;
   
-  public abstract InputStream getAsInputStream( ) throws FileNotFoundException;
-  
-  public abstract List<X509Certificate> getAllCertificates( ) throws KeyStoreException;
+  List<X509Certificate> getAllCertificates( ) throws KeyStoreException;
   
 }

--- a/clc/modules/core/src/main/java/com/eucalyptus/crypto/util/AbstractKeyStore.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/crypto/util/AbstractKeyStore.java
@@ -153,13 +153,18 @@ public abstract class AbstractKeyStore implements com.eucalyptus.crypto.KeyStore
     this.keyStore.setCertificateEntry( alias, cert );
     this.store( );
   }
-  
+
   @Override
   public void addKeyPair( final String alias, final X509Certificate cert, final PrivateKey privateKey, final String keyPassword ) throws IOException, GeneralSecurityException {
-    this.keyStore.setKeyEntry( alias, privateKey, keyPassword.toCharArray( ), new Certificate[] { cert } );
+    this.addKeyPair( alias, new X509Certificate[]{ cert }, privateKey, keyPassword );
+  }
+
+  @Override
+  public void addKeyPair( final String alias, final X509Certificate[] certs, final PrivateKey privateKey, final String keyPassword ) throws IOException, GeneralSecurityException {
+    this.keyStore.setKeyEntry( alias, privateKey, keyPassword.toCharArray( ), certs );
     this.store( );
   }
-  
+
   @Override
   public void store( ) throws IOException, GeneralSecurityException {
     LOG.info( "Writing back keystore: " + this.fileName );

--- a/clc/modules/core/src/main/java/com/eucalyptus/crypto/util/PEMFiles.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/crypto/util/PEMFiles.java
@@ -49,6 +49,8 @@ import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.annotation.Nullable;
 
@@ -125,6 +127,22 @@ public class PEMFiles {
       LOG.error( e, e );//this can never happen
     }
     return x509;
+  }
+
+  public static List<X509Certificate> getCertChain( final byte[] o ) {
+    final List<X509Certificate> certificates = new ArrayList<>();
+    final ByteArrayInputStream pemByteIn = new ByteArrayInputStream( o );
+    try ( final PEMParser in = new PEMParser( new InputStreamReader( pemByteIn ) ) ) {
+      final JcaX509CertificateConverter converter =
+          new JcaX509CertificateConverter( ).setProvider( BouncyCastleProvider.PROVIDER_NAME );
+      X509CertificateHolder certificateHolder;
+      while( ( certificateHolder = (X509CertificateHolder) in.readObject( ) ) != null ) {
+        certificates.add( converter.getCertificate( certificateHolder ) );
+      }
+    } catch ( IOException | CertificateException e ) {
+      LOG.error( e, e );
+    }
+    return certificates;
   }
 
   @Nullable

--- a/clc/modules/core/src/test/java/com/eucalyptus/crypto/util/PEMFilesTest.java
+++ b/clc/modules/core/src/test/java/com/eucalyptus/crypto/util/PEMFilesTest.java
@@ -1,0 +1,83 @@
+package com.eucalyptus.crypto.util;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Security;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class PEMFilesTest {
+
+  private static final String CERT_PEM =
+          "-----BEGIN CERTIFICATE-----\n" +
+          "MIID6jCCAtICCQDicjjWYnwY6jANBgkqhkiG9w0BAQ0FADCBtjELMAkGA1UEBhMC\n" +
+          "VVMxCzAJBgNVBAgMAkNBMRYwFAYDVQQHDA1TYW50YSBCYXJiYXJhMSEwHwYDVQQK\n" +
+          "DBhFdWNhbHlwdHVzIFN5c3RlbXMsIEluYy4xIDAeBgNVBAsMF0V1Y2FseXB0dXMg\n" +
+          "VXNlciBDb25zb2xlMRowGAYDVQQDDBFuYzA0LmFwcHNjYWxlLm5ldDEhMB8GCSqG\n" +
+          "SIb3DQEJARYSQG5jMDQuYXBwc2NhbGUubmV0MB4XDTIwMDEyMzAyMDk1MloXDTIx\n" +
+          "MDEyMjAyMDk1MlowgbYxCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJDQTEWMBQGA1UE\n" +
+          "BwwNU2FudGEgQmFyYmFyYTEhMB8GA1UECgwYRXVjYWx5cHR1cyBTeXN0ZW1zLCBJ\n" +
+          "bmMuMSAwHgYDVQQLDBdFdWNhbHlwdHVzIFVzZXIgQ29uc29sZTEaMBgGA1UEAwwR\n" +
+          "bmMwNC5hcHBzY2FsZS5uZXQxITAfBgkqhkiG9w0BCQEWEkBuYzA0LmFwcHNjYWxl\n" +
+          "Lm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKewrozUIFu5XsJ3\n" +
+          "lk0Y3rjju05zx6HMXabn9kyhexKCrgT/lqw+ueA80s0crpBHTvKH3MdVAF6rPj+J\n" +
+          "N7+Dang3LGNzThWmooPCFIxFopr+HAvbsHJb1SKXbzaYZ75AjfCpq9hnhT+MS53e\n" +
+          "7xzLa3gMNNJgE1FM4zzfL3gxK2ZDVgJsQOxVrpLFcGAtOniLvc47KwMNuiLtLlTD\n" +
+          "qzWk7ROKh4on2KS/3Zw8XRT+p1xy7H5UDZ69JUTRR9Lllyo/M9Oj+7MrAXqd7L2L\n" +
+          "Tp3Fju3SeLe2eSL43AYreEh0DsKg+VXx7TdsVODjAQWQ0FYkUayogcoQMCVYkqMC\n" +
+          "lwL2EvMCAwEAATANBgkqhkiG9w0BAQ0FAAOCAQEApkoAeeolIBgTNjSCqFWqDIn2\n" +
+          "oRV+C6YOR/e+YVKTZdraWQ4Bv0QjzsfhCX1h+EqGhxqV+lssphWm7FdF1Us4yOVT\n" +
+          "V2vGB5ripd0YN87Ef0BNKohkdVsTWvyY/LTMCvjJFpDc5KxYT4GH1ZzviAmGiud3\n" +
+          "Br8aSZGl0AJU2d5VZ0fN1SW9V21fo0X6qJqhQhTIt98cZ5uvc49b2ZtyIZbbxodi\n" +
+          "OAsRFnOrYq2/s1Q20WulIKSpy+nMW2zkLz7RIVneyJFONZNdpBZOgoBIx6o42qnk\n" +
+          "v0J04FqCEUJzedMbSMFqvPkZttCs+JaQQg0QMxeoV/IVJtsqSA/Kc73CIZZC0A==\n" +
+          "-----END CERTIFICATE-----\n";
+
+  private static final String CERT_CHAIN1_PEM = CERT_PEM;
+
+  private static final String CERT_CHAIN2_PEM = CERT_PEM + CERT_PEM;
+
+  private static final String CERT_CHAIN3_PEM = CERT_PEM + CERT_PEM + CERT_PEM;
+
+  @BeforeClass
+  public static void beforeClass() {
+    if ( Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null ) {
+      Security.addProvider(new BouncyCastleProvider());
+    }
+  }
+
+  @Test
+  public void testGetCertificate( ) {
+    Assert.assertNotNull(
+        "Certificate",
+        PEMFiles.getCert( CERT_PEM.getBytes( StandardCharsets.UTF_8 ) ) );
+  }
+
+  @Test
+  public void testGetCertificateChain1( ) {
+    Assert.assertEquals(
+        "Certificate chain length",
+        1,
+        PEMFiles.getCertChain( CERT_CHAIN1_PEM.getBytes( StandardCharsets.UTF_8 ) ).size( ) );
+  }
+
+  @Test
+  public void testGetCertificateChain2( ) {
+    Assert.assertEquals(
+        "Certificate chain length",
+        2,
+        PEMFiles.getCertChain( CERT_CHAIN2_PEM.getBytes( StandardCharsets.UTF_8 ) ).size( ) );
+  }
+
+  @Test
+  public void testGetCertificateChain3( ) {
+    Assert.assertEquals(
+        "Certificate chain length",
+        3,
+        PEMFiles.getCertChain( CERT_CHAIN3_PEM.getBytes( StandardCharsets.UTF_8 ) ).size( ) );
+  }
+}


### PR DESCRIPTION
Update utility methods to support certificate chains in addition to single certificates. This is useful when using a production https configuration where intermediate certificates may be required.