### PR TITLE
Route53 support for persistent change batch requests

### DIFF
--- a/clc/modules/route53/src/main/java/com/eucalyptus/route53/service/Route53Workflow.java
+++ b/clc/modules/route53/src/main/java/com/eucalyptus/route53/service/Route53Workflow.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2020 AppScale Systems, Inc
+ *
+ * Use of this source code is governed by a BSD-2-Clause
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/BSD-2-Clause
+ */
+package com.eucalyptus.route53.service;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import org.apache.log4j.Logger;
+import org.hibernate.criterion.Example;
+import org.hibernate.criterion.Restrictions;
+import com.eucalyptus.bootstrap.Bootstrap;
+import com.eucalyptus.component.Topology;
+import com.eucalyptus.component.id.Eucalyptus;
+import com.eucalyptus.compute.common.CloudMetadatas;
+import com.eucalyptus.entities.Entities;
+import com.eucalyptus.entities.TransactionResource;
+import com.eucalyptus.event.ClockTick;
+import com.eucalyptus.event.EventListener;
+import com.eucalyptus.event.Listeners;
+import com.eucalyptus.event.SystemClock;
+import com.eucalyptus.route53.common.Route53;
+import com.eucalyptus.route53.service.persist.ChangeInfos;
+import com.eucalyptus.route53.service.persist.Route53MetadataNotFoundException;
+import com.eucalyptus.route53.service.persist.entities.ChangeInfo;
+import com.eucalyptus.route53.service.persist.entities.ChangeInfo.Status;
+import com.eucalyptus.route53.service.persist.entities.PersistenceChangeInfos;
+import com.google.common.base.Functions;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+
+/**
+ *
+ */
+@SuppressWarnings("Guava")
+public class Route53Workflow {
+
+  private static final Logger logger = Logger.getLogger( Route53Workflow.class );
+
+  private final List<WorkflowTask> workflowTasks = ImmutableList.<WorkflowTask>builder()
+      .add( new WorkflowTask(  10, "Change.Completion" ) { @Override void doWork( ) throws Exception { changeCompletion( ); } } )
+      .add( new WorkflowTask( 300, "Change.Expiry"     ) { @Override void doWork( ) throws Exception { changeExpiry( ); } } )
+      .build( );
+
+  private final ChangeInfos changeInfos;
+
+  public Route53Workflow(
+      final ChangeInfos changeInfos
+  ) {
+    this.changeInfos = changeInfos;
+  }
+
+  private void doWorkflow( ) {
+    for ( final WorkflowTask workflowTask : workflowTasks ) {
+      try {
+        workflowTask.perhapsWork( );
+      } catch ( Exception e ) {
+        logger.error( e, e );
+      }
+    }
+  }
+
+  /**
+   * Update any changes that have been pending for the requisite interval
+   */
+  private void changeCompletion( ) {
+    List<String> pendingChanges = Collections.emptyList( );
+    try ( final TransactionResource tx = Entities.transactionFor( ChangeInfo.class ) ) {
+      pendingChanges = changeInfos.list(
+          null,
+          Restrictions.and(
+              Example.create( ChangeInfo.exampleWithState( Status.PENDING ) ),
+              Restrictions.lt( "lastUpdateTimestamp", new Date( System.currentTimeMillis( ) - ChangeInfos.PENDING_AGE ) )
+          ),
+          Collections.emptyMap( ),
+          Predicates.alwaysTrue( ),
+          CloudMetadatas.toDisplayName( )
+      );
+    } catch ( final Exception e ) {
+      logger.error( "Error listing pending changes", e );
+    }
+
+    for ( final String changeId : pendingChanges ) {
+      try ( final TransactionResource tx = Entities.transactionFor( ChangeInfo.class ) ) {
+        changeInfos.updateByExample(
+            ChangeInfo.exampleWithName(null, changeId),
+            null,
+            changeId,
+            changeInfo -> {
+              logger.info( "Updating pending change " + changeInfo.getDisplayName( ) + " with state " + changeInfo.getState( ) );
+              changeInfo.setState( Status.INSYNC );
+              return changeId;
+            } );
+        tx.commit( );
+      } catch ( final Route53MetadataNotFoundException e ) {
+        logger.info( "Route53 change " + changeId + " not found for state transition" );
+      } catch ( final Exception e ) {
+        logger.error( "Error updating pending change " + changeId, e );
+      }
+    }
+  }
+
+  /**
+   * Delete any changes that have expired
+   */
+  private void changeExpiry( ) {
+    List<String> expiredChanges = Collections.emptyList( );
+    try ( final TransactionResource tx = Entities.transactionFor( ChangeInfo.class ) ) {
+      expiredChanges = changeInfos.list(
+          null,
+          Restrictions.lt( "lastUpdateTimestamp", new Date( System.currentTimeMillis( ) - ChangeInfos.EXPIRY_AGE ) ),
+          Collections.emptyMap( ),
+          Predicates.alwaysTrue( ),
+          CloudMetadatas.toDisplayName( )
+      );
+    } catch ( final Exception e ) {
+      logger.error( "Error listing expired changes", e );
+    }
+
+    for ( final String changeId : expiredChanges ) {
+      try ( final TransactionResource tx = Entities.transactionFor( ChangeInfo.class ) ) {
+        final ChangeInfo changeInfo = changeInfos.lookupByName( null, changeId, Predicates.alwaysTrue(), Functions.identity( ) );
+        logger.info( "Deleting expired change " + changeInfo.getDisplayName( ) + " with state " + changeInfo.getState( ) );
+        changeInfos.delete( changeInfo );
+        tx.commit( );
+      } catch ( final Route53MetadataNotFoundException e ) {
+        logger.info( "Route53 change " + changeId + " not found for deletion" );
+      } catch ( final Exception e ) {
+        logger.error( "Error deleting expired change " + changeId, e );
+      }
+    }
+  }
+
+  private static abstract class WorkflowTask {
+    private volatile int count = 0;
+    private final int factor;
+    private final String task;
+
+    protected WorkflowTask( final int factor, final String task ) {
+      this.factor = factor;
+      this.task = task;
+    }
+
+    protected final int calcFactor() {
+      return factor / (int) Math.max( 1, SystemClock.RATE / 1000 );
+    }
+
+    protected final void perhapsWork() throws Exception {
+      if ( ++count % calcFactor() == 0 ) {
+        logger.trace( "Running route53 workflow task: " + task );
+        doWork();
+        logger.trace( "Completed route53 workflow task: " + task );
+      }
+    }
+
+    abstract void doWork( ) throws Exception;
+  }
+
+  public static class Route53WorkflowEventListener implements EventListener<ClockTick> {
+    private final Route53Workflow route53Workflow = new Route53Workflow(
+        new PersistenceChangeInfos( )
+    );
+
+    public static void register( ) {
+      Listeners.register( ClockTick.class, new Route53WorkflowEventListener() );
+    }
+
+    @Override
+    public void fireEvent( final ClockTick event ) {
+      if ( Bootstrap.isOperational( ) &&
+          Topology.isEnabledLocally( Eucalyptus.class ) &&
+          Topology.isEnabled( Route53.class ) ) {
+        route53Workflow.doWorkflow( );
+      }
+    }
+  }
+}

