### PR TITLE
EC2 VPC nat gateway private ip reservation remains pending / is removed

### DIFF
--- a/clc/modules/compute-backend/src/main/java/com/eucalyptus/compute/vpc/NatGatewayHelper.java
+++ b/clc/modules/compute-backend/src/main/java/com/eucalyptus/compute/vpc/NatGatewayHelper.java
@@ -153,20 +153,11 @@ public class NatGatewayHelper {
       if ( networkInterface.isAttached( ) ) {
         networkInterface.detach( );
       }
+
+      NetworkInterfaceHelper.release( networkInterface );
+
       if ( networkInterface.isAssociated( ) ) {
         networkInterface.disassociate( );
-      }
-    }
-    final String associationId = natGateway.getAssociationId( );
-    if ( associationId != null ) {
-      Address address;
-      try {
-        address = RestrictedTypes.resolver( Address.class ).apply( associationId );
-      } catch ( final Exception e ) {
-        address = null;
-      }
-      if ( address != null ) {
-        Addresses.getInstance( ).unassign( address, associationId );
       }
     }
     return Optional.fromNullable( networkInterface );

--- a/clc/modules/compute-backend/src/main/java/com/eucalyptus/compute/vpc/VpcWorkflow.java
+++ b/clc/modules/compute-backend/src/main/java/com/eucalyptus/compute/vpc/VpcWorkflow.java
@@ -69,6 +69,7 @@ import com.eucalyptus.event.ClockTick;
 import com.eucalyptus.event.EventListener;
 import com.eucalyptus.event.Listeners;
 import com.eucalyptus.event.SystemClock;
+import com.eucalyptus.network.PrivateAddresses;
 import com.google.common.base.Functions;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicates;
@@ -160,7 +161,9 @@ public class VpcWorkflow {
             throw new ClientComputeException( "Gateway.NotAttached", "Internet gateway not found for VPC" );
           }
 
-          networkInterfaces.save( NatGatewayHelper.createNetworkInterface( natGateway, subnet ) );
+          final NetworkInterface networkInterface =
+              networkInterfaces.save( NatGatewayHelper.createNetworkInterface( natGateway, subnet ) );
+          PrivateAddresses.associate( networkInterface.getPrivateIpAddress(), networkInterface );
         } catch ( final ComputeException e ) { // NAT gateway creation failure
           cleanup = true;
           natGateway.markDeletion( );


### PR DESCRIPTION
When a NAT gateway is created a private ip address is allocated. This pull request ensures that the private ip resource reservation is extant and uses the existing helper method for the network interface resource release on delete.

Fixes corymbia/eucalyptus#198