### PR TITLE
Key store error handling for unknown alias

### DIFF
--- a/clc/modules/core/src/main/java/com/eucalyptus/crypto/util/AbstractKeyStore.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/crypto/util/AbstractKeyStore.java
@@ -87,6 +87,9 @@ public abstract class AbstractKeyStore implements com.eucalyptus.crypto.KeyStore
   public KeyPair getKeyPair( final String alias, final String password ) throws GeneralSecurityException {
     final Certificate cert = this.keyStore.getCertificate( alias );
     final PrivateKey privateKey = ( PrivateKey ) this.keyStore.getKey( alias, password.toCharArray( ) );
+    if ( cert == null || privateKey == null ) {
+      throw new KeyStoreException("Key pair not found: " + alias);
+    }
     final KeyPair kp = new KeyPair( cert.getPublicKey( ), privateKey );
     return kp;
   }


### PR DESCRIPTION
Improve error handling for an invalid keystore alias.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=458
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/25/
Test: /job/eucalyptus-5-qa-fast/62/

Demo is that there is now a useful error logged when an invalid alias is configured:

```
# 
# rpm -qa eucalyptus
eucalyptus-5.0.0-0.95.keyalias.el7.x86_64
# 
# 
# euctl bootstrap.webservices.ssl.server_alias=invalid-alias
bootstrap.webservices.ssl.server_alias = invalid-alias
# 
```

Error log will show `/var/log/eucalyptus/cloud-error.log`:

```
Thu Sep 17 21:19:24 2020 ERROR [SslSetup:web-services-worker-pool-35] [com.eucalyptus.crypto.util.SslSetup$1.get(SslSetup.java):423] java.security.KeyStoreException: Key pair not found: inva
lid-alias
java.security.KeyStoreException: Key pair not found: invalid-alias
        at com.eucalyptus.crypto.util.AbstractKeyStore.getKeyPair(AbstractKeyStore.java:91)
        at com.eucalyptus.component.auth.SystemCredentials$EucaKeyStore.getKeyPair(SystemCredentials.java:385)
        at com.eucalyptus.crypto.util.SslSetup$1.get(SslSetup.java:419)
        at com.eucalyptus.crypto.util.SslSetup$1.get(SslSetup.java:414)
        ...
```