### PR TITLE
Message processing query pipeline request decoding

### DIFF
--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/ws/CloudFormationCfnAuthenticationStage.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/ws/CloudFormationCfnAuthenticationStage.java
@@ -47,9 +47,4 @@ public class CloudFormationCfnAuthenticationStage implements UnrollableStage {
   public String getName( ) {
     return "cloudformation-cfn-authentication";
   }
-
-  @Override
-  public int compareTo( UnrollableStage o ) {
-    return this.getName( ).compareTo( o.getName( ) );
-  }
 }

--- a/clc/modules/core/src/main/java/com/eucalyptus/auth/login/HmacCredentials.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/auth/login/HmacCredentials.java
@@ -44,11 +44,13 @@ import static com.eucalyptus.auth.principal.AccessKeyCredential.SignatureVersion
 import static com.eucalyptus.auth.principal.TemporaryAccessKey.TemporaryKeyType;
 import static com.eucalyptus.ws.util.HmacUtils.headerLookup;
 import static com.eucalyptus.ws.util.HmacUtils.parameterLookup;
+import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import com.eucalyptus.auth.principal.AccessKeyCredential;
 import com.eucalyptus.crypto.Hmac;
@@ -64,7 +66,7 @@ public class HmacCredentials extends WrappedCredentials<String> {
   private final String servicePath;
   private final Map<String,List<String>> parameters;
   private final Map<String, List<String>> headers;
-  private final String body;
+  private final Supplier<ByteBuffer> body;
   private String headerHost;
   private String headerPort;
   private final String queryId;
@@ -78,7 +80,7 @@ public class HmacCredentials extends WrappedCredentials<String> {
                           final Map<String,List<String>> headers,
                           final String verb,
                           final String servicePath,
-                          final String body ) throws AuthenticationException {
+                          final Supplier<ByteBuffer> body ) throws AuthenticationException {
     super( correlationId, variant.getSignature( headerLookup(headers), parameterLookup( parameters ) ) );
     final Function<String,List<String>> headerLookup = headerLookup( headers );
     final Function<String,List<String>> parameterLookup = parameterLookup( parameters );
@@ -156,8 +158,8 @@ public class HmacCredentials extends WrappedCredentials<String> {
     return this.parameters;
   }
 
-  public String getBody() {
-    return body;
+  public ByteBuffer getBody() {
+    return body.get( );
   }
 
   public Map<String, List<String>> getHeaders() {

--- a/clc/modules/core/src/main/java/com/eucalyptus/ws/Handlers.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/ws/Handlers.java
@@ -53,6 +53,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 
 import com.eucalyptus.ws.handlers.InternalXmlBindingHandler;
+import com.eucalyptus.ws.handlers.QueryParameterHandler;
+import com.eucalyptus.ws.stages.QueryDecompressionStage;
+import com.eucalyptus.ws.stages.UnrollableStage;
 import com.google.common.base.*;
 import org.apache.log4j.Logger;
 import org.jboss.netty.buffer.ChannelBuffer;
@@ -112,6 +115,7 @@ public class Handlers {
   private static Logger                                      LOG                      = Logger.getLogger( Handlers.class );
   private static final ExecutionHandler                      pipelineExecutionHandler = new ExecutionHandler( new OrderedMemoryAwareThreadPoolExecutor( StackConfiguration.SERVER_POOL_MAX_THREADS, 0, 0, 30L, TimeUnit.SECONDS, Threads.threadFactory( "web-services-pipeline-%d" ) ) );
   private static final ExecutionHandler                      serviceExecutionHandler  = new ExecutionHandler( new OrderedMemoryAwareThreadPoolExecutor( StackConfiguration.SERVER_POOL_MAX_THREADS, 0, 0, 30L, TimeUnit.SECONDS, Threads.threadFactory( "web-services-exec-%d" ) ) );
+  private static final ChannelHandler                        queryParameterHandler    = new QueryParameterHandler( );
   private static final ChannelHandler                        queryTimestampHandler    = new QueryTimestampHandler( );
   private static final ChannelHandler                        soapMarshallingHandler   = new SoapMarshallingHandler( );
   private static final ChannelHandler                        internalWsSecHandler     = new InternalWsSecHandler( );
@@ -690,6 +694,20 @@ public class Handlers {
 
   public static ExecutionHandler serviceExecutionHandler( ) {
     return serviceExecutionHandler;
+  }
+
+  public static UnrollableStage optionalQueryDecompressionStage( ) {
+    return StackConfiguration.PIPELINE_ENABLE_QUERY_DECOMPRESS ?
+        newQueryDecompressionStage( ) :
+        UnrollableStage.empty( );
+  }
+
+  public static UnrollableStage newQueryDecompressionStage( ) {
+    return new QueryDecompressionStage();
+  }
+
+  public static ChannelHandler queryParameterHandler() {
+    return queryParameterHandler;
   }
 
   public static ChannelHandler queryTimestamphandler( ) {

--- a/clc/modules/core/src/main/java/com/eucalyptus/ws/StackConfiguration.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/ws/StackConfiguration.java
@@ -197,8 +197,11 @@ public class StackConfiguration extends AbstractPersistent {
 
   @ConfigurableField( description = "Maximum Query Pipeline http chunk size (bytes).",
                       initial = "307200")
-  public static Integer       PIPELINE_MAX_QUERY_REQUEST_SIZE    = 30 * 10 * 1024;
-  
+  public static Integer       PIPELINE_MAX_QUERY_REQUEST_SIZE   = 30 * 10 * 1024;
+
+  @ConfigurableField( description = "Enable Query Pipeline http request decompression.", initial = "true" )
+  public static Boolean       PIPELINE_ENABLE_QUERY_DECOMPRESS  = Boolean.TRUE;
+
   @ConfigurableField( description = "Maximum HTTP initial line size (bytes).", initial = "4096" )
   public static Integer       HTTP_MAX_INITIAL_LINE_BYTES       = 4 * 1024;
   

--- a/clc/modules/core/src/main/java/com/eucalyptus/ws/handlers/HmacHandler.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/ws/handlers/HmacHandler.java
@@ -41,10 +41,12 @@ package com.eucalyptus.ws.handlers;
 
 import com.eucalyptus.auth.principal.AccessKeyCredential;
 import static com.eucalyptus.auth.principal.TemporaryAccessKey.TemporaryKeyType;
+import java.nio.ByteBuffer;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 import javax.security.auth.Subject;
 import org.apache.log4j.Logger;
 import org.jboss.netty.channel.MessageEvent;
@@ -87,7 +89,7 @@ public class HmacHandler extends MessageStackHandler {
     if ( event.getMessage( ) instanceof MappingHttpRequest ) {
       final MappingHttpRequest httpRequest = ( MappingHttpRequest ) event.getMessage( );
       final Map<String,String> parameters = httpRequest.getParameters();
-      final String body = httpRequest.getContentAsString( );
+      final Supplier<ByteBuffer> body = () -> httpRequest.getContent().toByteBuffer();
       final Function<String,List<String>> headerLookup = SignatureHandlerUtils.headerLookup( httpRequest );
       final Function<String,List<String>> parameterLookup = SignatureHandlerUtils.parameterLookup( httpRequest );
       final HmacUtils.SignatureVariant variant = HmacUtils.detectSignatureVariant( headerLookup, parameterLookup );

--- a/clc/modules/core/src/main/java/com/eucalyptus/ws/handlers/QueryParameterHandler.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/ws/handlers/QueryParameterHandler.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 AppScale Systems, Inc
+ *
+ * Use of this source code is governed by a BSD-2-Clause
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/BSD-2-Clause
+ */
+package com.eucalyptus.ws.handlers;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.net.URLCodec;
+import org.jboss.netty.channel.ChannelHandler;
+import org.jboss.netty.channel.MessageEvent;
+import org.jboss.netty.handler.codec.http.HttpHeaders;
+import org.jboss.netty.handler.codec.http.HttpMethod;
+import com.eucalyptus.http.MappingHttpRequest;
+import com.google.common.collect.Sets;
+
+/**
+ *
+ */
+@ChannelHandler.Sharable
+public class QueryParameterHandler extends MessageStackHandler {
+
+  @Override
+  public void incomingMessage( final MessageEvent event ) throws Exception {
+    if ( event.getMessage( ) instanceof MappingHttpRequest) {
+      final MappingHttpRequest httpRequest = ( MappingHttpRequest ) event.getMessage( );
+      if ( httpRequest.getParameters().isEmpty() &&
+          httpRequest.getMethod( ).equals( HttpMethod.POST ) &&
+          ( !httpRequest.containsHeader(HttpHeaders.Names.CONTENT_ENCODING) ||
+              HttpHeaders.Values.IDENTITY.equals(httpRequest.getHeader(HttpHeaders.Names.CONTENT_ENCODING)) ) ) {
+        final Map<String, String> parameters = new HashMap<>( httpRequest.getParameters( ) );
+        final Set<String> nonQueryParameters = Sets.newHashSet( );
+        final String query = httpRequest.getContentAsString( true );
+        for ( String p : query.split( "&" ) ) {
+          String[] splitParam = p.split( "=", 2 );
+          String lhs = splitParam[ 0 ];
+          String rhs = splitParam.length == 2 ? splitParam[ 1 ] : null;
+          try {
+            if ( lhs != null ) lhs = new URLCodec( ).decode( lhs );
+          } catch ( DecoderException ignore ) {
+          }
+          try {
+            if ( rhs != null ) rhs = new URLCodec( ).decode( rhs );
+          } catch ( DecoderException ignore ) {
+          }
+          parameters.put( lhs, rhs );
+          nonQueryParameters.add( lhs );
+        }
+        httpRequest.getParameters( ).putAll( parameters );
+        httpRequest.addNonQueryParameterKeys( nonQueryParameters );
+      }
+    }
+  }
+}

--- a/clc/modules/core/src/main/java/com/eucalyptus/ws/stages/HmacUserAuthenticationStage.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/ws/stages/HmacUserAuthenticationStage.java
@@ -75,10 +75,4 @@ public class HmacUserAuthenticationStage implements UnrollableStage {
     pipeline.addLast( "hmac-v2-verify", new HmacHandler( allowedTemporaryCredentials, allowedSignatureVersions ) );
     pipeline.addLast( "timestamp-verify", new QueryTimestampHandler( ) );
   }
-
-  @Override
-  public int compareTo( UnrollableStage o ) {
-    return this.getName( ).compareTo( o.getName( ) );
-  }
-
 }

--- a/clc/modules/core/src/main/java/com/eucalyptus/ws/stages/NodeAuthenticationStage.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/ws/stages/NodeAuthenticationStage.java
@@ -36,11 +36,6 @@ import com.eucalyptus.ws.handlers.NodeWsSecHandler;
 public class NodeAuthenticationStage implements UnrollableStage {
 
 	@Override
-	public int compareTo(UnrollableStage o) {
-		return this.getName( ).compareTo( o.getName( ) );		
-	}
-
-	@Override
 	public void unrollStage(ChannelPipeline pipeline) {
 		pipeline.addLast( "node-soap-authentication", new NodeWsSecHandler( ) );
 	}

--- a/clc/modules/core/src/main/java/com/eucalyptus/ws/stages/QueryDecompressionStage.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/ws/stages/QueryDecompressionStage.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 AppScale Systems, Inc
+ *
+ * Use of this source code is governed by a BSD-2-Clause
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/BSD-2-Clause
+ */
+package com.eucalyptus.ws.stages;
+
+import org.jboss.netty.channel.ChannelPipeline;
+import org.jboss.netty.handler.codec.http.HttpContentDecompressor;
+import com.eucalyptus.ws.Handlers;
+
+/**
+ *
+ */
+public class QueryDecompressionStage implements UnrollableStage {
+
+  @Override
+  public void unrollStage( final ChannelPipeline pipeline ) {
+    pipeline.addLast( "decompressor", new HttpContentDecompressor( ) );
+    pipeline.addLast( "parameters-post", Handlers.queryParameterHandler( ) );
+  }
+
+  @Override
+  public String getName( ) {
+    return "query-decompression";
+  }
+}

--- a/clc/modules/core/src/main/java/com/eucalyptus/ws/stages/SoapUserAuthenticationStage.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/ws/stages/SoapUserAuthenticationStage.java
@@ -50,11 +50,6 @@ public class SoapUserAuthenticationStage implements UnrollableStage {
   }
 
   @Override
-  public int compareTo( UnrollableStage o ) {
-    return this.getName( ).compareTo( o.getName( ) );
-  }
-
-  @Override
   public String getName( ) {
     return "soap-user-authentication";
   }

--- a/clc/modules/core/src/main/java/com/eucalyptus/ws/stages/UnrollableStage.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/ws/stages/UnrollableStage.java
@@ -43,6 +43,31 @@ import org.jboss.netty.channel.ChannelPipeline;
 import com.eucalyptus.util.HasName;
 
 public interface UnrollableStage extends HasName<UnrollableStage> {
-  public void unrollStage( ChannelPipeline pipeline );
-  public String getName();    
+
+  void unrollStage( ChannelPipeline pipeline );
+
+  String getName( );
+
+  @Override
+  default int compareTo( final UnrollableStage o ) {
+    return this.getName( ).compareTo( o.getName( ) );
+  }
+
+  static UnrollableStage empty( ) {
+    return EmptyUnrollableStage.INSTANCE;
+  }
+
+  final class EmptyUnrollableStage implements UnrollableStage {
+     private static final EmptyUnrollableStage INSTANCE = new EmptyUnrollableStage();
+
+     private EmptyUnrollableStage( ) { }
+
+     @Override
+     public void unrollStage( final ChannelPipeline pipeline ) { }
+
+     @Override
+     public String getName( ) {
+       return "empty";
+     }
+  }
 }

--- a/clc/modules/core/src/test/java/com/eucalyptus/auth/login/HmacLoginModuleTest.java
+++ b/clc/modules/core/src/test/java/com/eucalyptus/auth/login/HmacLoginModuleTest.java
@@ -44,6 +44,9 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URLEncoder;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -51,6 +54,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -586,7 +590,7 @@ public class HmacLoginModuleTest {
               values -> Lists.transform(Lists.newArrayList(values), value -> Iterables.get(Splitter.on(":").limit(2).split(value), 1))),
           verb,
           Iterables.get(Splitter.on("?").limit(2).split(pathWithQuery), 0),
-          Iterables.get(Splitter.on("\n\n").limit(2).split(sreq), 1, "")
+          body( Iterables.get(Splitter.on("\n\n").limit(2).split(sreq), 1, "" ))
       );
       assertTrue("Authentication successful " + testName, hmacV4LoginModule().authenticate(creds));
     }
@@ -615,7 +619,7 @@ public class HmacLoginModuleTest {
             .build(),
         "POST",
         "/services/Euare/",
-        "Action=ListGroups&Version=2010-05-08"
+        body( "Action=ListGroups&Version=2010-05-08" )
     );
     assertTrue("Authentication successful", hmacV4LoginModule("ea9nMgw6353ANsJeylVkNIIzuCU0hz0xtErRbcj0").authenticate(creds));
   }
@@ -636,7 +640,7 @@ public class HmacLoginModuleTest {
             .build(),
         "GET",
         "/",
-        ""
+        body( "" )
     );
     assertTrue("Authentication successful", hmacV4LoginModule("vNhDy9ERZQP5WXCdmPR7ZbbzZwdlQXETeZ6wM64i").authenticate(creds));
   }
@@ -702,13 +706,17 @@ public class HmacLoginModuleTest {
         Collections.singletonMap( "host", Collections.singletonList(headerHost) ), 
         verb, 
         servicePath, 
-        "" );
+        body( "" ) );
 
     if ( signatureVersion == 1 || ( signatureVersion == 2 && !paramMap.containsKey( SecurityParameter.SignatureMethod.parameter() ) ) ) {
       creds.setSignatureMethod( hmacType );
     }
 
     return creds;
+  }
+
+  private Supplier<ByteBuffer> body( final String text ) {
+    return () -> StandardCharsets.UTF_8.encode( CharBuffer.wrap( text ) );
   }
 
   //TODO:MOCKING

--- a/clc/modules/euare/src/main/java/com/eucalyptus/auth/euare/identity/ws/IdentitySoapAuthenticationStage.java
+++ b/clc/modules/euare/src/main/java/com/eucalyptus/auth/euare/identity/ws/IdentitySoapAuthenticationStage.java
@@ -66,11 +66,6 @@ public class IdentitySoapAuthenticationStage implements UnrollableStage {
   }
 
   @Override
-  public int compareTo( UnrollableStage o ) {
-    return this.getName( ).compareTo( o.getName( ) );
-  }
-
-  @Override
   public String getName( ) {
     return "identity-soap-authentication";
   }

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageAuthenticationAggregatorStage.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageAuthenticationAggregatorStage.java
@@ -58,9 +58,4 @@ public class ObjectStorageAuthenticationAggregatorStage implements UnrollableSta
   public String getName() {
     return NAME;
   }
-
-  @Override
-  public int compareTo(UnrollableStage o) {
-    return getName().compareTo(o.getName());
-  }
 }

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageDELETEBindingStage.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageDELETEBindingStage.java
@@ -47,11 +47,6 @@ import com.eucalyptus.ws.stages.UnrollableStage;
 public class ObjectStorageDELETEBindingStage implements UnrollableStage {
 
   @Override
-  public int compareTo(UnrollableStage o) {
-    return this.getName().compareTo(o.getName());
-  }
-
-  @Override
   public String getName() {
     return "objectstorage-delete-binding";
   }

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageDELETEOutboundStage.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageDELETEOutboundStage.java
@@ -48,11 +48,6 @@ import com.eucalyptus.ws.stages.UnrollableStage;
 public class ObjectStorageDELETEOutboundStage implements UnrollableStage {
 
   @Override
-  public int compareTo(UnrollableStage o) {
-    return this.getName().compareTo(o.getName());
-  }
-
-  @Override
   public String getName() {
     return "objectstorage-delete-outbound";
   }

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageFormPOSTAggregatorStage.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageFormPOSTAggregatorStage.java
@@ -37,11 +37,6 @@ import com.eucalyptus.ws.stages.UnrollableStage;
 public class ObjectStorageFormPOSTAggregatorStage implements UnrollableStage {
 
   @Override
-  public int compareTo(UnrollableStage o) {
-    return this.getName().compareTo(o.getName());
-  }
-
-  @Override
   public String getName() {
     return "objectstorage-form-post-aggregator";
   }

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageFormPOSTBindingStage.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageFormPOSTBindingStage.java
@@ -47,11 +47,6 @@ import com.eucalyptus.ws.stages.UnrollableStage;
 public class ObjectStorageFormPOSTBindingStage implements UnrollableStage {
 
   @Override
-  public int compareTo(UnrollableStage o) {
-    return this.getName().compareTo(o.getName());
-  }
-
-  @Override
   public String getName() {
     return "objectstorage-post-binding";
   }

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageFormPOSTOutboundStage.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageFormPOSTOutboundStage.java
@@ -48,11 +48,6 @@ import com.eucalyptus.ws.stages.UnrollableStage;
 public class ObjectStorageFormPOSTOutboundStage implements UnrollableStage {
 
   @Override
-  public int compareTo(UnrollableStage o) {
-    return this.getName().compareTo(o.getName());
-  }
-
-  @Override
   public String getName() {
     return "objectstorage-post-outbound";
   }

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageFormPOSTUserAuthenticationStage.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageFormPOSTUserAuthenticationStage.java
@@ -46,10 +46,6 @@ import com.eucalyptus.objectstorage.pipeline.handlers.ObjectStorageFormPOSTAuthe
 import com.eucalyptus.ws.stages.UnrollableStage;
 
 public class ObjectStorageFormPOSTUserAuthenticationStage implements UnrollableStage {
-  @Override
-  public int compareTo(UnrollableStage o) {
-    return this.getName().compareTo(o.getName());
-  }
 
   @Override
   public String getName() {

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageGETBindingStage.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageGETBindingStage.java
@@ -47,11 +47,6 @@ import com.eucalyptus.ws.stages.UnrollableStage;
 public class ObjectStorageGETBindingStage implements UnrollableStage {
 
   @Override
-  public int compareTo(UnrollableStage o) {
-    return this.getName().compareTo(o.getName());
-  }
-
-  @Override
   public String getName() {
     return "objectstorage-get-binding";
   }

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageGETOutboundStage.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageGETOutboundStage.java
@@ -48,11 +48,6 @@ import com.eucalyptus.ws.stages.UnrollableStage;
 public class ObjectStorageGETOutboundStage implements UnrollableStage {
 
   @Override
-  public int compareTo(UnrollableStage o) {
-    return this.getName().compareTo(o.getName());
-  }
-
-  @Override
   public String getName() {
     return "objectstorage-get-outbound";
   }

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageHEADBindingStage.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageHEADBindingStage.java
@@ -47,11 +47,6 @@ import com.eucalyptus.ws.stages.UnrollableStage;
 public class ObjectStorageHEADBindingStage implements UnrollableStage {
 
   @Override
-  public int compareTo(UnrollableStage o) {
-    return this.getName().compareTo(o.getName());
-  }
-
-  @Override
   public String getName() {
     return "objectstorage-head-binding";
   }

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageHEADOutboundStage.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageHEADOutboundStage.java
@@ -48,11 +48,6 @@ import com.eucalyptus.ws.stages.UnrollableStage;
 public class ObjectStorageHEADOutboundStage implements UnrollableStage {
 
   @Override
-  public int compareTo(UnrollableStage o) {
-    return this.getName().compareTo(o.getName());
-  }
-
-  @Override
   public String getName() {
     return "objectstorage-head-outbound";
   }

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageMetadataAggregatorStage.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageMetadataAggregatorStage.java
@@ -58,9 +58,4 @@ public class ObjectStorageMetadataAggregatorStage implements UnrollableStage {
   public String getName() {
     return NAME;
   }
-
-  @Override
-  public int compareTo(UnrollableStage o) {
-    return this.getName().compareTo(o.getName());
-  }
 }

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageOPTIONSBindingStage.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageOPTIONSBindingStage.java
@@ -47,11 +47,6 @@ import com.eucalyptus.ws.stages.UnrollableStage;
 public class ObjectStorageOPTIONSBindingStage implements UnrollableStage {
 
   @Override
-  public int compareTo(UnrollableStage o) {
-    return this.getName().compareTo(o.getName());
-  }
-
-  @Override
   public String getName() {
     return "objectstorage-options-binding";
   }

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageOPTIONSOutboundStage.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageOPTIONSOutboundStage.java
@@ -48,11 +48,6 @@ import com.eucalyptus.ws.stages.UnrollableStage;
 public class ObjectStorageOPTIONSOutboundStage implements UnrollableStage {
 
   @Override
-  public int compareTo(UnrollableStage o) {
-    return this.getName().compareTo(o.getName());
-  }
-
-  @Override
   public String getName() {
     return "objectstorage-options-outbound";
   }

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStoragePUTAggregatorStage.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStoragePUTAggregatorStage.java
@@ -37,11 +37,6 @@ import com.eucalyptus.ws.stages.UnrollableStage;
 public class ObjectStoragePUTAggregatorStage implements UnrollableStage {
 
   @Override
-  public int compareTo(UnrollableStage o) {
-    return this.getName().compareTo(o.getName());
-  }
-
-  @Override
   public String getName() {
     return "objectstorage-put-aggregator";
   }

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStoragePUTBindingStage.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStoragePUTBindingStage.java
@@ -47,11 +47,6 @@ import com.eucalyptus.ws.stages.UnrollableStage;
 public class ObjectStoragePUTBindingStage implements UnrollableStage {
 
   @Override
-  public int compareTo(UnrollableStage o) {
-    return this.getName().compareTo(o.getName());
-  }
-
-  @Override
   public String getName() {
     return "objectstorage-put-binding";
   }

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStoragePUTOutboundStage.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStoragePUTOutboundStage.java
@@ -48,11 +48,6 @@ import com.eucalyptus.ws.stages.UnrollableStage;
 public class ObjectStoragePUTOutboundStage implements UnrollableStage {
 
   @Override
-  public int compareTo(UnrollableStage o) {
-    return this.getName().compareTo(o.getName());
-  }
-
-  @Override
   public String getName() {
     return "objectstorage-outbound";
   }

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageRESTExceptionStage.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageRESTExceptionStage.java
@@ -37,11 +37,6 @@ import com.eucalyptus.ws.stages.UnrollableStage;
 public class ObjectStorageRESTExceptionStage implements UnrollableStage {
 
   @Override
-  public int compareTo(UnrollableStage arg0) {
-    return this.getName().compareTo(arg0.getName());
-  }
-
-  @Override
   public void unrollStage(ChannelPipeline pipeline) {
     pipeline.addLast("osg-exception", new ObjectStorageRESTExceptionHandler());
   }

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageUserAuthenticationStage.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/stages/ObjectStorageUserAuthenticationStage.java
@@ -47,11 +47,6 @@ import com.eucalyptus.ws.stages.UnrollableStage;
 public class ObjectStorageUserAuthenticationStage implements UnrollableStage {
 
   @Override
-  public int compareTo(UnrollableStage o) {
-    return this.getName().compareTo(o.getName());
-  }
-
-  @Override
   public String getName() {
     return "objectstorage-user-authentication";
   }

--- a/clc/modules/simplequeue/src/main/java/com/eucalyptus/simplequeue/ws/SimpleQueueQueryPipeline.java
+++ b/clc/modules/simplequeue/src/main/java/com/eucalyptus/simplequeue/ws/SimpleQueueQueryPipeline.java
@@ -118,11 +118,6 @@ public class SimpleQueueQueryPipeline extends QueryPipeline {
     public String getName() {
       return "simplequeue-user-authentication";
     }
-
-    @Override
-    public int compareTo( UnrollableStage o ) {
-      return this.getName( ).compareTo( o.getName( ) );
-    }
   }
 
   public static class SimpleQueueAuthenticationHandler extends MessageStackHandler {

--- a/clc/modules/tokens/src/main/java/com/eucalyptus/tokens/ws/TokensQueryPipeline.java
+++ b/clc/modules/tokens/src/main/java/com/eucalyptus/tokens/ws/TokensQueryPipeline.java
@@ -117,11 +117,6 @@ public class TokensQueryPipeline extends QueryPipeline {
     public String getName() {
       return "tokens-user-authentication";
     }
-
-    @Override
-    public int compareTo( UnrollableStage o ) {
-      return this.getName( ).compareTo( o.getName( ) );
-    }
   }
 
   public static class TokensAuthenticationHandler extends MessageStackHandler {

--- a/clc/modules/walrus/src/main/java/com/eucalyptus/walrus/pipeline/stages/WalrusOutboundStage.java
+++ b/clc/modules/walrus/src/main/java/com/eucalyptus/walrus/pipeline/stages/WalrusOutboundStage.java
@@ -47,11 +47,6 @@ import com.eucalyptus.ws.stages.UnrollableStage;
 public class WalrusOutboundStage implements UnrollableStage {
 
   @Override
-  public int compareTo(UnrollableStage o) {
-    return this.getName().compareTo(o.getName());
-  }
-
-  @Override
   public String getName() {
     return "walrus-outbound";
   }

--- a/clc/modules/walrus/src/main/java/com/eucalyptus/walrus/pipeline/stages/WalrusRESTBindingStage.java
+++ b/clc/modules/walrus/src/main/java/com/eucalyptus/walrus/pipeline/stages/WalrusRESTBindingStage.java
@@ -47,11 +47,6 @@ import com.eucalyptus.ws.stages.UnrollableStage;
 public class WalrusRESTBindingStage implements UnrollableStage {
 
   @Override
-  public int compareTo(UnrollableStage o) {
-    return this.getName().compareTo(o.getName());
-  }
-
-  @Override
   public String getName() {
     return "walrus-rest-binding";
   }

--- a/clc/modules/walrus/src/main/java/com/eucalyptus/walrus/pipeline/stages/WalrusRESTExceptionStage.java
+++ b/clc/modules/walrus/src/main/java/com/eucalyptus/walrus/pipeline/stages/WalrusRESTExceptionStage.java
@@ -37,11 +37,6 @@ import com.eucalyptus.ws.stages.UnrollableStage;
 public class WalrusRESTExceptionStage implements UnrollableStage {
 
   @Override
-  public int compareTo(UnrollableStage arg0) {
-    return this.getName().compareTo(arg0.getName());
-  }
-
-  @Override
   public void unrollStage(ChannelPipeline pipeline) {
     pipeline.addLast("walrus-exception", new WalrusRESTExceptionHandler());
   }

--- a/clc/modules/walrus/src/main/java/com/eucalyptus/walrus/pipeline/stages/WalrusUserAuthenticationStage.java
+++ b/clc/modules/walrus/src/main/java/com/eucalyptus/walrus/pipeline/stages/WalrusUserAuthenticationStage.java
@@ -47,11 +47,6 @@ import com.eucalyptus.ws.stages.UnrollableStage;
 public class WalrusUserAuthenticationStage implements UnrollableStage {
 
   @Override
-  public int compareTo(UnrollableStage o) {
-    return this.getName().compareTo(o.getName());
-  }
-
-  @Override
   public String getName() {
     return "walrus-user-authentication";
   }


### PR DESCRIPTION
Support for aws query services using encoded http requests. Decompression uses `netty` functionality for handling http requests with a `content-encoding` of `gzip` or `deflate`. A new property (`bootstrap.webservices.pipeline_enable_query_decompress`) is added allowing this functionality to be disabled.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=498
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/45/
Test: /job/eucalyptus-5-qa-fast/76/

Demo is that the property is present:

```
# 
# rpm -q eucalyptus
eucalyptus-5.0.0-0.112.reqdec3.el7.x86_64
# 
# 
# euctl -s bootstrap.webservices.pipeline_enable_query_decompress
bootstrap.webservices.pipeline_enable_query_decompress = Enable Query Pipeline http request decompression.
# 
# 
# euctl -d bootstrap.webservices.pipeline_enable_query_decompress
bootstrap.webservices.pipeline_enable_query_decompress = true
# 
# 
# euctl bootstrap.webservices.pipeline_enable_query_decompress
bootstrap.webservices.pipeline_enable_query_decompress = true
# 
```

and that clients enabling request compression can be used with eucalyptus when decompression is enabled.