### PR TITLE
Convert InstanceProtocol to upper case

### DIFF
--- a/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/LoadBalancers.java
+++ b/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/LoadBalancers.java
@@ -428,7 +428,7 @@ public class LoadBalancers {
 	        				LoadBalancerListener.Builder builder = new LoadBalancerListener.Builder(lb, listener.getInstancePort(),
 											listener.getLoadBalancerPort(), LoadBalancerListener.PROTOCOL.valueOf(listener.getProtocol().toUpperCase()));
 	            			if(!Strings.isNullOrEmpty(listener.getInstanceProtocol()))
-	            				builder.instanceProtocol(PROTOCOL.valueOf(listener.getInstanceProtocol()));
+	            				builder.instanceProtocol(PROTOCOL.valueOf(listener.getInstanceProtocol().toUpperCase()));
 
 	            			if(!Strings.isNullOrEmpty(listener.getSSLCertificateId()))
 	            				builder.withSSLCerntificate(listener.getSSLCertificateId());


### PR DESCRIPTION
When the ELB listeners are empty there exists a case when the AWS SDK will add listeners using lower case values of the Protocol, i.e. "tcp" when the construct is expected the upper case value, i.e. "TCP". This adds the `toUpperCase()` function to convert the string when building the listener.