### PR TITLE
DNS configurable listener port

### DIFF
--- a/clc/modules/dns/src/main/java/com/eucalyptus/cloud/ws/DNSControl.java
+++ b/clc/modules/dns/src/main/java/com/eucalyptus/cloud/ws/DNSControl.java
@@ -118,6 +118,11 @@ public class DNSControl {
       changeListener = DnsAddressChangeListener.class )
   public static volatile String dns_listener_address_match = "";
 
+  @ConfigurableField( description = "Port number to listen on for DNS requests.",
+      initial = "53",
+      changeListener = WebServices.CheckNonNegativeIntegerPropertyChangeListener.class )
+  public static volatile Integer dns_listener_port = 53;
+
   @ConfigurableField( description = "Server worker thread pool max.",
       initial = "32",
       changeListener = WebServices.CheckNonNegativeIntegerPropertyChangeListener.class )
@@ -204,11 +209,11 @@ public class DNSControl {
 
   private static final ChannelGroup udpChannelGroup = new DefaultChannelGroup(
       DNSControl.class.getSimpleName( )
-          + ":udp:53" );
+          + ":udp" );
 
   private static final ChannelGroup tcpChannelGroup = new DefaultChannelGroup(
       DNSControl.class.getSimpleName( )
-          + ":tcp:53" );
+          + ":tcp" );
 
   private static DatagramChannelFactory udpChannelFactory = null;
 
@@ -309,7 +314,7 @@ public class DNSControl {
         }
         for ( final InetAddress listenAddr : listenAddresses ) {
           try {
-            Channel udpChannel = b.bind( new InetSocketAddress( listenAddr, 53 ) );
+            Channel udpChannel = b.bind( new InetSocketAddress( listenAddr, dns_listener_port ) );
             udpChannelGroup.add( udpChannel );
           } catch ( final Exception ex ) {
             continue;
@@ -373,7 +378,7 @@ public class DNSControl {
         b.setOption( "keepAlive", false );
         b.setOption( "reuseAddress", true );
         b.setOption( "connectTimeoutMillis", 3000 );
-        final Channel tcpChannel = b.bind( new InetSocketAddress( 53 ) );
+        final Channel tcpChannel = b.bind( new InetSocketAddress( dns_listener_port ) );
         tcpChannelGroup.add( tcpChannel );
       } catch ( final Exception ex ) {
         LOG.debug( ex, ex );


### PR DESCRIPTION
Add a DNS option for configuration of the listen port:

```
# euctl dns.dns_listener_port=8753
```

The cluster interface will always have a listener on port `53` for internal use by instances.

Changing the listen port allows each host with a dns service to also run a public facing reverse proxy dns server such as `dnsdist` which would access the cloud public dns on the configured port.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=410
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/9/
Test: /job/eucalyptus-5-qa-fast/48/

Demo is that the listen port can be configured:

```
# netstat -nlp | grep 53 | grep java
tcp        0      0 192.168.111.14:53       0.0.0.0:*               LISTEN      29398/java          
tcp        0      0 10.116.111.14:53        0.0.0.0:*               LISTEN      29398/java          
tcp        0      0 10.117.111.14:53        0.0.0.0:*               LISTEN      29398/java          
tcp        0      0 10.234.234.234:53       0.0.0.0:*               LISTEN      29398/java          
udp        0      0 192.168.111.14:53       0.0.0.0:*                           29398/java          
udp        0      0 10.116.111.14:53        0.0.0.0:*                           29398/java          
udp        0      0 10.117.111.14:53        0.0.0.0:*                           29398/java          
udp        0      0 10.234.234.234:53       0.0.0.0:*                           29398/java
# 
# 
# euctl dns.dns_listener_port=8753
dns.dns_listener_port = 8753
# 
# 
# netstat -nlp | grep 53 | grep java
tcp        0      0 10.117.111.14:53        0.0.0.0:*               LISTEN      29398/java          
tcp        0      0 192.168.111.14:8753     0.0.0.0:*               LISTEN      29398/java          
tcp        0      0 10.116.111.14:8753      0.0.0.0:*               LISTEN      29398/java          
tcp        0      0 10.117.111.14:8753      0.0.0.0:*               LISTEN      29398/java          
tcp        0      0 10.234.234.234:8753     0.0.0.0:*               LISTEN      29398/java          
udp        0      0 10.117.111.14:53        0.0.0.0:*                           29398/java          
udp        0      0 192.168.111.14:8753     0.0.0.0:*                           29398/java          
udp        0      0 10.116.111.14:8753      0.0.0.0:*                           29398/java          
udp        0      0 10.117.111.14:8753      0.0.0.0:*                           29398/java          
udp        0      0 10.234.234.234:8753     0.0.0.0:*                           29398/java          
# 
```

The cluster address for this host is `10.117.111.14` so that has listeners on port `53` and (the configured) port `8753`.

When the `dns.dns_listener_address_match` is configured then only matching interfaces will have listeners on the configured port.