### PR TITLE
ObjectStorage configurable error code for unknown actions

### DIFF
--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/exceptions/s3/NotImplementedException.java
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/exceptions/s3/NotImplementedException.java
@@ -32,12 +32,24 @@ import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
 public class NotImplementedException extends S3Exception {
 
+  private static final String ERROR_STATUS_CODE_PROPERTY = "com.eucalyptus.objectstorage.notImplementedErrorCode";
+  private static final HttpResponseStatus ERROR_STATUS_CODE = initErrorStatusCode();
+
   public NotImplementedException( ) {
-    super( S3ErrorCodeStrings.NotImplemented, "A header you provided implies functionality that is not implemented.", HttpResponseStatus.NOT_IMPLEMENTED );
+    super( S3ErrorCodeStrings.NotImplemented, "A header you provided implies functionality that is not implemented.", ERROR_STATUS_CODE );
   }
 
   public NotImplementedException( String resource ) {
     this( );
     this.setResource( resource );
+  }
+
+  private static HttpResponseStatus initErrorStatusCode( ) {
+    HttpResponseStatus status = HttpResponseStatus.NOT_IMPLEMENTED;
+    try {
+      status = HttpResponseStatus.valueOf( Integer.getInteger( ERROR_STATUS_CODE_PROPERTY, status.getCode( ) ) );
+    } catch ( final Exception ignore ) {
+    }
+    return status;
   }
 }


### PR DESCRIPTION
The objectstorage error code is now configurable which can be used to return codes that may be better handled by clients than the default `501`.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=847
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/201/
Test: /job/eucalyptus-5-qa-fast/153/