### PR TITLE
S3 log level configuration for apache http library

### DIFF
--- a/clc/modules/core/src/main/resources/log4j.xml
+++ b/clc/modules/core/src/main/resources/log4j.xml
@@ -259,6 +259,9 @@
   <category name="org.apache.commons.httpclient">
     <priority value="ERROR" />
   </category>
+  <category name="org.apache.http">
+    <priority value="INFO" />
+  </category>
   <category name="httpclient.wire">
     <priority value="ERROR" />
   </category>


### PR DESCRIPTION
Log level configuration for apache http core library, which is an aws sdk for java dependency. The `org.apache.http.wire` logger was previously enabled causing wire trace output to be generated for s3 provider (backend) requests. The output was not logged but was impacting s3 performance.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=697
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/130/
Test: /job/eucalyptus-5-qa-fast/124/

Demo is that upload to s3 performance is back to 4.4 levels.