### PR TITLE
CloudFormation update validation for configured urlsuffix pseudo param

### DIFF
--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/config/CloudFormationProperties.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/config/CloudFormationProperties.java
@@ -93,7 +93,7 @@ public class CloudFormationProperties {
       changeListener = PropertyChangeListeners.RegexMatchListener.class )
   @PropertyChangeListeners.RegexMatchListener.RegexMatch(
       message = "Invalid url suffix value, must be a valid domain with optional port",
-      regex = "[a-zA-Z0-9-]{3,64}(?:\\.[a-zA-Z0-9-]{3,64})*(?::[0-9]{1,5})?" )
+      regex = "[a-zA-Z0-9-]{2,64}(?:\\.[a-zA-Z0-9-]{2,64})*(?::[0-9]{1,5})?" )
   public static volatile String PSEUDO_PARAM_URLSUFFIX = "";
 
   // In case we are using AWS SWF


### PR DESCRIPTION
Input validation for the cloudformation urlsuffix pseudo parameter is overly restrictive, we should allow shorter dns labels.