### PR TITLE
EC2 image identifers use ami/aki/ari by default

### DIFF
--- a/clc/modules/compute-backend/src/main/java/com/eucalyptus/cloud/run/Allocations.java
+++ b/clc/modules/compute-backend/src/main/java/com/eucalyptus/cloud/run/Allocations.java
@@ -468,8 +468,8 @@ public class Allocations {
     public void setRootDirective() {
       if ( ! bootSet.isBlockStorage( ) ) {
         try {
-          final MachineImageInfo emi = LookupMachine.INSTANCE.apply( this.getRequest( ).getImageId());
-          rootDirective = emi.getRootDirective();
+          final MachineImageInfo mi = LookupMachine.INSTANCE.apply( this.getRequest( ).getImageId());
+          rootDirective = mi.getRootDirective();
         } catch (Exception ex) {}
       }
     }

--- a/clc/modules/compute-backend/src/main/java/com/eucalyptus/images/UnavailableImageInfo.java
+++ b/clc/modules/compute-backend/src/main/java/com/eucalyptus/images/UnavailableImageInfo.java
@@ -74,7 +74,7 @@ class UnavailableImageInfo implements BootableImageInfo {
 
   @Override
   public String getDisplayName() {
-    return ResourceIdentifiers.tryNormalize( ).apply( "emi-00000000" );
+    return ResourceIdentifiers.tryNormalize( ).apply( "ami-00000000" );
   }
 
   @Override

--- a/clc/modules/compute-backend/src/main/java/com/eucalyptus/vm/VmInstanceMetadata.java
+++ b/clc/modules/compute-backend/src/main/java/com/eucalyptus/vm/VmInstanceMetadata.java
@@ -327,8 +327,7 @@ public class VmInstanceMetadata {
       // Iterate through the list of volume attachments and populate ebs mappings
       for (VmVolumeAttachment attachment : volAttachments ) {
         if (attachment.getIsRootDevice()) {
-          m.put( "block-device-mapping/ami", attachment.getShortDeviceName() );
-          m.put( "block-device-mapping/emi", attachment.getShortDeviceName() );
+          m.put( "block-device-mapping/" + VmInstances.getEbsRootDeviceName( ), attachment.getShortDeviceName() );
           m.put( "block-device-mapping/root", attachment.getDevice() );
         }
         // add only volumes added at start up time and don't list root see EUCA-8636
@@ -349,8 +348,7 @@ public class VmInstanceMetadata {
     } else if (vm.getBootRecord().getMachine() instanceof MachineImageInfo) {
       MachineImageInfo mii = (MachineImageInfo) vm.getBootRecord().getMachine();
       String s = mii.getRootDeviceName();
-      m.put( "block-device-mapping/emi", mii.getShortRootDeviceName() );
-      m.put( "block-device-mapping/ami", mii.getShortRootDeviceName() );
+      m.put( "block-device-mapping/" + VmInstances.getEbsRootDeviceName(), mii.getShortRootDeviceName() );
       m.put( "block-device-mapping/root", s );
       if ( ImageManager.isPathAPartition( s )) {
         m.put( "block-device-mapping/ephemeral0", "sda2" );

--- a/clc/modules/compute-backend/src/main/java/com/eucalyptus/vm/VmInstances.java
+++ b/clc/modules/compute-backend/src/main/java/com/eucalyptus/vm/VmInstances.java
@@ -555,9 +555,9 @@ public class VmInstances extends com.eucalyptus.compute.common.internal.vm.VmIns
   public static Integer   EBS_VOLUME_CREATION_TIMEOUT   = 30;
 
   @ConfigurableField( description = "Name for root block device mapping",
-                      initial = "emi",
+                      initial = "ami",
                       changeListener = EbsRootDeviceChangeListener.class )
-  public static volatile String EBS_ROOT_DEVICE_NAME    = "emi";
+  public static volatile String EBS_ROOT_DEVICE_NAME    = "ami";
 
   @ConfigurableField( description = "Amount of time (in seconds) to let instance state settle after a transition to either stopping or shutting-down.",
                       initial = "40" )
@@ -623,7 +623,7 @@ public class VmInstances extends com.eucalyptus.compute.common.internal.vm.VmIns
       if ( newValue != null && !"[a-zA-Z0-9]{1,128}".matches( String.valueOf( newValue ) ) ) {
         throw new ConfigurablePropertyException( "Invalid ebs root device name: " + newValue );
       }
-      ebsRootDeviceName.set( String.valueOf( MoreObjects.firstNonNull( newValue, MoreObjects.firstNonNull( EBS_ROOT_DEVICE_NAME, "emi" ) ) ) );
+      ebsRootDeviceName.set( String.valueOf( MoreObjects.firstNonNull( newValue, MoreObjects.firstNonNull( EBS_ROOT_DEVICE_NAME, "ami" ) ) ) );
     }
   }
 

--- a/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/ImageMetadata.java
+++ b/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/ImageMetadata.java
@@ -46,7 +46,7 @@ import com.eucalyptus.util.CompatFunction;
 import com.eucalyptus.util.CompatPredicate;
 
 @PolicyResourceType( "image" )
-@CloudMetadataLongIdentifierConfigurable( prefix = "emi", relatedPrefixes = {"eki", "eri", "ami", "aki", "ari"})
+@CloudMetadataLongIdentifierConfigurable( prefix = "ami", relatedPrefixes = {"aki", "ari", "emi", "eki", "eri" })
 public interface ImageMetadata extends CloudMetadata {
   
   String TYPE_MANIFEST_XPATH = "/manifest/image/type/text()";
@@ -58,7 +58,7 @@ public interface ImageMetadata extends CloudMetadata {
        */
       @Override
       public String getTypePrefix( ) {
-        return "emi";
+        return "ami";
       }
       
       @Override
@@ -72,7 +72,7 @@ public interface ImageMetadata extends CloudMetadata {
        */
       @Override
       public String getTypePrefix( ) {
-        return "eki";
+        return "aki";
       }
       
       @Override
@@ -91,7 +91,7 @@ public interface ImageMetadata extends CloudMetadata {
        */
       @Override
       public String getTypePrefix( ) {
-        return "eri";
+        return "ari";
       }
       
       @Override

--- a/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/identifier/ExiResourceIdentifierCanonicalizer.java
+++ b/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/identifier/ExiResourceIdentifierCanonicalizer.java
@@ -1,0 +1,32 @@
+package com.eucalyptus.compute.common.internal.identifier;
+
+import java.util.Map;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Canonicalizer for A?I -> E?I conversions.
+ */
+public class ExiResourceIdentifierCanonicalizer implements ResourceIdentifierCanonicalizer {
+
+  private static final Map<String,String> prefixMap = ImmutableMap.of(
+      "aki", "eki",
+      "ami", "emi",
+      "ari", "eri"
+  );
+
+  @Override
+  public String getName() {
+    return "exi";
+  }
+
+  @Override
+  public String canonicalizePrefix( final String prefix ) {
+    return MoreObjects.firstNonNull( prefixMap.get( prefix ), prefix );
+  }
+
+  @Override
+  public String canonicalizeHex( final String hex ) {
+    return hex;
+  }
+}

--- a/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/vm/VmBootRecord.java
+++ b/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/vm/VmBootRecord.java
@@ -249,7 +249,7 @@ public class VmBootRecord {
 
   @Nonnull
   public String getDisplayMachineImageId( ) {
-    return displayName( machineImageId, machineImage, ResourceIdentifiers.tryNormalize().apply( "emi-00000000" ) );
+    return displayName( machineImageId, machineImage, ResourceIdentifiers.tryNormalize().apply( "ami-00000000" ) );
   }
 
   @Nullable

--- a/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/vm/VmInstances.java
+++ b/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/vm/VmInstances.java
@@ -77,7 +77,7 @@ public class VmInstances {
   private static final Logger LOG = Logger.getLogger( VmInstances.class );
 
 
-  protected static final AtomicReference<String> ebsRootDeviceName = new AtomicReference<String>( "emi" );
+  protected static final AtomicReference<String> ebsRootDeviceName = new AtomicReference<String>( "ami" );
 
   public static String getEbsRootDeviceName( ) {
     return ebsRootDeviceName.get( );

--- a/clc/modules/core/src/main/java/com/eucalyptus/configurable/StaticDatabasePropertyEntry.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/configurable/StaticDatabasePropertyEntry.java
@@ -842,6 +842,7 @@ public class StaticDatabasePropertyEntry extends AbstractPersistent {
           "bootstrap.webservices.client_pool_max_mem_per_conn",
           "bootstrap.webservices.client_pool_timeout_millis",
           "bootstrap.webservices.client_pool_total_mem",
+          "bootstrap.webservices.default_eustore_url",
           "cloudformation.swf_client_config",
           "cloud.vmstate.network_metadata_refresh_time",
           "reporting.data_collection_enabled",
@@ -863,7 +864,9 @@ public class StaticDatabasePropertyEntry extends AbstractPersistent {
       ) );
 
       UpgradeUtils.updatePropertyValues( LOG, ImmutableList.of(
-          Tuple.of( "bootstrap.webservices.cluster_connect_timeout_millis", "2000", "3000" )
+          Tuple.of( "bootstrap.webservices.cluster_connect_timeout_millis", "2000", "3000" ),
+          Tuple.of( "cloud.identifier_canonicalizer", "lower", "lower,exi" ),
+          Tuple.of( "cloud.identifier_canonicalizer", "upper", "upper,exi" )
       ) );
 
       UpgradeUtils.createOrOverwriteProperties( LOG, ImmutableList.of(

--- a/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/LoadBalancingWorkerProperties.java
+++ b/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/LoadBalancingWorkerProperties.java
@@ -58,7 +58,7 @@ public class LoadBalancingWorkerProperties {
   private static Logger  LOG     = Logger.getLogger( LoadBalancingWorkerProperties.class );
 
   @ConfigurableField( displayName = "image", 
-      description = "EMI containing haproxy and the controller",
+      description = "Machine image containing haproxy and the controller",
       initial = "NULL", 
       readonly = false,
       type = ConfigurableFieldType.KEYVALUE,
@@ -176,7 +176,7 @@ public class LoadBalancingWorkerProperties {
             onPropertyChange((String)newValue, null, null, null);
         }
       } catch ( final Exception e ) {
-        throw new ConfigurablePropertyException("Could not change EMI ID due to: " + e.getMessage());
+        throw new ConfigurablePropertyException("Could not change image ID due to: " + e.getMessage());
       }
     }
   }
@@ -253,14 +253,14 @@ public class LoadBalancingWorkerProperties {
     }
   }
 
-  private static void onPropertyChange(final String emi, final String instanceType,
+  private static void onPropertyChange(final String machineImageIdentifier, final String instanceType,
       final String keyname, String initScript) throws EucalyptusCloudException{
     if (!( Bootstrap.isOperational()  && Topology.isEnabled( Compute.class ) ) )
       return;
-    if ((emi!=null && emi.length()>0) ||
+    if ((machineImageIdentifier!=null && machineImageIdentifier.length()>0) ||
         (instanceType!=null && instanceType.length()>0) ||
         (keyname!=null) || (initScript != null) ){
-      if(!LoadBalancingWorkflows.modifyServicePropertiesSync(emi, instanceType, 
+      if(!LoadBalancingWorkflows.modifyServicePropertiesSync(machineImageIdentifier, instanceType,
           keyname, initScript)) {
         throw new EucalyptusCloudException("Failed to modify properties. Check log files for error details");
       }

--- a/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/workflow/LoadBalancingActivities.java
+++ b/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/workflow/LoadBalancingActivities.java
@@ -144,9 +144,9 @@ public interface LoadBalancingActivities {
   /***** END ApplySecurityGroups activities ****/
   
   /***** ModifyProperties activities *****/
-  void modifyServicePropertiesValidateRequest(String emi, String instanceType,
+  void modifyServicePropertiesValidateRequest(String machineImageId, String instanceType,
       String keyname, String initScript) throws LoadBalancingActivityException;
-  void modifyServicePropertiesUpdateScalingGroup(String emi, String instanceType,
+  void modifyServicePropertiesUpdateScalingGroup(String machineImageId, String instanceType,
       String keyname, String initScript) throws LoadBalancingActivityException;
   
   /***** Activities for ELB VMs *****/

--- a/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/workflow/LoadBalancingWorkflows.java
+++ b/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/workflow/LoadBalancingWorkflows.java
@@ -324,11 +324,11 @@ public class LoadBalancingWorkflows {
     };
   }
   
-  public static Boolean modifyServicePropertiesSync(final String emi, final String instanceType,
+  public static Boolean modifyServicePropertiesSync(final String machineImageId, final String instanceType,
       final String keyname, final String initScript ) {
     final  Future<Boolean> task = 
         Threads.enqueue(LoadBalancing.class, LoadBalancingWorkflows.class,  
-            modifyServicePropertiesImpl( emi, instanceType, keyname, initScript ));
+            modifyServicePropertiesImpl( machineImageId, instanceType, keyname, initScript ));
     try{ 
       return task.get();
     }catch(final Exception ex) {
@@ -337,20 +337,20 @@ public class LoadBalancingWorkflows {
     }
   }
   
-  public static void modifyServicePropertiesAsync( final String emi, final String instanceType,
+  public static void modifyServicePropertiesAsync( final String machineImageId, final String instanceType,
       final String keyname, final String initScript ) {
     Threads.enqueue(LoadBalancing.class, LoadBalancingWorkflows.class,  
-        modifyServicePropertiesImpl( emi, instanceType, keyname, initScript ));
+        modifyServicePropertiesImpl( machineImageId, instanceType, keyname, initScript ));
   }
       
-  private static Callable<Boolean> modifyServicePropertiesImpl( final String emi, final String instanceType,
+  private static Callable<Boolean> modifyServicePropertiesImpl( final String machineImageId, final String instanceType,
       final String keyname, final String initScript ) {
     return new Callable<Boolean>() {
       @Override
       public Boolean call() throws Exception {
         final ModifyServicePropertiesWorkflowClientExternal workflow =
             WorkflowClients.getModifyServicePropertiesClient();
-        workflow.modifyServiceProperties(emi, instanceType, keyname, initScript);
+        workflow.modifyServiceProperties(machineImageId, instanceType, keyname, initScript);
         return waitFor(new Supplier<ElbWorkflowState>() {
           @Override
           public ElbWorkflowState get() {

--- a/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/workflow/ModifyServicePropertiesWorkflow.java
+++ b/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/workflow/ModifyServicePropertiesWorkflow.java
@@ -42,7 +42,7 @@ import com.amazonaws.services.simpleworkflow.flow.annotations.WorkflowRegistrati
 defaultTaskStartToCloseTimeoutSeconds = 60)
 public interface ModifyServicePropertiesWorkflow {
   @Execute(name = "ModifyServiceProperties", version = "1.0")
-  void modifyServiceProperties(String emi, String instanceType,
+  void modifyServiceProperties(String machineImageId, String instanceType,
       String keyname, String initScript);
   
   @GetState

--- a/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/workflow/ModifyServicePropertiesWorkflowImpl.java
+++ b/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/workflow/ModifyServicePropertiesWorkflowImpl.java
@@ -52,14 +52,14 @@ public class ModifyServicePropertiesWorkflowImpl
   TryCatchFinally task = null;
   
   @Override
-  public void modifyServiceProperties(final String emi, final String instanceType,
+  public void modifyServiceProperties(final String machineImageId, final String instanceType,
       final String keyname, final String initScript) {
     task = new TryCatchFinally() {
       @Override
       protected void doTry() throws Throwable {
         final Promise<Void> validator = 
-            client.modifyServicePropertiesValidateRequest(emi, instanceType, keyname, initScript);
-        client.modifyServicePropertiesUpdateScalingGroup(emi, instanceType, 
+            client.modifyServicePropertiesValidateRequest(machineImageId, instanceType, keyname, initScript);
+        client.modifyServicePropertiesUpdateScalingGroup(machineImageId, instanceType,
             keyname, initScript, validator);
       }
       


### PR DESCRIPTION
EC2 image identifiers are now ami/aki/ari by default rather than emi/eki/eri on upgrade a new identifier canonicalizer is enabled to translate to the old naming scheme.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=589
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/80/
Test: /job/eucalyptus-5-qa-fast/95/ (short) /job/eucalyptus-5-qa-suite/186/ (long)

Demo is that `ami` names are used:

```
# euca-describe-images ami-6a50ba8ce48a52d05
IMAGE	ami-6a50ba8ce48a52d05	centos-7-x86-64-genericcloud/centos-7-x86_64-genericcloud.manifest.xml	000262227258	available	public	x86_64	machine				instance-store	hvm
```