### PR TITLE
EC2 node controller windows password encryption

### DIFF
--- a/storage/storage-windows.c
+++ b/storage/storage-windows.c
@@ -324,7 +324,7 @@ int encryptWindowsPassword(char *pass, char *key, char **out, int *outsize)
         return (EUCA_MEMORY_ERROR);
     }
 
-    if (!BN_hex2bn(e, exponentbuf) || !BN_hex2bn(n, modbuf)) {
+    if (!BN_hex2bn(&e, exponentbuf) || !BN_hex2bn(&n, modbuf)) {
         BN_free(e);
         BN_free(n);
         RSA_free(r);


### PR DESCRIPTION
Node controller windows instance password encryption fix.

Build: /job/eucalyptus-internal-5-build-random-rpms/221/
Stage: /job/eucalyptus-internal-5-stage-random/183/
Deploy: /job/eucalyptus-5-ansible-deploy/145/
Test: /job/eucalyptus-5-qa-fast/43/

Demo is that you can run a "windows" instance without the node controller crashing:

```
# 
# rpm -qa eucalyptus
eucalyptus-5.0.0-0.221.wpe.as.el7.x86_64
# 
#  ssh-keygen 
...
#  euca-import-keypair -f ~/.ssh/id_rsa.pub root
...
#  euca-create-volume -s 1 -z cloud-1a
...
#  euca-create-snapshot vol-24fab76693196fb07
...
#  euca-register -n windows --arch x86_64 --virt hvm --platform windows -s snap-bead94dccec0cf1d1
...
# euca-modify-image-attribute -l -a all emi-49198de4cf83f883f
...
# euca-run-instances -k root emi-49198de4cf83f883f
...
```

After launch manually verify that instance goes to running and node controller does not crash. Note that the snapshot is registered with the `windows` platform. This is not a valid instance, but the test covers launch, which is where the issue occurs.

Fixes corymbia/eucalyptus#200