### PR TITLE
CloudFormation fix attribute check for stack resources

### DIFF
--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/ResourceInfoHelper.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/ResourceInfoHelper.java
@@ -44,7 +44,7 @@ public class ResourceInfoHelper {
   public static void setResourceAttributesJson(ResourceInfo resourceInfo, String json) throws CloudFormationException {
     JsonNode attributeNode = JsonHelper.getJsonNodeFromString(json);
     for (String attributeName: Lists.newArrayList(attributeNode.fieldNames())) {
-      if (resourceInfo.getAttributeNames().contains(attributeName)) {
+      if (resourceInfo.isAttributeAllowed(attributeName)) {
         resourceInfo.setResourceAttributeJson(attributeName, attributeNode.get(attributeName).asText());
       } else {
         LOG.warn("Attempting to set non-existent attribute '" + attributeName + "' on resource " + resourceInfo.getLogicalResourceId() + " (" + resourceInfo.getType() + "). " +


### PR DESCRIPTION
CloudFormation `AWS::CloudFormation::Stack` outputs were not found when used as attributes from the parent stack. You can now use these attributes as expected, e.g.:

```
!GetAtt StackResourceName.Outputs.NestedStackOutputName
!GetAtt [StackResourceName, Outputs.NestedStackOutputName]
```