### PR TITLE
ELB check for conflicts when creating system subnets

### DIFF
--- a/clc/modules/core/src/main/java/com/eucalyptus/util/Cidr.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/util/Cidr.java
@@ -159,12 +159,16 @@ public class Cidr implements Predicate<InetAddress> {
     return ( cidr.ip & prefixMask( prefix ) ) == this.ip && cidr.prefix >= this.prefix;
   }
 
-  public Predicate<Cidr> contains( ) {
+  public CompatPredicate<Cidr> contains( ) {
     return cidr -> contains( cidr );
   }
 
-  public Predicate<Cidr> containedBy( ) {
+  public CompatPredicate<Cidr> containedBy( ) {
     return cidr -> cidr.contains( this );
+  }
+
+  public CompatPredicate<Cidr> conflicts( ) {
+    return CompatPredicate.of(contains().or(containedBy()));
   }
 
   public Iterable<Cidr> split( final int parts ) {

--- a/clc/modules/core/src/main/java/com/eucalyptus/util/CompatPredicate.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/util/CompatPredicate.java
@@ -35,6 +35,17 @@ import java.util.function.Predicate;
  */
 public interface CompatPredicate<T> extends Predicate<T>, com.google.common.base.Predicate<T> {
 
+  static <T> CompatPredicate<T> of( final Predicate<T> pred ) {
+    //noinspection TrivialMethodReference
+    return pred::test;
+  }
+
+  @SuppressWarnings( "Guava" )
+  static <F, T> CompatPredicate<T> of( final com.google.common.base.Predicate<T> pred ) {
+    //noinspection TrivialMethodReference
+    return pred::apply;
+  }
+
   @Override
   default boolean test( T t ) {
     return apply( t );


### PR DESCRIPTION
The load balancing service now checks for conflicts with any existing subnets in the vpc when creating system subnets.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=478
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/33/
Test: /job/eucalyptus-5-qa-fast/67/

Demo is that elb system public/private subnets are now created using the "first" available subnet cidr blocks:

```
# 
# rpm -q eucalyptus
eucalyptus-5.0.0-0.102.elbsyssub.el7.x86
# 
# 
# eval $(clcadmin-impersonate-user -a '(eucalyptus)loadbalancing')
# 
# 
# euca-describe-subnets 
SUBNET	subnet-e3064a9355349379a	available	vpc-24d75a8e0ebeaa336	10.254.16.0/20	4091	cloud-1a	false	false
SUBNET	subnet-f49aaa8a381f197a4	available	vpc-fea88d994e5b41f99	172.16.0.0/24	250	cloud-1a	false	false
SUBNET	subnet-990b0443958cab61d	available	vpc-24d75a8e0ebeaa336	10.254.0.0/24	250	cloud-1a	false	false
SUBNET	subnet-06499133a84df1be0	available	vpc-fea88d994e5b41f99	172.16.16.0/20	4091	cloud-1a	false	false
# 
```