### PR TITLE
EC2 instance type and instance-store disk handling

### DIFF
--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2InstanceTypeResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSEC2InstanceTypeResourceAction.java
@@ -46,6 +46,7 @@ public class AWSEC2InstanceTypeResourceAction extends StepBasedResourceAction {
         modifyInstanceType.setName(action.properties.getName());
         modifyInstanceType.setCpu(action.properties.getCpu());
         modifyInstanceType.setDisk(action.properties.getDisk());
+        modifyInstanceType.setDiskCount(action.properties.getDiskCount());
         modifyInstanceType.setEnabled(action.properties.getEnabled());
         modifyInstanceType.setMemory(action.properties.getMemory());
         modifyInstanceType.setNetworkInterfaces(action.properties.getNetworkInterfaces());
@@ -79,6 +80,7 @@ public class AWSEC2InstanceTypeResourceAction extends StepBasedResourceAction {
         modifyInstanceType.setName(newAction.properties.getName( ));
         modifyInstanceType.setCpu(newAction.properties.getCpu());
         modifyInstanceType.setDisk(newAction.properties.getDisk());
+        modifyInstanceType.setDiskCount(newAction.properties.getDiskCount());
         modifyInstanceType.setEnabled(newAction.properties.getEnabled());
         modifyInstanceType.setMemory(newAction.properties.getMemory());
         modifyInstanceType.setNetworkInterfaces(newAction.properties.getNetworkInterfaces());

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/AWSEC2InstanceTypeProperties.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/AWSEC2InstanceTypeProperties.java
@@ -23,6 +23,9 @@ public class AWSEC2InstanceTypeProperties implements ResourceProperties {
   private Integer disk;
 
   @Property
+  private Integer diskCount;
+
+  @Property
   private Integer memory;
 
   @Property
@@ -55,6 +58,14 @@ public class AWSEC2InstanceTypeProperties implements ResourceProperties {
     this.disk = disk;
   }
 
+  public Integer getDiskCount( ) {
+    return diskCount;
+  }
+
+  public void setDiskCount( final Integer diskCount ) {
+    this.diskCount = diskCount;
+  }
+
   public Integer getMemory( ) {
     return memory;
   }
@@ -85,6 +96,7 @@ public class AWSEC2InstanceTypeProperties implements ResourceProperties {
         .add( "name", name )
         .add( "cpu", cpu )
         .add( "disk", disk )
+        .add( "diskCount", diskCount )
         .add( "memory", memory )
         .add( "networkInterfaces", networkInterfaces )
         .add( "enabled", enabled )

--- a/clc/modules/cluster-common/src/main/java/com/eucalyptus/cluster/common/ResourceState.java
+++ b/clc/modules/cluster-common/src/main/java/com/eucalyptus/cluster/common/ResourceState.java
@@ -411,7 +411,7 @@ public class ResourceState {
     
     static class ZeroTypeAvailability extends VmTypeAvailability {
       ZeroTypeAvailability( ) {
-        super( VmType.create( "ZERO", -1, -1, -1, -1, false ), 0, 0 );
+        super( VmType.create( "ZERO", -1, -1, -1, -1, -1, false ), 0, 0 );
       }
       
       @Override

--- a/clc/modules/cluster-common/src/main/java/com/eucalyptus/cluster/common/msgs/VmTypeInfo.java
+++ b/clc/modules/cluster-common/src/main/java/com/eucalyptus/cluster/common/msgs/VmTypeInfo.java
@@ -123,7 +123,7 @@ public class VmTypeInfo extends EucalyptusData implements Cloneable {
     this.virtualBootRecord.add( record );
   }
 
-  public void setEphemeral( Integer index, String deviceName, Long sizeBytes, String formatName ) {
+  public void addEphemeral( String deviceName, Long sizeBytes, String formatName ) {
     final VirtualBootRecord record = new VirtualBootRecord( );
     record.setGuestDeviceName( deviceName );
     record.setSize( sizeBytes );

--- a/clc/modules/compute-backend/src/main/java/com/eucalyptus/vmtypes/VmTypes.java
+++ b/clc/modules/compute-backend/src/main/java/com/eucalyptus/vmtypes/VmTypes.java
@@ -109,9 +109,9 @@ public class VmTypes {
                       initial = "t2.micro" )
   public static String         DEFAULT_TYPE_NAME        = "t2.micro";
 
-  @ConfigurableField( description = "Format first ephemeral disk by default with ext3", initial = "true",
+  @ConfigurableField( description = "Format first ephemeral disk by default with ext3", initial = "false",
       changeListener = PropertyChangeListeners.IsBoolean.class)
-  public static Boolean        FORMAT_EPHEMERAL_STORAGE = true;
+  public static Boolean        FORMAT_EPHEMERAL_STORAGE = false;
 
   @ConfigurableField( description = "Format swap disk by default. The property will be deprecated in next major release.",
       initial = "false", changeListener = PropertyChangeListeners.IsBoolean.class)

--- a/clc/modules/compute-backend/src/main/java/com/eucalyptus/vmtypes/VmTypesManager.java
+++ b/clc/modules/compute-backend/src/main/java/com/eucalyptus/vmtypes/VmTypesManager.java
@@ -95,6 +95,7 @@ public class VmTypesManager {
           {
             this.setName( v.getName( ) );
             this.setDisk( v.getDisk( ) );
+            this.setDiskCount( v.getDiskCount( ) );
             this.setCpu( v.getCpu( ) );
             this.setMemory( v.getMemory( ) );
             this.setNetworkInterfaces( v.getNetworkInterfaces( ) );
@@ -134,11 +135,13 @@ public class VmTypesManager {
               PredefinedTypes defaultVmType = PredefinedTypes.valueOf( vmTypeName.toUpperCase( ).replace( ".", "" ) );
               vmType.setCpu( defaultVmType.getCpu( ) );
               vmType.setDisk( defaultVmType.getDisk( ) );
+              vmType.setDiskCount( defaultVmType.getDiskCount( ) );
               vmType.setMemory( defaultVmType.getMemory( ) );
               vmType.setNetworkInterfaces( defaultVmType.getEthernetInterfaceLimit( ) );
             } else {
               vmType.setCpu( MoreObjects.firstNonNull( request.getCpu( ), vmType.getCpu( ) ) );
               vmType.setDisk( MoreObjects.firstNonNull( request.getDisk( ), vmType.getDisk( ) ) );
+              vmType.setDiskCount( MoreObjects.firstNonNull( request.getDiskCount( ), vmType.getDiskCount( ) ) );
               vmType.setMemory( MoreObjects.firstNonNull( request.getMemory( ), vmType.getMemory( ) ) );
               vmType.setNetworkInterfaces( MoreObjects.firstNonNull( request.getNetworkInterfaces( ), vmType.getNetworkInterfaces( ) ) );
               vmType.setEnabled( MoreObjects.firstNonNull( request.getEnabled( ), vmType.getEnabled( ) ) );

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyInstanceTypeAttributeType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyInstanceTypeAttributeType.java
@@ -41,6 +41,8 @@ public class ModifyInstanceTypeAttributeType extends VmTypeMessage {
   private Integer cpu;
   @ComputeMessageValidation.FieldRange( min = 1l )
   private Integer disk;
+  @ComputeMessageValidation.FieldRange( min = 0l )
+  private Integer diskCount;
   @ComputeMessageValidation.FieldRange( min = 1l )
   private Integer memory;
   @ComputeMessageValidation.FieldRange( min = 1l, max = 15l )
@@ -85,6 +87,14 @@ public class ModifyInstanceTypeAttributeType extends VmTypeMessage {
 
   public void setDisk( Integer disk ) {
     this.disk = disk;
+  }
+
+  public Integer getDiskCount( ) {
+    return diskCount;
+  }
+
+  public void setDiskCount( final Integer diskCount ) {
+    this.diskCount = diskCount;
   }
 
   public Integer getMemory( ) {

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/VmTypeDetails.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/VmTypeDetails.java
@@ -36,6 +36,7 @@ public class VmTypeDetails extends EucalyptusData {
   private String name;
   private Integer cpu;
   private Integer disk;
+  private Integer diskCount;
   private Integer memory;
   private Integer networkInterfaces;
   private ArrayList<VmTypeZoneStatus> availability = new ArrayList<VmTypeZoneStatus>( );
@@ -63,6 +64,14 @@ public class VmTypeDetails extends EucalyptusData {
 
   public void setDisk( Integer disk ) {
     this.disk = disk;
+  }
+
+  public Integer getDiskCount( ) {
+    return diskCount;
+  }
+
+  public void setDiskCount( Integer diskCount ) {
+    this.diskCount = diskCount;
   }
 
   public Integer getMemory( ) {

--- a/clc/modules/compute-common-msgs/src/main/resources/euca-instance-types.xml
+++ b/clc/modules/compute-common-msgs/src/main/resources/euca-instance-types.xml
@@ -36,6 +36,7 @@
         <value name="name" field="name" usage="optional" style="element"/>
         <value name="cpu" field="cpu" usage="optional" style="element"/>
         <value name="disk" field="disk" usage="optional" style="element"/>
+        <value name="diskCount" field="diskCount" usage="optional" style="element"/>
         <value name="memory" field="memory" usage="optional" style="element"/>
         <value name="networkInterfaces" field="networkInterfaces" usage="optional" style="element"/>
         <structure name="availability" usage="optional">
@@ -69,6 +70,7 @@
         <value name="name" field="name" usage="optional" style="element"/>
         <value name="cpu" field="cpu" usage="optional" style="element"/>
         <value name="disk" field="disk" usage="optional" style="element"/>
+        <value name="diskCount" field="diskCount" usage="optional" style="element"/>
         <value name="memory" field="memory" usage="optional" style="element"/>
     </mapping>
     <mapping name="ModifyInstanceTypeAttributeResponseType"

--- a/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/vmtypes/VmType.java
+++ b/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/vmtypes/VmType.java
@@ -63,6 +63,7 @@ import com.eucalyptus.auth.principal.FullName;
 import com.eucalyptus.util.HasFullName;
 import com.eucalyptus.auth.principal.OwnerFullName;
 import com.google.common.base.Function;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Maps;
@@ -115,7 +116,10 @@ public class VmType extends AbstractPersistent implements VmTypeMetadata, HasFul
   
   @Column( name = "config_vm_type_disk" )
   private Integer            disk;
-  
+
+  @Column( name = "config_vm_type_disk_count" )
+  private Integer            diskCount;
+
   @Column( name = "config_vm_type_memory" )
   private Integer            memory;
   
@@ -149,6 +153,7 @@ public class VmType extends AbstractPersistent implements VmTypeMetadata, HasFul
       final String name,
       final Integer cpu,
       final Integer disk,
+      final Integer diskCount,
       final Integer memory,
       final Integer networkInterfaces,
       final Boolean enabled
@@ -156,6 +161,7 @@ public class VmType extends AbstractPersistent implements VmTypeMetadata, HasFul
     this( name );
     this.cpu = cpu;
     this.disk = disk;
+    this.diskCount = diskCount;
     this.memory = memory;
     this.networkInterfaces = networkInterfaces;
     this.enabled = enabled;
@@ -196,7 +202,18 @@ public class VmType extends AbstractPersistent implements VmTypeMetadata, HasFul
   public void setDisk( final Integer disk ) {
     this.disk = disk;
   }
-  
+
+  /**
+   * A disk count of zero means there is no ephemeral disk when used with an ebs image.
+   */
+  public Integer getDiskCount( ) {
+    return diskCount;
+  }
+
+  public void setDiskCount( final Integer diskCount ) {
+    this.diskCount = diskCount;
+  }
+
   @Override
   public Integer getMemory( ) {
     return this.memory;
@@ -408,8 +425,8 @@ public class VmType extends AbstractPersistent implements VmTypeMetadata, HasFul
     return new VmType.EphemeralBuilder( this );
   }
   
-  public static VmType create( String name, Integer cpu, Integer disk, Integer memory, Integer networkInterfaces, Boolean enabled ) {
-    return new VmType( name, cpu, disk, memory, networkInterfaces, enabled );
+  public static VmType create( String name, Integer cpu, Integer disk, Integer diskCount, Integer memory, Integer networkInterfaces, Boolean enabled ) {
+    return new VmType( name, cpu, disk, diskCount, memory, networkInterfaces, enabled );
   }
   
   public static VmType named( String name ) {

--- a/clc/modules/core/src/main/java/com/eucalyptus/configurable/StaticDatabasePropertyEntry.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/configurable/StaticDatabasePropertyEntry.java
@@ -881,7 +881,10 @@ public class StaticDatabasePropertyEntry extends AbstractPersistent {
                     "euca-" ),
           Tuple.of( "com.eucalyptus.vm.VmInstances.instance_public_prefix",
                     "cloud.vmstate.instance_public_prefix",
-                    "euca-" )
+                    "euca-" ),
+          Tuple.of( "com.eucalyptus.vmtypes.VmTypes.merge_ephemeral_storage",
+                    "cloud.vmtypes.merge_ephemeral_storage",
+                    "true" )
       ) );
 
       return true;

--- a/storage/blobstore.c
+++ b/storage/blobstore.c
@@ -4277,6 +4277,9 @@ int blockblob_clone(blockblob * bb, const blockmap * map, unsigned int map_size)
         const blockmap *m = map + i;
         const char *dev;
 
+        if (m->len_blocks <= 0)
+            continue;
+
         switch (m->source_type) {
         case BLOBSTORE_DEVICE:
             dev = m->source.device_path;

--- a/storage/vbr.c
+++ b/storage/vbr.c
@@ -2066,7 +2066,7 @@ f_out:
             char buf[32];              // first part of artifact ID
             char *art_pref;
             if (strcmp(vbr->id, "none") == 0) {
-                if (snprintf(buf, sizeof(buf), "prt-%05lld%s", vbr->sizeBytes / 1048576, vbr->formatName) >= sizeof(buf))   // output was truncated
+                if (snprintf(buf, sizeof(buf), "prt-%02d-%05lld%s", vbr->diskNumber, vbr->sizeBytes / 1048576, vbr->formatName) >= sizeof(buf))   // output was truncated
                     break;
                 art_pref = buf;
             } else {

--- a/tools/cf-templates/ec2-instance-types-accelerated.yaml
+++ b/tools/cf-templates/ec2-instance-types-accelerated.yaml
@@ -45,6 +45,7 @@ Resources:
       Enabled: !Ref EnableF1
       Cpu: 64
       Disk: 3760
+      DiskCount: 4
       Memory: 999424
       NetworkInterfaces: 8
   F12XLARGE:
@@ -55,6 +56,7 @@ Resources:
       Enabled: !Ref EnableF1
       Cpu: 8
       Disk: 470
+      DiskCount: 1
       Memory: 124928
       NetworkInterfaces: 4
   F14XLARGE:
@@ -65,6 +67,7 @@ Resources:
       Enabled: !Ref EnableF1
       Cpu: 16
       Disk: 940
+      DiskCount: 1
       Memory: 249856
       NetworkInterfaces: 4
   G22XLARGE:
@@ -74,6 +77,7 @@ Resources:
       Enabled: !Ref EnableG2
       Cpu: 8
       Disk: 60
+      DiskCount: 1
       Memory: 15360
       NetworkInterfaces: 4
   G28XLARGE:
@@ -84,6 +88,7 @@ Resources:
       Enabled: !Ref EnableG2
       Cpu: 32
       Disk: 240
+      DiskCount: 2
       Memory: 61440
       NetworkInterfaces: 8
   G316XLARGE:

--- a/tools/cf-templates/ec2-instance-types-compute.yaml
+++ b/tools/cf-templates/ec2-instance-types-compute.yaml
@@ -60,6 +60,7 @@ Resources:
       Enabled: !Ref EnableC1
       Cpu: 2
       Disk: 350
+      DiskCount: 1
       Memory: 1741
       NetworkInterfaces: 2
   C1XLARGE:
@@ -70,6 +71,7 @@ Resources:
       Enabled: !Ref EnableC1
       Cpu: 8
       Disk: 1680
+      DiskCount: 4
       Memory: 7168
       NetworkInterfaces: 4
   C32XLARGE:
@@ -79,6 +81,7 @@ Resources:
       Enabled: !Ref EnableC3
       Cpu: 8
       Disk: 160
+      DiskCount: 2
       Memory: 15360
       NetworkInterfaces: 4
   C34XLARGE:
@@ -89,6 +92,7 @@ Resources:
       Enabled: !Ref EnableC3
       Cpu: 16
       Disk: 320
+      DiskCount: 2
       Memory: 30720
       NetworkInterfaces: 8
   C38XLARGE:
@@ -99,6 +103,7 @@ Resources:
       Enabled: !Ref EnableC3
       Cpu: 32
       Disk: 640
+      DiskCount: 2
       Memory: 61440
       NetworkInterfaces: 8
   C3LARGE:
@@ -109,6 +114,7 @@ Resources:
       Enabled: !Ref EnableC3
       Cpu: 2
       Disk: 32
+      DiskCount: 2
       Memory: 3840
       NetworkInterfaces: 3
   C3XLARGE:
@@ -119,6 +125,7 @@ Resources:
       Enabled: !Ref EnableC3
       Cpu: 4
       Disk: 80
+      DiskCount: 2
       Memory: 7680
       NetworkInterfaces: 4
   C42XLARGE:
@@ -236,6 +243,7 @@ Resources:
       Enabled: !Ref EnableC5D
       Cpu: 72
       Disk: 1800
+      DiskCount: 2
       Memory: 147456
       NetworkInterfaces: 15
   C5D2XLARGE:
@@ -246,6 +254,7 @@ Resources:
       Enabled: !Ref EnableC5D
       Cpu: 8
       Disk: 200
+      DiskCount: 1
       Memory: 16384
       NetworkInterfaces: 4
   C5D4XLARGE:
@@ -256,6 +265,7 @@ Resources:
       Enabled: !Ref EnableC5D
       Cpu: 16
       Disk: 400
+      DiskCount: 1
       Memory: 32768
       NetworkInterfaces: 8
   C5D9XLARGE:
@@ -266,6 +276,7 @@ Resources:
       Enabled: !Ref EnableC5D
       Cpu: 36
       Disk: 900
+      DiskCount: 1
       Memory: 73728
       NetworkInterfaces: 8
   C5DLARGE:
@@ -276,6 +287,7 @@ Resources:
       Enabled: !Ref EnableC5D
       Cpu: 2
       Disk: 50
+      DiskCount: 1
       Memory: 4096
       NetworkInterfaces: 3
   C5DXLARGE:
@@ -286,6 +298,7 @@ Resources:
       Enabled: !Ref EnableC5D
       Cpu: 4
       Disk: 100
+      DiskCount: 1
       Memory: 8192
       NetworkInterfaces: 4
   CC28XLARGE:
@@ -295,6 +308,7 @@ Resources:
       Enabled: !Ref EnableCC2
       Cpu: 32
       Disk: 3360
+      DiskCount: 4
       Memory: 61952
       NetworkInterfaces: 8
   CG14XLARGE:
@@ -304,6 +318,7 @@ Resources:
       Enabled: !Ref EnableCG1
       Cpu: 16
       Disk: 200
+      DiskCount: 1
       Memory: 12288
       NetworkInterfaces: 8
   CR18XLARGE:
@@ -313,5 +328,6 @@ Resources:
       Enabled: !Ref EnableCR1
       Cpu: 32
       Disk: 240
+      DiskCount: 2
       Memory: 249856
       NetworkInterfaces: 8

--- a/tools/cf-templates/ec2-instance-types-eucalyptus-4.yaml
+++ b/tools/cf-templates/ec2-instance-types-eucalyptus-4.yaml
@@ -37,6 +37,7 @@ Resources:
       Enabled: !Ref EnableCompat
       Cpu: 2
       Disk: 10
+      DiskCount: 1
       Memory: 512
       NetworkInterfaces: 2
   C1XLARGE:
@@ -47,6 +48,7 @@ Resources:
       Enabled: !Ref EnableCompat
       Cpu: 2
       Disk: 10
+      DiskCount: 1
       Memory: 2048
       NetworkInterfaces: 4
   CC28XLARGE:
@@ -56,6 +58,7 @@ Resources:
       Enabled: !Ref EnableCompat
       Cpu: 16
       Disk: 120
+      DiskCount: 4
       Memory: 6144
       NetworkInterfaces: 8
   CG14XLARGE:
@@ -65,6 +68,7 @@ Resources:
       Enabled: !Ref EnableCompat
       Cpu: 16
       Disk: 200
+      DiskCount: 1
       Memory: 12288
       NetworkInterfaces: 8
   CR18XLARGE:
@@ -74,6 +78,7 @@ Resources:
       Enabled: !Ref EnableCompat
       Cpu: 16
       Disk: 240
+      DiskCount: 2
       Memory: 16384
       NetworkInterfaces: 8
   HI14XLARGE:
@@ -82,7 +87,8 @@ Resources:
       Name: hi1.4xlarge
       Enabled: !Ref EnableCompat
       Cpu: 8
-      Disk: 120
+      Disk: 2000
+      DiskCount: 2
       Memory: 6144
       NetworkInterfaces: 8
   HS18XLARGE:
@@ -92,6 +98,7 @@ Resources:
       Enabled: !Ref EnableCompat
       Cpu: 48
       Disk: 24000
+      DiskCount: 24
       Memory: 119808
       NetworkInterfaces: 8
   M1LARGE:
@@ -101,6 +108,7 @@ Resources:
       Enabled: !Ref EnableCompat
       Cpu: 2
       Disk: 10
+      DiskCount: 1
       Memory: 512
       NetworkInterfaces: 3
   M1MEDIUM:
@@ -111,6 +119,7 @@ Resources:
       Enabled: !Ref EnableCompat
       Cpu: 1
       Disk: 10
+      DiskCount: 1
       Memory: 512
       NetworkInterfaces: 2
   M1SMALL:
@@ -121,6 +130,7 @@ Resources:
       Enabled: !Ref EnableCompat
       Cpu: 1
       Disk: 5
+      DiskCount: 1
       Memory: 256
       NetworkInterfaces: 2
   M1XLARGE:
@@ -131,6 +141,7 @@ Resources:
       Enabled: !Ref EnableCompat
       Cpu: 2
       Disk: 10
+      DiskCount: 1
       Memory: 1024
       NetworkInterfaces: 4
   M22XLARGE:
@@ -140,6 +151,7 @@ Resources:
       Enabled: !Ref EnableCompat
       Cpu: 2
       Disk: 30
+      DiskCount: 1
       Memory: 4096
       NetworkInterfaces: 4
   M24XLARGE:
@@ -150,6 +162,7 @@ Resources:
       Enabled: !Ref EnableCompat
       Cpu: 8
       Disk: 60
+      DiskCount: 2
       Memory: 4096
       NetworkInterfaces: 8
   M2XLARGE:
@@ -160,6 +173,7 @@ Resources:
       Enabled: !Ref EnableCompat
       Cpu: 2
       Disk: 10
+      DiskCount: 1
       Memory: 2048
       NetworkInterfaces: 4
   M32XLARGE:
@@ -169,6 +183,7 @@ Resources:
       Enabled: !Ref EnableCompat
       Cpu: 4
       Disk: 30
+      DiskCount: 2
       Memory: 4096
       NetworkInterfaces: 4
   M3XLARGE:
@@ -179,6 +194,7 @@ Resources:
       Enabled: !Ref EnableCompat
       Cpu: 4
       Disk: 15
+      DiskCount: 1
       Memory: 2048
       NetworkInterfaces: 4
   M512XLARGE:

--- a/tools/cf-templates/ec2-instance-types-general.yaml
+++ b/tools/cf-templates/ec2-instance-types-general.yaml
@@ -65,6 +65,7 @@ Resources:
       Enabled: !Ref EnableM1
       Cpu: 2
       Disk: 840
+      DiskCount: 2
       Memory: 7680
       NetworkInterfaces: 3
   M1MEDIUM:
@@ -75,6 +76,7 @@ Resources:
       Enabled: !Ref EnableM1
       Cpu: 1
       Disk: 410
+      DiskCount: 1
       Memory: 3840
       NetworkInterfaces: 2
   M1SMALL:
@@ -85,6 +87,7 @@ Resources:
       Enabled: !Ref EnableM1
       Cpu: 1
       Disk: 160
+      DiskCount: 1
       Memory: 1741
       NetworkInterfaces: 2
   M1XLARGE:
@@ -95,6 +98,7 @@ Resources:
       Enabled: !Ref EnableM1
       Cpu: 4
       Disk: 1680
+      DiskCount: 4
       Memory: 15360
       NetworkInterfaces: 4
   M22XLARGE:
@@ -104,6 +108,7 @@ Resources:
       Enabled: !Ref EnableM2
       Cpu: 4
       Disk: 850
+      DiskCount: 1
       Memory: 35021
       NetworkInterfaces: 4
   M24XLARGE:
@@ -114,6 +119,7 @@ Resources:
       Enabled: !Ref EnableM2
       Cpu: 8
       Disk: 1680
+      DiskCount: 2
       Memory: 70042
       NetworkInterfaces: 8
   M2XLARGE:
@@ -124,6 +130,7 @@ Resources:
       Enabled: !Ref EnableM2
       Cpu: 2
       Disk: 420
+      DiskCount: 1
       Memory: 17510
       NetworkInterfaces: 4
   M32XLARGE:
@@ -133,6 +140,7 @@ Resources:
       Enabled: !Ref EnableM3
       Cpu: 8
       Disk: 160
+      DiskCount: 2
       Memory: 30720
       NetworkInterfaces: 4
   M3LARGE:
@@ -143,6 +151,7 @@ Resources:
       Enabled: !Ref EnableM3
       Cpu: 2
       Disk: 32
+      DiskCount: 1
       Memory: 7680
       NetworkInterfaces: 3
   M3MEDIUM:
@@ -153,6 +162,7 @@ Resources:
       Enabled: !Ref EnableM3
       Cpu: 1
       Disk: 4
+      DiskCount: 1
       Memory: 3840
       NetworkInterfaces: 2
   M3XLARGE:
@@ -163,6 +173,7 @@ Resources:
       Enabled: !Ref EnableM3
       Cpu: 4
       Disk: 80
+      DiskCount: 2
       Memory: 15360
       NetworkInterfaces: 4
   M410XLARGE:
@@ -290,6 +301,7 @@ Resources:
       Enabled: !Ref EnableM5D
       Cpu: 48
       Disk: 1800
+      DiskCount: 2
       Memory: 196608
       NetworkInterfaces: 8
   M5D24XLARGE:
@@ -300,6 +312,7 @@ Resources:
       Enabled: !Ref EnableM5D
       Cpu: 96
       Disk: 3600
+      DiskCount: 4
       Memory: 393216
       NetworkInterfaces: 15
   M5D2XLARGE:
@@ -310,6 +323,7 @@ Resources:
       Enabled: !Ref EnableM5D
       Cpu: 8
       Disk: 300
+      DiskCount: 1
       Memory: 32768
       NetworkInterfaces: 4
   M5D4XLARGE:
@@ -320,6 +334,7 @@ Resources:
       Enabled: !Ref EnableM5D
       Cpu: 16
       Disk: 600
+      DiskCount: 2
       Memory: 65536
       NetworkInterfaces: 8
   M5DLARGE:
@@ -330,6 +345,7 @@ Resources:
       Enabled: !Ref EnableM5D
       Cpu: 2
       Disk: 75
+      DiskCount: 1
       Memory: 8192
       NetworkInterfaces: 3
   M5DXLARGE:
@@ -340,6 +356,7 @@ Resources:
       Enabled: !Ref EnableM5D
       Cpu: 4
       Disk: 150
+      DiskCount: 1
       Memory: 16384
       NetworkInterfaces: 4
   T1MICRO:

--- a/tools/cf-templates/ec2-instance-types-memory.yaml
+++ b/tools/cf-templates/ec2-instance-types-memory.yaml
@@ -55,6 +55,7 @@ Resources:
       Enabled: !Ref EnableR3
       Cpu: 8
       Disk: 160
+      DiskCount: 1
       Memory: 62464
       NetworkInterfaces: 4
   R34XLARGE:
@@ -65,6 +66,7 @@ Resources:
       Enabled: !Ref EnableR3
       Cpu: 16
       Disk: 320
+      DiskCount: 1
       Memory: 124928
       NetworkInterfaces: 8
   R38XLARGE:
@@ -75,6 +77,7 @@ Resources:
       Enabled: !Ref EnableR3
       Cpu: 32
       Disk: 640
+      DiskCount: 2
       Memory: 249856
       NetworkInterfaces: 8
   R3LARGE:
@@ -85,6 +88,7 @@ Resources:
       Enabled: !Ref EnableR3
       Cpu: 2
       Disk: 32
+      DiskCount: 1
       Memory: 15616
       NetworkInterfaces: 3
   R3XLARGE:
@@ -95,6 +99,7 @@ Resources:
       Enabled: !Ref EnableR3
       Cpu: 4
       Disk: 80
+      DiskCount: 1
       Memory: 31232
       NetworkInterfaces: 4
   R416XLARGE:
@@ -222,6 +227,7 @@ Resources:
       Enabled: !Ref EnableR5D
       Cpu: 48
       Disk: 1800
+      DiskCount: 2
       Memory: 393216
       NetworkInterfaces: 8
   R5D24XLARGE:
@@ -232,6 +238,7 @@ Resources:
       Enabled: !Ref EnableR5D
       Cpu: 96
       Disk: 3600
+      DiskCount: 4
       Memory: 786432
       NetworkInterfaces: 15
   R5D2XLARGE:
@@ -242,6 +249,7 @@ Resources:
       Enabled: !Ref EnableR5D
       Cpu: 8
       Disk: 300
+      DiskCount: 1
       Memory: 65536
       NetworkInterfaces: 4
   R5D4XLARGE:
@@ -252,6 +260,7 @@ Resources:
       Enabled: !Ref EnableR5D
       Cpu: 16
       Disk: 600
+      DiskCount: 2
       Memory: 131072
       NetworkInterfaces: 8
   R5DLARGE:
@@ -262,6 +271,7 @@ Resources:
       Enabled: !Ref EnableR5D
       Cpu: 2
       Disk: 75
+      DiskCount: 1
       Memory: 16384
       NetworkInterfaces: 3
   R5DXLARGE:
@@ -272,6 +282,7 @@ Resources:
       Enabled: !Ref EnableR5D
       Cpu: 4
       Disk: 150
+      DiskCount: 1
       Memory: 32768
       NetworkInterfaces: 4
   X116XLARGE:
@@ -281,6 +292,7 @@ Resources:
       Enabled: !Ref EnableX1
       Cpu: 64
       Disk: 1920
+      DiskCount: 1
       Memory: 999424
       NetworkInterfaces: 8
   X132XLARGE:
@@ -291,6 +303,7 @@ Resources:
       Enabled: !Ref EnableX1
       Cpu: 128
       Disk: 3840
+      DiskCount: 2
       Memory: 1998848
       NetworkInterfaces: 8
   X1E16XLARGE:
@@ -300,6 +313,7 @@ Resources:
       Enabled: !Ref EnableX1E
       Cpu: 64
       Disk: 1920
+      DiskCount: 1
       Memory: 1998848
       NetworkInterfaces: 8
   X1E2XLARGE:
@@ -310,6 +324,7 @@ Resources:
       Enabled: !Ref EnableX1E
       Cpu: 8
       Disk: 240
+      DiskCount: 1
       Memory: 249856
       NetworkInterfaces: 4
   X1E32XLARGE:
@@ -320,6 +335,7 @@ Resources:
       Enabled: !Ref EnableX1E
       Cpu: 128
       Disk: 3840
+      DiskCount: 2
       Memory: 3997696
       NetworkInterfaces: 8
   X1E4XLARGE:
@@ -330,6 +346,7 @@ Resources:
       Enabled: !Ref EnableX1E
       Cpu: 16
       Disk: 480
+      DiskCount: 1
       Memory: 499712
       NetworkInterfaces: 4
   X1E8XLARGE:
@@ -340,6 +357,7 @@ Resources:
       Enabled: !Ref EnableX1E
       Cpu: 32
       Disk: 960
+      DiskCount: 1
       Memory: 999424
       NetworkInterfaces: 4
   X1EXLARGE:
@@ -350,6 +368,7 @@ Resources:
       Enabled: !Ref EnableX1E
       Cpu: 4
       Disk: 120
+      DiskCount: 1
       Memory: 124928
       NetworkInterfaces: 3
   Z1D12XLARGE:
@@ -359,6 +378,7 @@ Resources:
       Enabled: !Ref EnableZ1D
       Cpu: 48
       Disk: 1800
+      DiskCount: 2
       Memory: 393216
       NetworkInterfaces: 15
   Z1D2XLARGE:
@@ -369,6 +389,7 @@ Resources:
       Enabled: !Ref EnableZ1D
       Cpu: 8
       Disk: 300
+      DiskCount: 1
       Memory: 65536
       NetworkInterfaces: 4
   Z1D3XLARGE:
@@ -379,6 +400,7 @@ Resources:
       Enabled: !Ref EnableZ1D
       Cpu: 12
       Disk: 450
+      DiskCount: 1
       Memory: 98304
       NetworkInterfaces: 8
   Z1D6XLARGE:
@@ -389,6 +411,7 @@ Resources:
       Enabled: !Ref EnableZ1D
       Cpu: 24
       Disk: 900
+      DiskCount: 1
       Memory: 196608
       NetworkInterfaces: 8
   Z1DLARGE:
@@ -399,6 +422,7 @@ Resources:
       Enabled: !Ref EnableZ1D
       Cpu: 2
       Disk: 75
+      DiskCount: 1
       Memory: 16384
       NetworkInterfaces: 3
   Z1DXLARGE:
@@ -409,5 +433,6 @@ Resources:
       Enabled: !Ref EnableZ1D
       Cpu: 4
       Disk: 150
+      DiskCount: 1
       Memory: 32768
       NetworkInterfaces: 4

--- a/tools/cf-templates/ec2-instance-types-storage.yaml
+++ b/tools/cf-templates/ec2-instance-types-storage.yaml
@@ -50,6 +50,7 @@ Resources:
       Enabled: !Ref EnableD2
       Cpu: 8
       Disk: 12000
+      DiskCount: 6
       Memory: 62464
       NetworkInterfaces: 4
   D24XLARGE:
@@ -60,6 +61,7 @@ Resources:
       Enabled: !Ref EnableD2
       Cpu: 16
       Disk: 24000
+      DiskCount: 12
       Memory: 124928
       NetworkInterfaces: 8
   D28XLARGE:
@@ -70,6 +72,7 @@ Resources:
       Enabled: !Ref EnableD2
       Cpu: 36
       Disk: 48000
+      DiskCount: 24
       Memory: 249856
       NetworkInterfaces: 8
   D2XLARGE:
@@ -80,6 +83,7 @@ Resources:
       Enabled: !Ref EnableD2
       Cpu: 4
       Disk: 6000
+      DiskCount: 3
       Memory: 31232
       NetworkInterfaces: 4
   H116XLARGE:
@@ -89,6 +93,7 @@ Resources:
       Enabled: !Ref EnableH1
       Cpu: 64
       Disk: 16000
+      DiskCount: 8
       Memory: 262144
       NetworkInterfaces: 15
   H12XLARGE:
@@ -99,6 +104,7 @@ Resources:
       Enabled: !Ref EnableH1
       Cpu: 8
       Disk: 2000
+      DiskCount: 1
       Memory: 32768
       NetworkInterfaces: 4
   H14XLARGE:
@@ -109,6 +115,7 @@ Resources:
       Enabled: !Ref EnableH1
       Cpu: 16
       Disk: 4000
+      DiskCount: 2
       Memory: 65536
       NetworkInterfaces: 8
   H18XLARGE:
@@ -119,6 +126,7 @@ Resources:
       Enabled: !Ref EnableH1
       Cpu: 32
       Disk: 8000
+      DiskCount: 4
       Memory: 131072
       NetworkInterfaces: 8
   HI14XLARGE:
@@ -128,6 +136,7 @@ Resources:
       Enabled: !Ref EnableHI1
       Cpu: 48
       Disk: 24000
+      DiskCount: 2
       Memory: 119808
       NetworkInterfaces: 8
   HS18XLARGE:
@@ -137,6 +146,7 @@ Resources:
       Enabled: !Ref EnableHS1
       Cpu: 16
       Disk: 48000
+      DiskCount: 24
       Memory: 119808
       NetworkInterfaces: 8
   I22XLARGE:
@@ -146,6 +156,7 @@ Resources:
       Enabled: !Ref EnableI2
       Cpu: 8
       Disk: 1600
+      DiskCount: 2
       Memory: 62464
       NetworkInterfaces: 4
   I24XLARGE:
@@ -156,6 +167,7 @@ Resources:
       Enabled: !Ref EnableI2
       Cpu: 16
       Disk: 3200
+      DiskCount: 4
       Memory: 124928
       NetworkInterfaces: 8
   I28XLARGE:
@@ -166,6 +178,7 @@ Resources:
       Enabled: !Ref EnableI2
       Cpu: 32
       Disk: 6400
+      DiskCount: 8
       Memory: 249856
       NetworkInterfaces: 8
   I2XLARGE:
@@ -176,6 +189,7 @@ Resources:
       Enabled: !Ref EnableI2
       Cpu: 4
       Disk: 800
+      DiskCount: 1
       Memory: 31232
       NetworkInterfaces: 4
   I316XLARGE:
@@ -185,6 +199,7 @@ Resources:
       Enabled: !Ref EnableI3
       Cpu: 64
       Disk: 15200
+      DiskCount: 8
       Memory: 499712
       NetworkInterfaces: 15
   I32XLARGE:
@@ -195,6 +210,7 @@ Resources:
       Enabled: !Ref EnableI3
       Cpu: 8
       Disk: 1900
+      DiskCount: 1
       Memory: 62464
       NetworkInterfaces: 4
   I34XLARGE:
@@ -205,6 +221,7 @@ Resources:
       Enabled: !Ref EnableI3
       Cpu: 16
       Disk: 3800
+      DiskCount: 2
       Memory: 124928
       NetworkInterfaces: 8
   I38XLARGE:
@@ -215,6 +232,7 @@ Resources:
       Enabled: !Ref EnableI3
       Cpu: 32
       Disk: 7600
+      DiskCount: 4
       Memory: 249856
       NetworkInterfaces: 8
   I3LARGE:
@@ -225,6 +243,7 @@ Resources:
       Enabled: !Ref EnableI3
       Cpu: 2
       Disk: 475
+      DiskCount: 1
       Memory: 15616
       NetworkInterfaces: 3
   I3XLARGE:
@@ -235,5 +254,6 @@ Resources:
       Enabled: !Ref EnableI3
       Cpu: 4
       Disk: 950
+      DiskCount: 1
       Memory: 31232
       NetworkInterfaces: 4


### PR DESCRIPTION
EC2 instance types are updated to include a disk count which will be zero for "ebs only" instance types. The root device for an `instance-store` instance will now always be the size of one of the ephemeral disks, not the size of the source image.

Using the instance type to define the device size allows instances to expand their file systems on first boot and means you do not have to start with large (when raw) images to get a reasonable root size.

We now create more than one ephemeral disk (instance type allowing) and the number of disks is now checked against the instance type so you can no longer create unlimited ephemeral storage for `ebs` instances.

An option (`cloud.vmtypes.merge_ephemeral_storage`) is added to merge non-root ephemeral disks so that behaviour is similar to previous releases.

The default setting for formatting the first ephemeral disk (`cloud.vmtypes.format_ephemeral_storage`) with `ext3` for `instance-store` instances is now false (do not format)