### PR TITLE
ELB consistently allow for case-insensitive protocol names when creating listeners

### DIFF
--- a/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/LoadBalancerListener.java
+++ b/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/LoadBalancerListener.java
@@ -154,7 +154,17 @@ public class LoadBalancerListener extends AbstractPersistent
 	public static String RESTRICTED_PORTS = DEFAULT_PORT_RESTRICTION;
 	
 	public enum PROTOCOL{
-		HTTP, HTTPS, TCP, SSL, NONE
+		HTTP,
+		HTTPS,
+		TCP,
+		SSL,
+		NONE,
+		;
+
+		public static PROTOCOL from(final String protocol) {
+			final String upperProtocol = protocol == null ? null : protocol.toUpperCase();
+			return PROTOCOL.valueOf(upperProtocol);
+		}
 	}
 
 	private static final long serialVersionUID = 1L;
@@ -250,13 +260,13 @@ public class LoadBalancerListener extends AbstractPersistent
 		if(this.instanceProtocol==null)
 			return PROTOCOL.NONE;
 		
-		return PROTOCOL.valueOf(this.instanceProtocol.toUpperCase());
+		return PROTOCOL.from(this.instanceProtocol);
 	}
 	public int getLoadbalancerPort(){
 		return this.loadbalancerPort;
 	}
 	public PROTOCOL getProtocol(){
-		return PROTOCOL.valueOf(this.protocol.toUpperCase());
+		return PROTOCOL.from(this.protocol);
 	}
 	public String getCertificateId(){
 		return this.sslCertificateArn;
@@ -300,7 +310,7 @@ public class LoadBalancerListener extends AbstractPersistent
 	
 	public static boolean protocolSupported(Listener listener){
 		try{
-			final PROTOCOL protocol = PROTOCOL.valueOf(listener.getProtocol().toUpperCase());
+			final PROTOCOL protocol = PROTOCOL.from(listener.getProtocol());
 			if(PROTOCOL.HTTP.equals(protocol) || PROTOCOL.TCP.equals(protocol) || PROTOCOL.HTTPS.equals(protocol) || PROTOCOL.SSL.equals(protocol))
 				return true;
 			else
@@ -317,9 +327,9 @@ public class LoadBalancerListener extends AbstractPersistent
 				!Strings.isNullOrEmpty(listener.getProtocol())))
 				return false;
 
-			PROTOCOL protocol = PROTOCOL.valueOf(listener.getProtocol().toUpperCase());
+			PROTOCOL protocol = PROTOCOL.from(listener.getProtocol());
 			if(!Strings.isNullOrEmpty(listener.getInstanceProtocol()))
-				protocol = PROTOCOL.valueOf(listener.getInstanceProtocol().toUpperCase());
+				protocol = PROTOCOL.from(listener.getInstanceProtocol());
 			return true;
 		}catch(Exception e){
 			return false;

--- a/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/LoadBalancers.java
+++ b/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/LoadBalancers.java
@@ -387,7 +387,7 @@ public class LoadBalancers {
 				throw new InvalidConfigurationRequestException("Invalid port range");
 			if(!LoadBalancerListener.portAvailable(listener))
 				throw new EucalyptusCloudException("The specified port(s) " + LoadBalancerListener.RESTRICTED_PORTS + ", are restricted for use as a loadbalancer port.");
-			final PROTOCOL protocol = PROTOCOL.valueOf(listener.getProtocol().toUpperCase());
+			final PROTOCOL protocol = PROTOCOL.from(listener.getProtocol());
 			  if(protocol.equals(PROTOCOL.HTTPS) || protocol.equals(PROTOCOL.SSL)) {
 			  final String sslId = listener.getSSLCertificateId();
 			  if(sslId==null || sslId.length()<=0)
@@ -426,9 +426,9 @@ public class LoadBalancers {
 	    			try{
 	        			if(!lb.hasListener( listener.getLoadBalancerPort() )){
 	        				LoadBalancerListener.Builder builder = new LoadBalancerListener.Builder(lb, listener.getInstancePort(),
-											listener.getLoadBalancerPort(), LoadBalancerListener.PROTOCOL.valueOf(listener.getProtocol().toUpperCase()));
+											listener.getLoadBalancerPort(), LoadBalancerListener.PROTOCOL.from(listener.getProtocol()));
 	            			if(!Strings.isNullOrEmpty(listener.getInstanceProtocol()))
-	            				builder.instanceProtocol(PROTOCOL.valueOf(listener.getInstanceProtocol()));
+	            				builder.instanceProtocol(PROTOCOL.from(listener.getInstanceProtocol()));
 
 	            			if(!Strings.isNullOrEmpty(listener.getSSLCertificateId()))
 	            				builder.withSSLCerntificate(listener.getSSLCertificateId());

--- a/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/workflow/LoadBalancingActivitiesImpl.java
+++ b/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/workflow/LoadBalancingActivitiesImpl.java
@@ -955,7 +955,7 @@ public class LoadBalancingActivitiesImpl implements LoadBalancingActivities {
     }
 
     for(Listener listener : listeners){
-      final PROTOCOL protocol = PROTOCOL.valueOf(listener.getProtocol().toUpperCase());
+      final PROTOCOL protocol = PROTOCOL.from(listener.getProtocol());
       if(protocol.equals(PROTOCOL.HTTPS) || protocol.equals(PROTOCOL.SSL)) {
         final String certArn = listener.getSSLCertificateId();
         if(certArn == null || certArn.length()<=0)
@@ -996,7 +996,7 @@ public class LoadBalancingActivitiesImpl implements LoadBalancingActivities {
     final List<String> policyNames = Lists.newArrayList();
 
     for(final Listener listener : listeners){
-      final PROTOCOL protocol = PROTOCOL.valueOf(listener.getProtocol().toUpperCase());
+      final PROTOCOL protocol = PROTOCOL.from(listener.getProtocol());
       if(protocol.equals(PROTOCOL.HTTPS) || protocol.equals(PROTOCOL.SSL)) {
         certArns.add(listener.getSSLCertificateId());
       }


### PR DESCRIPTION
Update ELB listener protocol handling by adding a utility method for case-insensitively creating protocols from names.

Fixes Corymbia/eucalyptus#194