--- a/clc/modules/route53/src/main/java/com/eucalyptus/route53/service/dns/Route53DnsResolver.java
+++ b/clc/modules/route53/src/main/java/com/eucalyptus/route53/service/dns/Route53DnsResolver.java
@@ -165,7 +165,7 @@ public class Route53DnsResolver extends DnsResolvers.DnsResolver {
       final String lookupName,
       final HostedZoneComposite zoneAndRecords) {
     for (final ResourceRecordSetView rrSet : zoneAndRecords.getResourceRecordSets()) {
-      if (rrSet.getName().equals(lookupName) && matchType(rrSet.getType(), queryType)) {
+      if (rrSet.getName().equalsIgnoreCase(lookupName) && matchType(rrSet.getType(), queryType)) {
         return response(request, queryName, rrSet, zoneAndRecords);
       }
     }
@@ -187,7 +187,7 @@ public class Route53DnsResolver extends DnsResolvers.DnsResolver {
   public Set<String> getCandidateZoneNames(final Name name) {
     final Set<String> zoneNames = Sets.newHashSet();
     for (Name zoneName = name; zoneName.labels() > 1; zoneName = new Name(zoneName, 1)) {
-      zoneNames.add(zoneName.toString());
+      zoneNames.add(zoneName.toString().toLowerCase());
     }
     return zoneNames;
   }
@@ -344,7 +344,7 @@ public class Route53DnsResolver extends DnsResolvers.DnsResolver {
   ) {
     final String lookupName = name.toString();
     for (final ResourceRecordSetView rrSet : zoneAndRecords.getResourceRecordSets()) {
-      if (rrSet.getName().equals(lookupName) && rrSet.getType()==Type.NS) {
+      if (rrSet.getName().equalsIgnoreCase(lookupName) && rrSet.getType()==Type.NS) {
         return getNameserverRecordsAndAdditionals(request, name, rrSet,
             getMatchingRRSets(Type.A, rrSet.getValues(), zoneAndRecords.getResourceRecordSets()));
       }

--- a/clc/modules/route53/src/main/java/com/eucalyptus/route53/service/persist/ChangeInfos.java
+++ b/clc/modules/route53/src/main/java/com/eucalyptus/route53/service/persist/ChangeInfos.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 AppScale Systems, Inc
+ *
+ * Use of this source code is governed by a BSD-2-Clause
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/BSD-2-Clause
+ */
+package com.eucalyptus.route53.service.persist;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.hibernate.criterion.Criterion;
+import com.eucalyptus.auth.principal.OwnerFullName;
+import com.eucalyptus.entities.AbstractPersistentSupport;
+import com.eucalyptus.route53.common.Route53Metadata.ChangeMetadata;
+import com.eucalyptus.route53.service.persist.entities.ChangeInfo;
+import com.eucalyptus.util.Intervals;
+import com.eucalyptus.util.TypeMapper;
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+
+/**
+ *
+ */
+@SuppressWarnings("Guava")
+public interface ChangeInfos {
+
+  long EXPIRY_AGE = Intervals.parse(
+      System.getProperty("com.eucalyptus.route53.changeExpiry"),
+      TimeUnit.SECONDS,
+      TimeUnit.HOURS.toMillis(24));
+
+  long PENDING_AGE = Intervals.parse(
+      System.getProperty("com.eucalyptus.route53.syncDuration"),
+      TimeUnit.SECONDS,
+      TimeUnit.SECONDS.toMillis( 30 ));
+
+  <T> T lookupByName(final OwnerFullName ownerFullName,
+                     final String name,
+                     final Predicate<? super ChangeInfo> filter,
+                     final Function<? super ChangeInfo, T> transform) throws Route53MetadataException;
+
+  <T> List<T> list(OwnerFullName ownerFullName,
+                   Predicate<? super ChangeInfo> filter,
+                   Function<? super ChangeInfo, T> transform) throws Route53MetadataException;
+
+  <T> List<T> list( OwnerFullName ownerFullName,
+                    Criterion criterion,
+                    Map<String,String> aliases,
+                    Predicate<? super ChangeInfo> filter,
+                    Function<? super  ChangeInfo,T> transform ) throws Route53MetadataException;
+
+
+  <T> List<T> listByExample(ChangeInfo example,
+                            Predicate<? super ChangeInfo> filter,
+                            Function<? super ChangeInfo, T> transform) throws Route53MetadataException;
+
+  <T> T updateByExample(ChangeInfo example,
+                        OwnerFullName ownerFullName,
+                        String changeInfoId,
+                        Function<? super ChangeInfo, T> updateTransform) throws Route53MetadataException;
+
+
+  ChangeInfo save(ChangeInfo changeInfo) throws Route53MetadataException;
+
+  boolean delete( final ChangeMetadata metadata ) throws Route53MetadataException;
+
+  List<ChangeInfo> deleteByExample(ChangeInfo example) throws Route53MetadataException;
+
+  AbstractPersistentSupport<ChangeMetadata, ChangeInfo, Route53MetadataException> withRetries();
+
+  @TypeMapper
+  enum ChangeInfoTransform implements Function<ChangeInfo, com.eucalyptus.route53.common.msgs.ChangeInfo> {
+    INSTANCE;
+
+    @Override
+    public com.eucalyptus.route53.common.msgs.ChangeInfo apply(final ChangeInfo changeInfo) {
+      final com.eucalyptus.route53.common.msgs.ChangeInfo resultChangeInfo = new com.eucalyptus.route53.common.msgs.ChangeInfo();
+      resultChangeInfo.setId(changeInfo.getDisplayName());
+      resultChangeInfo.setStatus(changeInfo.getState().name());
+      resultChangeInfo.setComment(changeInfo.getComment());
+      resultChangeInfo.setSubmittedAt(changeInfo.getCreationTimestamp());
+      return resultChangeInfo;
+    }
+  }
+}

--- a/clc/modules/route53/src/main/java/com/eucalyptus/route53/service/persist/entities/ChangeInfo.java
+++ b/clc/modules/route53/src/main/java/com/eucalyptus/route53/service/persist/entities/ChangeInfo.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 AppScale Systems, Inc
+ *
+ * Use of this source code is governed by a BSD-2-Clause
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/BSD-2-Clause
+ */
+package com.eucalyptus.route53.service.persist.entities;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Table;
+import com.eucalyptus.auth.principal.FullName;
+import com.eucalyptus.auth.principal.OwnerFullName;
+import com.eucalyptus.component.ComponentIds;
+import com.eucalyptus.entities.UserMetadata;
+import com.eucalyptus.route53.common.Route53;
+import com.eucalyptus.route53.common.Route53Metadata.ChangeMetadata;
+import com.eucalyptus.route53.service.persist.entities.ChangeInfo.Status;
+import com.eucalyptus.route53.service.persist.views.ChangeInfoView;
+
+/**
+ *
+ */
+@Entity
+@PersistenceContext(name = "eucalyptus_route53")
+@Table(name = "r53_change")
+public class ChangeInfo extends UserMetadata<Status> implements ChangeMetadata, ChangeInfoView {
+
+  private static final long serialVersionUID = 1L;
+
+  public enum Status {
+    PENDING,
+    INSYNC,
+  }
+
+  @Column( name = "r53_change_comment", length = 256 )
+  private String comment;
+
+  protected ChangeInfo() {
+  }
+
+  protected ChangeInfo(final OwnerFullName owner, final String displayName) {
+    super(owner, displayName);
+  }
+
+  public static ChangeInfo create(
+      final OwnerFullName owner,
+      final String displayName,
+      final String comment
+  ) {
+    final ChangeInfo changeInfo = new ChangeInfo(owner, displayName);
+    changeInfo.setState(Status.PENDING);
+    changeInfo.setComment(comment);
+    return changeInfo;
+  }
+
+  public static ChangeInfo exampleWithOwner(final OwnerFullName owner) {
+    return new ChangeInfo(owner, null);
+  }
+
+  public static ChangeInfo exampleWithName(final OwnerFullName owner, final String name) {
+    return new ChangeInfo(owner, name);
+  }
+
+  public static ChangeInfo exampleWithState(final ChangeInfo.Status state) {
+    final ChangeInfo example = new ChangeInfo( );
+    example.setState( state );
+    example.setLastState( null );
+    example.setStateChangeStack( null );
+    return example;
+  }
+
+  @Override
+  public String getComment( ) {
+    return comment;
+  }
+
+  public void setComment(final String comment) {
+    this.comment = comment;
+  }
+
+  @Override
+  public String getPartition() {
+    return "eucalyptus";
+  }
+
+  @Override
+  public FullName getFullName() {
+    return FullName.create.vendor("euca")
+        .region(ComponentIds.lookup(Route53.class).name())
+        .namespace(this.getOwnerAccountNumber())
+        .relativeId("change", getDisplayName());
+  }
+}

--- a/clc/modules/route53/src/main/java/com/eucalyptus/route53/service/persist/entities/PersistenceChangeInfos.java
+++ b/clc/modules/route53/src/main/java/com/eucalyptus/route53/service/persist/entities/PersistenceChangeInfos.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 AppScale Systems, Inc
+ *
+ * Use of this source code is governed by a BSD-2-Clause
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/BSD-2-Clause
+ */
+package com.eucalyptus.route53.service.persist.entities;
+
+import com.eucalyptus.auth.principal.OwnerFullName;
+import com.eucalyptus.component.annotation.ComponentNamed;
+import com.eucalyptus.route53.common.Route53Metadata.ChangeMetadata;
+import com.eucalyptus.route53.service.persist.ChangeInfos;
+
+/**
+ *
+ */
+@ComponentNamed
+public class PersistenceChangeInfos extends Route53PersistenceSupport<ChangeMetadata, ChangeInfo> implements ChangeInfos {
+
+  public PersistenceChangeInfos() {
+    super("change");
+  }
+
+  @Override
+  protected ChangeInfo exampleWithOwner(final OwnerFullName ownerFullName) {
+    return ChangeInfo.exampleWithOwner(ownerFullName);
+  }
+
+  @Override
+  protected ChangeInfo exampleWithName(final OwnerFullName ownerFullName, final String name) {
+    return ChangeInfo.exampleWithName(ownerFullName, name);
+  }
+}

--- a/clc/modules/route53/src/main/java/com/eucalyptus/route53/service/persist/views/ChangeInfoView.java
+++ b/clc/modules/route53/src/main/java/com/eucalyptus/route53/service/persist/views/ChangeInfoView.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 AppScale Systems, Inc
+ *
+ * Use of this source code is governed by a BSD-2-Clause
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/BSD-2-Clause
+ */
+package com.eucalyptus.route53.service.persist.views;
+
+import java.util.Date;
+import javax.annotation.Nullable;
+import org.immutables.value.Value.Immutable;
+import com.eucalyptus.route53.service.persist.entities.ChangeInfo;
+
+/**
+ *
+ */
+@Immutable
+public interface ChangeInfoView {
+
+  /**
+   * Get the change info id
+   */
+  String getDisplayName();
+
+  String getOwnerAccountNumber();
+
+  ChangeInfo.Status getState();
+
+  @Nullable
+  String getComment();
+
+  Date getCreationTimestamp();
+}


### PR DESCRIPTION
Basic implementation for persistent change batch requests using a timer for the pending to insync transition. This allows a short delay while dns records propagate.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=469
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/28/
Test: /job/eucalyptus-5-qa-fast/65/

The demo is that the route53 test suite passes and that changes are present/expired as expected:

```
# psql -h /var/lib/eucalyptus/db/data/ -p 8777 eucalyptus_shared
psql (9.2.24)
Type "help" for help.

eucalyptus_shared=# select creation_timestamp,last_update_timestamp,metadata_unique_name,metadata_state,r53_change_comment from eucalyptus_route53.r53_change;
   creation_timestamp    |  last_update_timestamp  |    metadata_unique_name     | metadata_state |             r53_change_comment              
-------------------------+-------------------------+-----------------------------+----------------+---------------------------------------------
 2020-09-18 04:23:13.252 | 2020-09-18 04:23:51.479 | 000555805084:CAANIYUY4GJBUL | INSYNC         | 
 2020-09-18 04:23:17.729 | 2020-09-18 04:23:51.493 | 000555805084:CAAVPSVPIUKJ7R | INSYNC         | 
 2020-09-18 04:28:10.112 | 2020-09-18 04:28:41.484 | 000004542424:CAATJ4ADNGONML | INSYNC         | Change resource records comment here
 2020-09-18 04:28:08.356 | 2020-09-18 04:28:41.494 | 000017310255:CAAKVBJSXD3M53 | INSYNC         | Change resource records delete comment here
 2020-09-18 04:28:07.924 | 2020-09-18 04:28:41.511 | 000017310255:CAABVFHJ6QOQLI | INSYNC         | Change resource records comment here
 2020-09-18 04:28:10.167 | 2020-09-18 04:28:41.519 | 000004542424:CAA4O6NOW6YHK2 | INSYNC         | Change resource records comment here
 2020-09-18 04:28:08.272 | 2020-09-18 04:28:41.527 | 000017310255:CAA5SWFZGU4XWO | INSYNC         | Change resource records comment here
 2020-09-18 04:28:08.296 | 2020-09-18 04:28:41.535 | 000017310255:CAAHAO7ZQ2RQLS | INSYNC         | Change resource records comment here
 2020-09-18 04:28:08.32  | 2020-09-18 04:28:41.553 | 000017310255:CAACM2H3PJEHPG | INSYNC         | Change resource records upsert comment here
 2020-09-18 04:28:07.963 | 2020-09-18 04:28:41.569 | 000017310255:CAAYITX76TRPWR | INSYNC         | Change resource records delete comment here
 2020-09-18 04:28:10.14  | 2020-09-18 04:28:41.586 | 000004542424:CAAK7A66GBU2HO | INSYNC         | Change resource records comment here
(11 rows)

```