### PR TITLE
Public service urls should use preferred service name and public port

### DIFF
--- a/clc/modules/core/src/main/java/com/eucalyptus/component/ServiceUris.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/component/ServiceUris.java
@@ -236,6 +236,9 @@ public class ServiceUris {
       checkParam( this.path, notNullValue() );
       if ( this.scheme == null ) this.scheme = BasicTransport.HTTP;
       if ( this.port == null ) this.port = this.componentId.getPort( );
+      if ( this.componentId.isPublicService() && this.port.equals(StackConfiguration.INTERNAL_PORT) ) {
+        this.port = StackConfiguration.PORT;
+      }
       if ( this.internal ) this.path = this.componentId.getInternalServicePath( this.path );
       String schemeString = StackConfiguration.DEFAULT_HTTPS_ENABLED
         ? this.scheme.getSecureScheme( )

--- a/clc/modules/core/src/main/java/com/eucalyptus/component/ServiceUris.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/component/ServiceUris.java
@@ -241,7 +241,7 @@ public class ServiceUris {
         ? this.scheme.getSecureScheme( )
         : this.scheme.getScheme( );
       String hostNameString = this.componentId.isPublicService() ? (StackConfiguration.USE_DNS_DELEGATION
-        ? this.componentId.name( ) + "." + StackConfiguration.lookupDnsDomain( )
+        ? this.componentId.getServiceNames( ).stream( ).findFirst( ).orElse(this.componentId.name( )) + "." + StackConfiguration.lookupDnsDomain( )
         : this.address.getHostAddress( )) : this.address.getHostAddress();
       String pathString = this.componentId.isPublicService() ? (StackConfiguration.USE_DNS_DELEGATION
         ? "/" : "/" + this.path)


### PR DESCRIPTION
Public service urls now use the preferred name for the service (e.g. `ec2` not `compute`) and the configured web services port.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=456
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/23/
Test: /job/eucalyptus-5-qa-fast/60/

Demo is that the preferred name is now used in public urls:

```
# 
# rpm -qa eucalyptus
eucalyptus-5.0.0-0.93.puburls.el7.x86_64
# 
# 
# euca-describe-regions 
REGION	cloud-1	http://ec2.nc04-euca.appscale.net:8773/
# 
```