### PR TITLE
CloudFormation allow but ignore template exports

### DIFF
--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/CloudFormationService.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/CloudFormationService.java
@@ -1794,7 +1794,9 @@ public class CloudFormationService {
   }
 
   public ListExportsResponseType listExports( final ListExportsType request ) throws CloudFormationException {
-    return handleStub( request );
+    final ListExportsResponseType response = handleStub( request );
+    response.getListExportsResult().setExports(new Exports());
+    return response;
   }
 
   public ListImportsResponseType listImports( final ListImportsType request ) throws CloudFormationException {

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/template/TemplateParser.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/template/TemplateParser.java
@@ -131,7 +131,8 @@ public class TemplateParser {
   private enum OutputKey {
     Description,
     Condition,
-    Value
+    Value,
+    Export,
   };
 
   public static final String AWS_ACCOUNT_ID = "AWS::AccountId";
@@ -1330,6 +1331,16 @@ public class TemplateParser {
 
           if (outputValueNode.isArray()) {
             throw new ValidationErrorException("The Value field of every Outputs member must evaluate to a String and not a List.");
+          }
+        }
+        final JsonNode outputExportNode = outputJsonNode.get(OutputKey.Export.toString());
+        if (outputExportNode != null) {
+          final Set<String> tempOutputExportKeys = Sets.newHashSet(outputExportNode.fieldNames());
+          if ( !tempOutputExportKeys.remove("Name") ) {
+            throw new ValidationErrorException("Outputs Export missing required Name");
+          }
+          if ( !tempOutputExportKeys.isEmpty() ) {
+            throw new ValidationErrorException("Invalid output/export property or properties " + tempOutputExportKeys);
           }
         }
 


### PR DESCRIPTION
CloudFormation update to allow use of `Export` for better portability of templates between aws and eucalyptus. 

Exports are now ignored rather than causing a failure.