### PR TITLE
Async request mark write complete on success only

### DIFF
--- a/clc/modules/core/src/main/java/com/eucalyptus/util/async/AsyncRequestHandler.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/util/async/AsyncRequestHandler.java
@@ -144,7 +144,9 @@ public class AsyncRequestHandler<Q extends BaseMessage, R extends BaseMessage> e
                 channel.writeAndFlush( ioMessage ).addListener( new ChannelFutureListener( ) {
                   @Override
                   public void operationComplete( final ChannelFuture future ) throws Exception {
-                    AsyncRequestHandler.this.writeComplete.set( true );
+                    if (future.isSuccess()) {
+                      AsyncRequestHandler.this.writeComplete.set(true);
+                    }
                     
                     Logs.extreme( ).debug(
                       EventRecord.here(


### PR DESCRIPTION
To make issues easier to debug we should correctly track whether a message has been sent successfully.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=457
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/24/
Test: /job/eucalyptus-5-qa-fast/61/

The demo is that the tests pass as this change only impacts logging.