### PR TITLE
Cluster service clean metadata on stop/start of ebs instance

### DIFF
--- a/clc/modules/cluster/src/main/java/com/eucalyptus/cluster/service/node/ClusterNodes.java
+++ b/clc/modules/cluster/src/main/java/com/eucalyptus/cluster/service/node/ClusterNodes.java
@@ -42,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.inject.Inject;
+import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import com.eucalyptus.cluster.common.msgs.InstanceType;
 import com.eucalyptus.cluster.common.msgs.NcDescribeInstancesResponseType;
@@ -362,7 +363,8 @@ public class ClusterNodes {
               vm.destinationMigrateState( now, ClusterVmMigrationState.none().getState( ), null, null )
                   .forEach( update -> logger.info( "Destination migration state for " + vm.getId( ) + " updated (migrated) from/to " + update ) );
             } else {
-              logger.info( "Ignoring instance " + vm.getId( ) + " report from unexpected node " + node.getNode( ) );
+              logger.log( "Teardown".equals( nodeVm.getStateName( ) ) ? Level.DEBUG : Level.INFO,
+                  "Ignoring instance " + vm.getId( ) + " report from unexpected node " + node.getNode( ) );
               return vm;
             }
           }


### PR DESCRIPTION
When an ebs instance is stopped and started the cluster services metadata for the older (torndown) instance should be cleaned up. If the old metadata is not removed then the instance can be reported as torndown when it is running on a different node than originally launched on.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=521
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/49/
Test: /job/eucalyptus-5-qa-fast/79/

Demo is that the nephoria tests no longer fail due to this error:

> Exception: i-6c867963 instance went to state:stopping while starting 

when run against a deployment with multiple nodes in a cluster.