### PR TITLE
eucanetd systemd mode

### DIFF
--- a/net/eucanetd.c
+++ b/net/eucanetd.c
@@ -333,7 +333,7 @@ int main(int argc, char **argv) {
 
     // parse commandline arguments
     config->flushmode = FLUSH_NONE;
-    while ((opt = getopt(argc, argv, "dhHlgfFmMuUCZT:v:V:z:")) != -1) {
+    while ((opt = getopt(argc, argv, "dhHlgfFmMsuUCZT:v:V:z:")) != -1) {
         switch (opt) {
         case 'd':
             config->debug = EUCANETD_DEBUG_TRACE;
@@ -372,6 +372,9 @@ int main(int argc, char **argv) {
         case 'M':
             config->flushmode = FLUSH_MIDO_DUPS;
             config->debug = EUCANETD_DEBUG_INFO;
+            break;
+        case 's':
+            config->systemd = TRUE;
             break;
         case 'u':
             config->flushmode = FLUSH_MIDO_CHECKUNCONNECTED;
@@ -455,11 +458,13 @@ int main(int argc, char **argv) {
         }
     }
 
-    // daemonize this process!
-    rc = eucanetd_daemonize();
-    if (rc) {
-        fprintf(stderr, "failed to eucanetd_daemonize eucanetd, exiting\n");
-        exit(1);
+    if (!config->systemd) {
+        // daemonize this process!
+        rc = eucanetd_daemonize();
+        if (rc) {
+            fprintf(stderr, "failed to eucanetd_daemonize eucanetd, exiting\n");
+            exit(1);
+        }
     }
 
     eucanetd_setlog_bootstrap();

--- a/net/eucanetd.h
+++ b/net/eucanetd.h
@@ -272,6 +272,7 @@ typedef struct eucanetdConfig_t {
     boolean validate_mido_config;
 
     int debug;
+    boolean systemd;                 //!< Set to TRUE to indicate systemd mode (do not switch user or daemonize)
     int flushmode;
     char *flushmodearg;
     boolean multieucanetd_safe;

--- a/net/eucanetd_edge.c
+++ b/net/eucanetd_edge.c
@@ -1182,7 +1182,7 @@ int do_edge_update_eips(edge_config *edge) {
                 // try arping up to 3 times
                 rc = EUCA_TIMEOUT_ERROR;
                 for (j = 1; j < 4 && rc != EUCA_OK; j++) {
-                    rc = euca_exec_wait(j, edge->config->cmdprefix, "arping", "-c", "1", "-U", "-I", edge->config->pubInterface, strptra, NULL);
+                    rc = euca_exec_wait(j, edge->config->cmdprefix, "arping", "-q", "-c", "1", "-U", "-I", edge->config->pubInterface, strptra, NULL);
                 }
             }
 
@@ -1287,8 +1287,10 @@ int do_edge_update_eips(edge_config *edge) {
                 strptra = hex2dot(edge->gni->public_ips[i]);
                 snprintf(cmd, EUCA_MAX_PATH, "%s/32", strptra);
                 EUCA_FREE(strptra);
-                if (euca_execlp_redirect(NULL, NULL, "/dev/null", FALSE, "/dev/null", FALSE, edge->config->cmdprefix,
-                                         "ip", "addr", "del", cmd, "dev", edge->config->pubInterface, NULL) != EUCA_OK) {
+                euca_execlp_redirect(&rc, NULL, "/dev/null", FALSE, "/dev/null", FALSE, edge->config->cmdprefix,
+                                     "ip", "addr", "del", cmd, "dev", edge->config->pubInterface, NULL);
+                rc = rc >> 8;
+                if (!(rc == 0 || rc == 2)) {
                     LOGERROR("could not execute: revoking no longer in use ips\n");
                     ret = 1;
                 }

--- a/systemd/units/eucanetd.service
+++ b/systemd/units/eucanetd.service
@@ -3,17 +3,17 @@ Description=Eucalyptus network daemon
 After=midolman.service network.target
 
 [Service]
-Type=forking
+Type=simple
 PIDFile=/run/eucalyptus/eucanetd.pid
-ExecStart=/usr/sbin/eucanetd
+ExecStart=/usr/sbin/eucanetd -s
+ExecStartPost=/bin/sh -c 'echo $MAINPID > /run/eucalyptus/eucanetd.pid'
 LimitNOFILE=10000
 LimitNPROC=100000
-# Need to come up with a better way of preserving nginx and dhcpd
-# processes across service restarts
-# https://eucalyptus.atlassian.net/browse/EUCA-12390
-#KillMode=process
-
-# KillMode removed per http://eucalyptus.atlassian.net/browse/EUCA-12424
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=true
+User=eucalyptus
+Group=eucalyptus
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
eucanetd now supports running under systemd as a `simple` service, with an option to skip closing file descriptors, switching user and forking.

The call to `arping` is modified to suppress output as this otherwise now ends up in the journal. The clean up for ip addresses now calls `ip addr del` as we do in other areas to avoid failures on error code 2 which is expected if the address is not present (so the delete is now idempotent)

The unit file now includes:

```
PrivateTmp=true
ProtectHome=true
ProtectSystem=true
```

which provide some additional protections.