### PR TITLE
Membership configuration for diagnostics (JGroups)

### DIFF
--- a/clc/modules/core/conf/scripts/setup_membership.groovy
+++ b/clc/modules/core/conf/scripts/setup_membership.groovy
@@ -86,6 +86,12 @@ String        gossipBindAddr             = Internets.localHostAddress( );
 Integer       tcpFailurePortBase         = 8779;
 Integer       tcpFailurePortRange        = 50
 /**
+ * Diagnostics
+ */
+Integer       diagnosticsPort            = 7500;
+Boolean       diagnosticsEnabled         = Boolean.valueOf( System.getProperty('euca.mcast.diagnostics.enable','true') );
+String        diagnosticsPasscode        = null;
+/**
  * General Transport thread configuration
  */
 Integer       threadPoolMaxThreads       = 25;
@@ -177,6 +183,9 @@ if ( !BootstrapArgs.parseBootstrapHosts( ).isEmpty( ) ) {
 
 TP transport = transportSupplier()
 transport.setValue( "singleton_name", SystemIds.membershipUdpMcastTransportName( ) );
+transport.setValue( "enable_diagnostics", diagnosticsEnabled );
+transport.setValue( "diagnostics_passcode", diagnosticsPasscode );
+transport.setValue( "diagnostics_port", diagnosticsPort );
 //transport.setDefaultThreadPool( defaultThreads );
 transport.setDefaultThreadPoolThreadFactory( defaultThreads );
 //transport thread factories


### PR DESCRIPTION
Membership setup options to simplify configuration for the diagnostics handler. There is a new system property `euca.mcast.diagnostics.enable` that can be used to disable the diagnostics port via `eucalyptus.conf` / `CLOUD_OPTS`.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=524
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/53/
Test: /job/eucalyptus-5-qa-suite/182/

Demo is that the listen port is not in use when the diagnostics handler is disabled:

```
# 
# grep CLOUD_OPTS /etc/eucalyptus/eucalyptus.conf 
CLOUD_OPTS="-Denable.route53.tech.preview=true -Denable.sqs.tech.preview=true -Xmx2g  --bind-addr=10.117.111.18 -Deuca.mcast.diagnostics.enable=false"
# 
# 
# ss -nl | grep 7500
# 
# 
```