### PR TITLE
EC2 volume deleted status metadata expiry

### DIFF
--- a/clc/modules/compute-backend/src/main/java/com/eucalyptus/blockstorage/Volumes.java
+++ b/clc/modules/compute-backend/src/main/java/com/eucalyptus/blockstorage/Volumes.java
@@ -67,6 +67,8 @@ import com.eucalyptus.compute.common.internal.blockstorage.State;
 import com.eucalyptus.compute.common.internal.blockstorage.Volume;
 import com.eucalyptus.compute.common.internal.blockstorage.VolumeTag;
 import com.eucalyptus.compute.common.internal.identifier.ResourceIdentifiers;
+import com.eucalyptus.configurable.ConfigurableClass;
+import com.eucalyptus.configurable.ConfigurableField;
 import com.eucalyptus.entities.Entities;
 import com.eucalyptus.entities.TransactionException;
 import com.eucalyptus.entities.TransactionResource;
@@ -92,8 +94,15 @@ import com.google.common.collect.Lists;
 
 import edu.ucsb.eucalyptus.cloud.VolumeSizeExceededException;
 
+@ConfigurableClass( root = "cloud.volumes",
+    description = "Parameters controlling storage volumes." )
 public class Volumes {
-  private static Logger     LOG                   = Logger.getLogger( Volumes.class );
+  private static final Logger     LOG                   = Logger.getLogger( Volumes.class );
+
+  @ConfigurableField( description = "Amount of time (in minutes) that a deleted volume will continue to be reported.",
+      initial = "60" )
+  public static Integer   DELETED_TIME                  = 60;
+
 
   @QuantityMetricFunction( VolumeMetadata.class )
   public enum CountVolumes implements Function<OwnerFullName, Long> {

--- a/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/blockstorage/Volume.java
+++ b/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/blockstorage/Volume.java
@@ -41,6 +41,7 @@ package com.eucalyptus.compute.common.internal.blockstorage;
 
 import java.util.Collection;
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 import javax.persistence.CascadeType;
@@ -167,7 +168,13 @@ public class Volume extends UserMetadata<State> implements VolumeMetadata {
         return "unavailable";
     }
   }
-  
+
+  public synchronized long getSplitTime( final TimeUnit units ) {
+    final long time = System.currentTimeMillis( );
+    final long split = time - super.getLastUpdateTimestamp( ).getTime( );
+    return units.convert( split, TimeUnit.MILLISECONDS );
+  }
+
   public com.eucalyptus.compute.common.Volume morph( final com.eucalyptus.compute.common.Volume vol ) {
     vol.setAvailabilityZone( this.getPartition( ) );
     vol.setCreateTime( this.getCreationTimestamp( ) );

--- a/clc/modules/compute-service/src/main/java/com/eucalyptus/compute/service/ComputeService.java
+++ b/clc/modules/compute-service/src/main/java/com/eucalyptus/compute/service/ComputeService.java
@@ -845,7 +845,6 @@ public class ComputeService {
         // build response volumes
         for ( final Volume foundVol : filteredVolumes ) {
           if ( State.ANNIHILATED.equals( foundVol.getState( ) ) ) {
-            Entities.delete( foundVol );
             if ( filterPredicate.apply( foundVol ) ) {
               replyVolumes.add( foundVol.morph( new com.eucalyptus.compute.common.Volume( ) ) );
             }
@@ -923,9 +922,6 @@ public class ComputeService {
             volumes,
             Predicates.and( new TrackingPredicate<>( volumeIds ), requestedAndAccessible ) );
         for ( final Volume foundVol : filteredVolumes ) {
-          if ( State.ANNIHILATED.equals( foundVol.getState( ) ) ) {
-            Entities.delete( foundVol );
-          }
           replyVolumes.add( volumeTransform.apply( foundVol ) );
         }
         return replyVolumes;


### PR DESCRIPTION
EC2 deleted volume metadata is now deleted as per a configurable expiry.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=659
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/114/
Test: /job/eucalyptus-5-qa-fast/121/

Demo is that the new property can be used:

```
# euctl cloud.volumes
cloud.volumes.deleted_time = 60
```

and that deleted volume metadata expires accordingly.

Fixes Corymbia/eucalyptus#227