### PR TITLE
EC2 : Support for Elastic IP address recovery

### DIFF
--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/AllocateAddressType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/AllocateAddressType.java
@@ -31,7 +31,17 @@ package com.eucalyptus.compute.common;
 
 public class AllocateAddressType extends VmAddressMessage {
 
+  private String address;
+
   private String domain;
+
+  public String getAddress( ) {
+    return address;
+  }
+
+  public void setAddress( String address ) {
+    this.address = address;
+  }
 
   public String getDomain( ) {
     return domain;

--- a/clc/modules/compute-common-msgs/src/main/resources/ec2-2016-11-15-binding.xml
+++ b/clc/modules/compute-common-msgs/src/main/resources/ec2-2016-11-15-binding.xml
@@ -36,7 +36,7 @@
   <include path="classpath:ec2-image-attr.xml" />
   <include path="classpath:ec2-import-13-10-15.xml" />
   <include path="classpath:ec2-export-12-05-01.xml" />
-  <include path="classpath:ec2-ips-15-04-15.xml" />
+  <include path="classpath:ec2-ips-16-11-15.xml" />
   <include path="classpath:ec2-keypairs-10-08-31.xml" />
   <include path="classpath:ec2-security-16-11-15.xml" />
   <include path="classpath:ec2-zones-10-08-31.xml" />

--- a/clc/modules/compute-common-msgs/src/main/resources/ec2-ips-16-11-15.xml
+++ b/clc/modules/compute-common-msgs/src/main/resources/ec2-ips-16-11-15.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2020 AppScale Systems, Inc
+
+  Use of this source code is governed by a BSD-2-Clause
+  license that can be found in the LICENSE file or at
+  https://opensource.org/licenses/BSD-2-Clause
+-->
+<binding>
+  <!--2008-02-01-->
+  <mapping name="AllocateAddress" class="com.eucalyptus.compute.common.AllocateAddressType" extends="com.eucalyptus.compute.common.ComputeMessage">
+    <structure map-as="com.eucalyptus.compute.common.ComputeMessage" />
+    <value name="address" field="address" usage="optional"/>
+    <value name="domain" field="domain" usage="optional"/>
+  </mapping>
+  <!--2008-02-01-->
+  <mapping name="AllocateAddressResponse" class="com.eucalyptus.compute.common.AllocateAddressResponseType" extends="com.eucalyptus.compute.common.ComputeMessage">
+    <structure map-as="com.eucalyptus.compute.common.ComputeMessage" />
+    <value name="publicIp" field="publicIp" />
+    <value name="domain" field="domain" />
+    <value name="allocationId" field="allocationId" usage="optional" />
+  </mapping>
+  <!--2008-02-01-->
+  <mapping name="ReleaseAddress" class="com.eucalyptus.compute.common.ReleaseAddressType" extends="com.eucalyptus.compute.common.ComputeMessage">
+    <structure map-as="com.eucalyptus.compute.common.ComputeMessage" />
+    <value name="publicIp" field="publicIp" usage="optional"/>
+    <value name="allocationId" field="allocationId" usage="optional"/>
+  </mapping>
+  <!--2008-02-01-->
+  <mapping name="ReleaseAddressResponse" class="com.eucalyptus.compute.common.ReleaseAddressResponseType" extends="com.eucalyptus.compute.common.ComputeMessage">
+    <structure map-as="com.eucalyptus.compute.common.ComputeMessage" />
+    <value name="return" get-method="get_return" set-method="set_return" />
+  </mapping>
+  <!--2008-02-01-->
+  <mapping name="DescribeAddresses" class="com.eucalyptus.compute.common.DescribeAddressesType" extends="com.eucalyptus.compute.common.ComputeMessage">
+    <structure map-as="com.eucalyptus.compute.common.ComputeMessage" />
+    <collection name="publicIpsSet" field="publicIpsSet" factory="org.jibx.runtime.Utility.arrayListFactory"
+                item-type="java.lang.String">
+      <structure name="item">
+        <value name="publicIp" />
+      </structure>
+    </collection>
+    <structure name="allocationIdsSet" usage="optional">
+      <collection field="allocationIds" factory="org.jibx.runtime.Utility.arrayListFactory" item-type="java.lang.String">
+        <structure name="item">
+          <value name="allocationId" />
+        </structure>
+      </collection>
+    </structure>
+    <structure name="filterSet" usage="optional">
+      <collection factory="org.jibx.runtime.Utility.arrayListFactory" field="filterSet">
+        <structure name="item" map-as="com.eucalyptus.compute.common.Filter" />
+      </collection>
+    </structure>
+  </mapping>
+  <!--2008-02-01-->
+  <mapping name="DescribeAddressesResponse" class="com.eucalyptus.compute.common.DescribeAddressesResponseType"
+           extends="com.eucalyptus.compute.common.ComputeMessage">
+    <structure map-as="com.eucalyptus.compute.common.ComputeMessage" />
+    <collection name="addressesSet" field="addressesSet" usage="required" factory="org.jibx.runtime.Utility.arrayListFactory">
+      <structure name="item" map-as="com.eucalyptus.compute.common.AddressInfoType" />
+    </collection>
+  </mapping>
+  <!--2008-02-01-->
+  <mapping name="AssociateAddress" class="com.eucalyptus.compute.common.AssociateAddressType" extends="com.eucalyptus.compute.common.ComputeMessage">
+    <structure map-as="com.eucalyptus.compute.common.ComputeMessage" />
+    <structure choice="true" ordered="false">
+      <value name="publicIp" field="publicIp" usage="optional"/>
+      <value name="allocationId" field="allocationId" usage="optional"/>
+    </structure>
+    <structure choice="true" ordered="false">
+      <value name="networkInterfaceId" field="networkInterfaceId" usage="optional"/>
+      <value name="instanceId" field="instanceId" usage="optional"/>
+    </structure>
+    <value name="privateIpAddress" field="privateIpAddress" usage="optional"/>
+    <value name="allowReassociation" field="allowReassociation" usage="optional"/>
+  </mapping>
+  <!--2008-02-01-->
+  <mapping name="AssociateAddressResponse" class="com.eucalyptus.compute.common.AssociateAddressResponseType"
+           extends="com.eucalyptus.compute.common.ComputeMessage">
+    <structure map-as="com.eucalyptus.compute.common.ComputeMessage" />
+    <value name="return" get-method="get_return" set-method="set_return" />
+    <value name="associationId" field="associationId" usage="optional"/>
+  </mapping>
+  <!--2008-02-01-->
+  <mapping name="DisassociateAddress" class="com.eucalyptus.compute.common.DisassociateAddressType" extends="com.eucalyptus.compute.common.ComputeMessage">
+    <structure map-as="com.eucalyptus.compute.common.ComputeMessage" />
+    <structure choice="true" ordered="false">
+      <value name="publicIp" field="publicIp" usage="optional"/>
+      <value name="associationId" field="associationId" usage="optional"/>
+    </structure>
+  </mapping>
+  <!--2008-02-01-->
+  <mapping name="DisassociateAddressResponse" class="com.eucalyptus.compute.common.DisassociateAddressResponseType"
+           extends="com.eucalyptus.compute.common.ComputeMessage">
+    <structure map-as="com.eucalyptus.compute.common.ComputeMessage" />
+    <value name="return" get-method="get_return" set-method="set_return" />
+  </mapping>
+  <mapping class="com.eucalyptus.compute.common.AddressInfoType" abstract="true">
+    <value name="publicIp" field="publicIp" />
+    <value name="allocationId" field="allocationId" usage="optional"/>
+    <value name="domain" field="domain" />
+    <value name="instanceId" field="instanceId" usage="optional" />
+    <value name="associationId" field="associationId" usage="optional" />
+    <value name="networkInterfaceId" field="networkInterfaceId" usage="optional" />
+    <value name="networkInterfaceOwnerId" field="networkInterfaceOwnerId" usage="optional" />
+    <value name="privateIpAddress" field="privateIpAddress" usage="optional" />
+    <structure name="tagSet" field="tagSet" usage="optional" type="com.eucalyptus.compute.common.ResourceTagSetType"/>
+  </mapping>
+  <!-- 2015-04-15 -->
+  <mapping name="DescribeMovingAddresses" class="com.eucalyptus.compute.common.DescribeMovingAddressesType"
+           extends="com.eucalyptus.compute.common.ComputeMessage">
+    <structure map-as="com.eucalyptus.compute.common.ComputeMessage" />
+    <structure name="filterSet" usage="optional">
+      <collection factory="org.jibx.runtime.Utility.arrayListFactory" field="filterSet">
+        <structure name="item" map-as="com.eucalyptus.compute.common.Filter" />
+      </collection>
+    </structure>
+    <collection name="publicIpsSet" field="publicIpsSet" factory="org.jibx.runtime.Utility.arrayListFactory"
+                item-type="java.lang.String">
+      <structure name="item">
+        <value name="publicIp" />
+      </structure>
+    </collection>
+    <value name="maxResults" field="maxResults" usage="optional"/>
+    <value name="nextToken" field="nextToken" usage="optional"/>
+  </mapping>
+  <mapping name="DescribeMovingAddressesResponse" class="com.eucalyptus.compute.common.DescribeMovingAddressesResponseType"
+           extends="com.eucalyptus.compute.common.ComputeMessage">
+    <structure map-as="com.eucalyptus.compute.common.ComputeMessage" />
+    <structure name="movingAddressStatusSet"/>
+  </mapping>
+  <mapping name="MoveAddressToVpc" class="com.eucalyptus.compute.common.MoveAddressToVpcType" extends="com.eucalyptus.compute.common.ComputeMessage">
+    <structure map-as="com.eucalyptus.compute.common.ComputeMessage" />
+    <value name="publicIp" field="publicIp" usage="optional"/>
+  </mapping>
+  <mapping name="MoveAddressToVpcResponse" class="com.eucalyptus.compute.common.MoveAddressToVpcResponseType"
+           extends="com.eucalyptus.compute.common.ComputeMessage">
+    <structure map-as="com.eucalyptus.compute.common.ComputeMessage" />
+  </mapping>
+  <mapping name="RestoreAddressToClassic" class="com.eucalyptus.compute.common.RestoreAddressToClassicType" extends="com.eucalyptus.compute.common.ComputeMessage">
+    <structure map-as="com.eucalyptus.compute.common.ComputeMessage" />
+    <value name="publicIp" field="publicIp" usage="optional"/>
+  </mapping>
+  <mapping name="RestoreAddressToClassicResponse" class="com.eucalyptus.compute.common.RestoreAddressToClassicResponseType"
+           extends="com.eucalyptus.compute.common.ComputeMessage">
+    <structure map-as="com.eucalyptus.compute.common.ComputeMessage" />
+  </mapping>
+</binding>


### PR DESCRIPTION
Add `address` parameter to `AllocateAddress` and filter available addresses accordingly on allocation.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=482
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/37/
Test: /job/eucalyptus-5-qa-fast/70/

The demo is that addresses can now be requested on allocation:

```
#
# rpm -q eucalyptus
eucalyptus-5.0.0-0.105.ec2ar2.el7.x86_64
#
#
# aws ec2 allocate-address 
eipalloc-7e4b18f383c4b14bb	vpc	192.168.134.184
#
#
# aws ec2 release-address --allocation-id eipalloc-7e4b18f383c4b14bb
#
#
# aws ec2 allocate-address --address 192.168.134.184
eipalloc-d2d51045b40e22cb8	vpc	192.168.134.184
#
#
# aws ec2 allocate-address --address 192.168.134.184

An error occurred (InvalidAddressID.NotFound) when calling the AllocateAddress operation: The requested IP address does not exist or is unavailable
#
```

Fixes corymbia/eucalyptus#211