### PR TITLE
CloudFormation timeouts not configurable for nat gateway and eni

### DIFF
--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2NatGatewayResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2NatGatewayResourceAction.java
@@ -61,6 +61,7 @@ import com.eucalyptus.compute.common.DescribeNatGatewaysType;
 import com.eucalyptus.compute.common.DescribeTagsResponseType;
 import com.eucalyptus.compute.common.DescribeTagsType;
 import com.eucalyptus.compute.common.TagInfo;
+import com.eucalyptus.configurable.ConfigurableClass;
 import com.eucalyptus.configurable.ConfigurableField;
 import com.eucalyptus.util.async.AsyncExceptions;
 import com.eucalyptus.util.async.AsyncRequests;
@@ -80,6 +81,7 @@ import static com.eucalyptus.util.async.AsyncExceptions.asWebServiceErrorMessage
 /**
  * Created by ethomas on 2/3/14.
  */
+@ConfigurableClass( root = "cloudformation", description = "Parameters controlling cloud formation")
 public class AWSEC2NatGatewayResourceAction extends StepBasedResourceAction {
   private static final Logger LOG = Logger.getLogger(AWSEC2NatGatewayResourceAction.class);
   private AWSEC2NatGatewayProperties properties = new AWSEC2NatGatewayProperties();

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2NetworkInterfaceAttachmentResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2NetworkInterfaceAttachmentResourceAction.java
@@ -57,6 +57,7 @@ import com.eucalyptus.compute.common.ModifyNetworkInterfaceAttributeResponseType
 import com.eucalyptus.compute.common.ModifyNetworkInterfaceAttributeType;
 import com.eucalyptus.compute.common.NetworkInterfaceIdSetItemType;
 import com.eucalyptus.compute.common.NetworkInterfaceIdSetType;
+import com.eucalyptus.configurable.ConfigurableClass;
 import com.eucalyptus.configurable.ConfigurableField;
 import com.eucalyptus.util.async.AsyncExceptions;
 import com.eucalyptus.util.async.AsyncExceptions.AsyncWebServiceError;
@@ -73,11 +74,12 @@ import java.util.Objects;
 /**
 * Created by ethomas on 2/3/14.
 */
+@ConfigurableClass( root = "cloudformation", description = "Parameters controlling cloud formation")
 public class AWSEC2NetworkInterfaceAttachmentResourceAction extends StepBasedResourceAction {
   private AWSEC2NetworkInterfaceAttachmentProperties properties = new AWSEC2NetworkInterfaceAttachmentProperties( );
   private AWSEC2NetworkInterfaceAttachmentResourceInfo info = new AWSEC2NetworkInterfaceAttachmentResourceInfo( );
 
-  @ConfigurableField(initial = "300", description = "The amount of time (in seconds) to wait for a network interface to be attached during createor update)")
+  @ConfigurableField(initial = "300", description = "The amount of time (in seconds) to wait for a network interface to be attached during create or update)")
   public static volatile Integer NETWORK_INTERFACE_ATTACHMENT_MAX_CREATE_OR_UPDATE_RETRY_SECS = 300;
 
   @ConfigurableField(initial = "300", description = "The amount of time (in seconds) to wait for a network interface to detach during delete or update)")

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2NetworkInterfaceResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2NetworkInterfaceResourceAction.java
@@ -82,6 +82,7 @@ import com.eucalyptus.compute.common.SubnetIdSetItemType;
 import com.eucalyptus.compute.common.SubnetIdSetType;
 import com.eucalyptus.compute.common.TagInfo;
 import com.eucalyptus.compute.common.UnassignPrivateIpAddressesType;
+import com.eucalyptus.configurable.ConfigurableClass;
 import com.eucalyptus.configurable.ConfigurableField;
 import com.eucalyptus.util.async.AsyncRequests;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -99,6 +100,7 @@ import java.util.Set;
 /**
  * Created by ethomas on 2/3/14.
  */
+@ConfigurableClass( root = "cloudformation", description = "Parameters controlling cloud formation")
 public class AWSEC2NetworkInterfaceResourceAction extends StepBasedResourceAction {
 
   private AWSEC2NetworkInterfaceProperties properties = new AWSEC2NetworkInterfaceProperties();


### PR DESCRIPTION
Add missing `@ConfigurableClass` annotations for cloudformation resources so that configurable properties are discovered.