### PR TITLE
CloudFormation allow configured partition and urlsuffix pseudo params

### DIFF
--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/CloudFormationService.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/CloudFormationService.java
@@ -1769,8 +1769,12 @@ public class CloudFormationService {
 
   public static PseudoParameterValues populateRegionPseudoParameters(final PseudoParameterValues pseudoParameterValues) {
     pseudoParameterValues.setRegion(getRegion( ));
-    pseudoParameterValues.setPartition("eucalyptus");
-    pseudoParameterValues.setUrlSuffix(DomainNames.externalSubdomain().relativize(Name.root).toString());
+    pseudoParameterValues.setPartition(Objects.toString(
+        Strings.emptyToNull(CloudFormationProperties.PSEUDO_PARAM_PARTITION),
+        "eucalyptus"));
+    pseudoParameterValues.setUrlSuffix(Objects.toString(
+        Strings.emptyToNull(CloudFormationProperties.PSEUDO_PARAM_URLSUFFIX),
+        DomainNames.externalSubdomain().relativize(Name.root).toString()));
     return pseudoParameterValues;
   }
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/config/CloudFormationProperties.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/config/CloudFormationProperties.java
@@ -80,6 +80,22 @@ public class CloudFormationProperties {
       changeListener = PropertyChangeListeners.CacheSpecListener.class )
   public static volatile String CFN_INSTANCE_AUTH_CACHE = "";
 
+  @ConfigurableField(
+      description = "CloudFormation AWS::Partition (default: eucalyptus)",
+      changeListener = PropertyChangeListeners.RegexMatchListener.class )
+  @PropertyChangeListeners.RegexMatchListener.RegexMatch(
+      message = "Invalid partition value, must be dashed lowercase alphanumeric, max length 64",
+      regex = "[a-z0-9-]{1,64}" )
+  public static volatile String PSEUDO_PARAM_PARTITION = "";
+
+  @ConfigurableField(
+      description = "CloudFormation AWS::URLSuffix (default: dns domain)",
+      changeListener = PropertyChangeListeners.RegexMatchListener.class )
+  @PropertyChangeListeners.RegexMatchListener.RegexMatch(
+      message = "Invalid url suffix value, must be a valid domain with optional port",
+      regex = "[a-zA-Z0-9-]{3,64}(?:\\.[a-zA-Z0-9-]{3,64})*(?::[0-9]{1,5})?" )
+  public static volatile String PSEUDO_PARAM_URLSUFFIX = "";
+
   // In case we are using AWS SWF
   public static boolean USE_AWS_SWF = "true".equalsIgnoreCase(System.getProperty("cloudformation.use_aws_swf"));
   public static String AWS_ACCESS_KEY = System.getProperty("cloudformation.aws_access_key", "");


### PR DESCRIPTION
CloudFormation add properties for configuration of cloud-wide pseudo parameters `AWS::Partition` and `AWS::URLSuffix`.

```
#
# euctl cloudformation.pseudo_param_partition=aws
cloudformation.pseudo_param_partition = aws
#
# euctl cloudformation.pseudo_param_urlsuffix=my-cloud-10-10-10-10.euca.me:8773
cloudformation.pseudo_param_urlsuffix = my-cloud-10-10-10-10.euca.me:8773
#
```

This allows deployments to mimic a particular aws partition if desired or to (or example) include a port number in the url suffix.