### PR TITLE
DNS handling for CAA and s3 TXT records

### DIFF
--- a/clc/modules/core/src/main/java/com/eucalyptus/util/dns/DnsResolvers.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/util/dns/DnsResolvers.java
@@ -144,6 +144,7 @@ public class DnsResolvers extends ServiceJarDiscovery {
     MAILB( 253 ),
     MAILA( 254 ),
     ANY( 255 ),
+    CAA( 257 ),
     DLV( 32769 );
     
     private static final Supplier<Map<Integer, RequestType>> backingMap = new Supplier( ) {

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageBucketResolver.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageBucketResolver.java
@@ -73,6 +73,9 @@ public class ObjectStorageBucketResolver extends DnsResolver {
       throw new NoSuchElementException( "Failed to lookup name: " + name );
     }
     if ( !RequestType.A.apply( query ) ) {
+      if ( RequestType.TXT.apply( query ) ) {
+        return null;
+      }
       return DnsResponse.forName( query.getName( ) ).answer( Collections.emptyList( ) );
     }
     try {


### PR DESCRIPTION
We now handle CAA queries without error and allow route53 handling of s3 TXT queries. Passing through the s3 TXT query allows for letsencrypt dns challenges.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=459
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/26/
Test: /job/eucalyptus-5-qa-fast/63/

Demo is that CAA queries no longer fail with an error:

```
#  dig s3.nc04-euca.appscale.net caa @192.168.111.14

; <<>> DiG 9.11.4-P2-RedHat-9.11.4-16.P2.el7_8.6 <<>> s3.nc04-euca.appscale.net caa @192.168.111.14
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 39251
;; flags: qr aa rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;s3.nc04-euca.appscale.net.	IN	CAA

;; Query time: 1 msec
;; SERVER: 192.168.111.14#53(192.168.111.14)
;; WHEN: Thu Sep 17 22:55:13 UTC 2020
;; MSG SIZE  rcvd: 54
```

Note the `NOERROR` status rather than `SERVFAIL`.