### PR TITLE
RPM packaging remove unused directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,6 @@ install: deploy
 	$(INSTALL) -d -m 0700 $(DESTDIR)$(vardir)/lib/eucalyptus/upgrade
 	$(INSTALL) -d -m 0700 $(DESTDIR)$(vardir)/lib/eucalyptus/volumes
 	$(INSTALL) -d -m 0700 $(DESTDIR)$(vardir)/lib/eucalyptus/webapps
-	touch $(DESTDIR)$(vardir)/lib/eucalyptus/services
 	$(INSTALL) -d -m 0755 $(DESTDIR)$(vardir)/run/eucalyptus/net
 	$(INSTALL) -d -m 0750 $(DESTDIR)$(vardir)/run/eucalyptus/status
 	@$(INSTALL) -d $(DESTDIR)$(vardir)/log/eucalyptus -m 750

--- a/clc/Makefile
+++ b/clc/Makefile
@@ -178,7 +178,6 @@ deploy: install
 uninstall:
 	$(RM) -rf $(DESTDIR)$(etcdir)/eucalyptus/cloud.d
 	$(RM) -rf $(DESTDIR)$(datarootdir)/eucalyptus/*jar
-	$(RM) -rf $(DESTDIR)$(vardir)/eucalyptus/webapps
 
 # cleaning up after run-test currently requires a few iterations of:
 #   dmsetup table | cut -d':' -f 1 | sort | uniq | xargs -L 1 dmsetup remove ; losetup -a | cut -d':' -f 1 | xargs -L 1 losetup -d; losetup -a

--- a/clc/build.xml
+++ b/clc/build.xml
@@ -171,7 +171,6 @@
 		<mkdir dir="${DESTDIR}${euca.var.dir}/keys" />
 		<mkdir dir="${DESTDIR}${euca.log.dir}" />
 		<chmod dir="${DESTDIR}${euca.log.dir}" perm="0750" />
-		<mkdir dir="${DESTDIR}${euca.var.dir}/webapps" />
 		<mkdir dir="${DESTDIR}${euca.var.dir}/modules" />
 		<mkdir dir="${DESTDIR}${euca.run.dir}" />
 		<call-module-target target="install"/>

--- a/rpm/eucalyptus.spec
+++ b/rpm/eucalyptus.spec
@@ -540,8 +540,6 @@ cp -Rp admin-tools/conf/* $RPM_BUILD_ROOT/%{_sysconfdir}/eucalyptus-admin
 /etc/eucalyptus/cloud.d/scripts/
 %{_libexecdir}/eucalyptus/euca-upgrade
 /usr/sbin/eucalyptus-cloud
-%ghost /var/lib/eucalyptus/services
-%attr(-,eucalyptus,eucalyptus) /var/lib/eucalyptus/webapps/
 %{_sysctldir}/70-eucalyptus-cloud.conf
 %{_unitdir}/eucalyptus-cloud.service
 %{_unitdir}/eucalyptus-cloud-upgrade.service
@@ -717,6 +715,9 @@ usermod -a -G libvirt eucalyptus || :
 
 
 %changelog
+* Fri Oct  9 2020 Steve Jones <steve.jones@appscale.com> - 5.0
+- Remove packaging for no longer used directories
+
 * Wed Mar 27 2019 Steve Jones <steve.jones@appscale.com> - 5.0
 - Update requires for eucalyptus java deps and selinux packages
 


### PR DESCRIPTION
Remove empty `/var/lib/eucalyptus/webapps` directory and packaging for `/var/lib/eucalyptus/services`.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=529
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/56/
Test: /job/eucalyptus-5-qa-fast/83/

Demo is that directories are not present:

```
# 
# rpm -q eucalyptus
eucalyptus-5.0.0-0.121.rpmdirs2.el7.x86_64
# 
# 
# ls -1 /var/lib/eucalyptus/
backups
bukkits
db
keys
queue
templates
upgrade
volumes
# 
# 
```