### PR TITLE
Upgrade set backwards compatible instance dns cloud properties

### DIFF
--- a/clc/modules/core/src/main/java/com/eucalyptus/configurable/StaticDatabasePropertyEntry.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/configurable/StaticDatabasePropertyEntry.java
@@ -875,7 +875,13 @@ public class StaticDatabasePropertyEntry extends AbstractPersistent {
                     "10" ),
           Tuple.of( "com.eucalyptus.loadbalancing.LoadBalancingServiceProperties.max_tags",
                     "services.loadbalancing.max_tags",
-                    "10" )
+                    "10" ),
+          Tuple.of( "com.eucalyptus.vm.VmInstances.instance_private_prefix",
+                    "cloud.vmstate.instance_private_prefix",
+                    "euca-" ),
+          Tuple.of( "com.eucalyptus.vm.VmInstances.instance_public_prefix",
+                    "cloud.vmstate.instance_public_prefix",
+                    "euca-" )
       ) );
 
       return true;


### PR DESCRIPTION
Upgrade should set backwards compatible (`euca-`) values for ec2 instance dns name prefix properties.

These properties are new so must be set for compatibility with the existing `cloud.vmstate.instance_subdomain` property.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=614
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/90/
Test: /job/eucalyptus-5-qa-fast/103/

This relates to corymbia/eucalyptus#222