### PR TITLE
DNS nameserver suffix

### DIFF
--- a/clc/modules/core/src/main/java/com/eucalyptus/util/dns/DomainNames.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/util/dns/DomainNames.java
@@ -235,7 +235,7 @@ public class DomainNames {
             this.get( ),
             DClass.IN,
             60,
-            Name.fromConstantString( "ns" + offset + "." + this.get( ).toString( ) )
+            Name.fromConstantString( "ns" + offset._1() + "." + this.get( ).toString( ) )
         ) );
       }
       return nsRecs; 


### PR DESCRIPTION
The suffix generated for nameserver names is incorrect, resulting in invalid names being present in dns responses. This pull request corrects the suffix so it is a number (1, 2, 3, etc)

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=450
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/22/
Test: /job/eucalyptus-5-qa-fast/59/

Demo is that the nameserver names are now correct:

```
# 
# rpm -qa eucalyptus
eucalyptus-5.0.0-0.92.dnsnsname.el7.x86_64
# 
# 
# dig +short nc04-euca.appscale.net ns @192.168.111.14
ns1.nc04-euca.appscale.net.
# 
```