### PR TITLE
Route53 support for TXT records

### DIFF
--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSRoute53RecordSetGroupResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSRoute53RecordSetGroupResourceAction.java
@@ -163,7 +163,7 @@ public class AWSRoute53RecordSetGroupResourceAction extends StepBasedResourceAct
           listHostedZonesByName.setDNSName(hostedZoneName);
           final ListHostedZonesByNameResponseType zoneListing =
               route53.listHostedZonesByName(listHostedZonesByName);
-          if (zoneListing.getHostedZones()!=null && zoneListing.getHostedZones().getMember().size()==1) {
+          if (zoneListing.getHostedZones()!=null && !zoneListing.getHostedZones().getMember().isEmpty()) {
             hostedZoneId = Strings.substringAfter("/hostedzone/",
                 zoneListing.getHostedZones().getMember().get(0).getId());
           } else {

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSRoute53RecordSetResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSRoute53RecordSetResourceAction.java
@@ -140,7 +140,7 @@ public class AWSRoute53RecordSetResourceAction extends StepBasedResourceAction {
           listHostedZonesByName.setDNSName(hostedZoneName);
           final ListHostedZonesByNameResponseType zoneListing =
               route53.listHostedZonesByName(listHostedZonesByName);
-          if (zoneListing.getHostedZones()!=null && zoneListing.getHostedZones().getMember().size()==1) {
+          if (zoneListing.getHostedZones()!=null && !zoneListing.getHostedZones().getMember().isEmpty()) {
             hostedZoneId = Strings.substringAfter("/hostedzone/",
                 zoneListing.getHostedZones().getMember().get(0).getId());
           } else {

--- a/clc/modules/route53/src/main/java/com/eucalyptus/route53/service/Route53Service.java
+++ b/clc/modules/route53/src/main/java/com/eucalyptus/route53/service/Route53Service.java
@@ -12,6 +12,7 @@ import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -541,7 +542,14 @@ public class Route53Service {
   }
 
   public GetChangeResponseType getChange(final GetChangeType request) {
-    return request.getReply();
+    final GetChangeResponseType reply = request.getReply();
+    final ChangeInfo changeInfo = new ChangeInfo();
+    changeInfo.setComment("");
+    changeInfo.setId(request.getId());
+    changeInfo.setStatus("INSYNC");
+    changeInfo.setSubmittedAt(new Date(System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(1)));
+    reply.setChangeInfo(changeInfo);
+    return reply;
   }
 
   public GetCheckerIpRangesResponseType getCheckerIpRanges(final GetCheckerIpRangesType request) {

--- a/clc/modules/route53/src/main/java/com/eucalyptus/route53/service/persist/entities/ResourceRecordSet.java
+++ b/clc/modules/route53/src/main/java/com/eucalyptus/route53/service/persist/entities/ResourceRecordSet.java
@@ -20,6 +20,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OrderColumn;
 import javax.persistence.PersistenceContext;
 import javax.persistence.Table;
+import org.xbill.DNS.Type;
 import com.eucalyptus.auth.principal.OwnerFullName;
 import com.eucalyptus.entities.AbstractOwnedPersistent;
 import com.eucalyptus.route53.service.dns.Route53DnsHelper;
@@ -41,6 +42,7 @@ public class ResourceRecordSet extends AbstractOwnedPersistent implements Resour
     CNAME(org.xbill.DNS.Type.CNAME),
     NS(org.xbill.DNS.Type.NS),
     SOA(org.xbill.DNS.Type.SOA),
+    TXT(org.xbill.DNS.Type.TXT)
     ;
 
     private final int code;


### PR DESCRIPTION
Route53 update to support `TXT` records and other changes needed for `certbot` such as the implementation of the `GetChange` action which will always return `INSYNC` as there is no delay applying changes in the current implementation.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=414
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/10/
Test: /job/eucalyptus-5-qa-fast/49/

Demo is that you can create and query `TXT` records:

```
# 
# cat route53-public-txt.yaml 
AWSTemplateFormatVersion: 2010-09-09

Resources:

  HostedZone:
    Type: AWS::Route53::HostedZone
    Properties:
      Name: example.com

  TXTRecordSet:
    Type: AWS::Route53::RecordSet
    DependsOn: HostedZone
    Properties:
      HostedZoneName: example.com
      Name: "txt.example.com"
      ResourceRecords:
      - '"textvaluehere"'
      TTL: 300
      Type: TXT
# 
# 
# euform-create-stack --template-file route53-public-txt.yaml r53-public-txt-1
arn:aws:cloudformation::000624961636:stack/r53-public-txt-1/951a7883-9fe7-45f8-ba7c-1419125c4876
# 
# 
# dig +short -t TXT txt.example.com @10.117.111.50
"textvaluehere"
# 
```