### PR TITLE
ObjectStorage stubs/errors for unimplemented actions

### DIFF
--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/msgs/GetBucketAccelerateConfigurationResponseType.java
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/msgs/GetBucketAccelerateConfigurationResponseType.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.objectstorage.msgs;
+
+import javax.annotation.Nonnull;
+import com.eucalyptus.binding.BindingReplace;
+import com.eucalyptus.storage.msgs.s3.AccelerateConfiguration;
+
+
+public class GetBucketAccelerateConfigurationResponseType extends ObjectStorageResponseType implements BindingReplace<AccelerateConfiguration> {
+  private AccelerateConfiguration accelerateConfiguration;
+
+  @Nonnull
+  @Override
+  public AccelerateConfiguration bindingReplace( ) {
+    return getAccelerateConfiguration( );
+  }
+
+  public AccelerateConfiguration getAccelerateConfiguration( ) {
+    return accelerateConfiguration;
+  }
+
+  public void setAccelerateConfiguration( final AccelerateConfiguration accelerateConfiguration ) {
+    this.accelerateConfiguration = accelerateConfiguration;
+  }
+}

--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/msgs/GetBucketAccelerateConfigurationType.java
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/msgs/GetBucketAccelerateConfigurationType.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.objectstorage.msgs;
+
+import com.eucalyptus.objectstorage.policy.AdminOverrideAllowed;
+import com.eucalyptus.objectstorage.policy.RequiresACLPermission;
+import com.eucalyptus.objectstorage.policy.RequiresPermission;
+import com.eucalyptus.objectstorage.policy.ResourceType;
+import com.eucalyptus.objectstorage.policy.S3PolicySpec;
+import com.eucalyptus.objectstorage.util.ObjectStorageProperties;
+
+
+@AdminOverrideAllowed
+@RequiresPermission( standard = S3PolicySpec.S3_GETBUCKETACCELERATECONFIGURATION )
+@ResourceType( S3PolicySpec.S3_RESOURCE_BUCKET )
+@RequiresACLPermission( object = {}, bucket = {}, ownerOf = ObjectStorageProperties.Resource.bucket )
+public class GetBucketAccelerateConfigurationType extends ObjectStorageRequestType {
+
+}

--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/msgs/GetBucketNotificationConfigurationResponseType.java
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/msgs/GetBucketNotificationConfigurationResponseType.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.objectstorage.msgs;
+
+import javax.annotation.Nonnull;
+import com.eucalyptus.binding.BindingReplace;
+import com.eucalyptus.storage.msgs.s3.NotificationConfiguration;
+
+
+public class GetBucketNotificationConfigurationResponseType extends ObjectStorageResponseType implements BindingReplace<NotificationConfiguration> {
+  private NotificationConfiguration notificationConfiguration;
+
+  @Nonnull
+  @Override
+  public NotificationConfiguration bindingReplace( ) {
+    return getNotificationConfiguration( );
+  }
+
+  public NotificationConfiguration getNotificationConfiguration( ) {
+    return notificationConfiguration;
+  }
+
+  public void setNotificationConfiguration( final NotificationConfiguration notificationConfiguration ) {
+    this.notificationConfiguration = notificationConfiguration;
+  }
+}

--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/msgs/GetBucketNotificationConfigurationType.java
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/msgs/GetBucketNotificationConfigurationType.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.objectstorage.msgs;
+
+import com.eucalyptus.objectstorage.policy.AdminOverrideAllowed;
+import com.eucalyptus.objectstorage.policy.RequiresACLPermission;
+import com.eucalyptus.objectstorage.policy.RequiresPermission;
+import com.eucalyptus.objectstorage.policy.ResourceType;
+import com.eucalyptus.objectstorage.policy.S3PolicySpec;
+import com.eucalyptus.objectstorage.util.ObjectStorageProperties;
+
+
+@AdminOverrideAllowed
+@RequiresPermission( standard = S3PolicySpec.S3_GETBUCKETNOTIFICATIONCONFIGURATION )
+@ResourceType( S3PolicySpec.S3_RESOURCE_BUCKET )
+@RequiresACLPermission( object = {}, bucket = {}, ownerOf = ObjectStorageProperties.Resource.bucket )
+public class GetBucketNotificationConfigurationType extends ObjectStorageRequestType {
+
+}

--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/msgs/GetBucketRequestPaymentResponseType.java
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/msgs/GetBucketRequestPaymentResponseType.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.objectstorage.msgs;
+
+import com.eucalyptus.binding.BindingReplace;
+import com.eucalyptus.storage.msgs.s3.RequestPaymentConfiguration;
+
+
+public class GetBucketRequestPaymentResponseType extends ObjectStorageResponseType implements BindingReplace<RequestPaymentConfiguration> {
+  private RequestPaymentConfiguration paymentConfiguration;
+
+  @Override
+  public RequestPaymentConfiguration bindingReplace( ) {
+    return getPaymentConfiguration( );
+  }
+
+  public RequestPaymentConfiguration getPaymentConfiguration( ) {
+    return paymentConfiguration;
+  }
+
+  public void setPaymentConfiguration( final RequestPaymentConfiguration paymentConfiguration ) {
+    this.paymentConfiguration = paymentConfiguration;
+  }
+}

--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/msgs/GetBucketRequestPaymentType.java
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/msgs/GetBucketRequestPaymentType.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.objectstorage.msgs;
+
+import com.eucalyptus.objectstorage.policy.AdminOverrideAllowed;
+import com.eucalyptus.objectstorage.policy.RequiresACLPermission;
+import com.eucalyptus.objectstorage.policy.RequiresPermission;
+import com.eucalyptus.objectstorage.policy.ResourceType;
+import com.eucalyptus.objectstorage.policy.S3PolicySpec;
+import com.eucalyptus.objectstorage.util.ObjectStorageProperties;
+
+
+@AdminOverrideAllowed
+@RequiresPermission( standard = S3PolicySpec.S3_GETBUCKETREQUESTPAYMENT )
+@ResourceType( S3PolicySpec.S3_RESOURCE_BUCKET )
+@RequiresACLPermission( object = {}, bucket = {}, ownerOf = ObjectStorageProperties.Resource.bucket )
+public class GetBucketRequestPaymentType extends ObjectStorageRequestType {
+
+}

--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/policy/S3PolicySpec.java
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/policy/S3PolicySpec.java
@@ -54,6 +54,7 @@ public interface S3PolicySpec {
   String S3_GETBUCKETLOCATION = "getbucketlocation";
   String S3_GETBUCKETLOGGING = "getbucketlogging";
   String S3_GETBUCKETNOTIFICATION = "getbucketnotification";
+  String S3_GETBUCKETNOTIFICATIONCONFIGURATION = "getbucketnotificationconfiguration";
   String S3_GETBUCKETPOLICY = "getbucketpolicy";
   String S3_GETBUCKETREQUESTPAYMENT = "getbucketrequestpayment";
   String S3_GETBUCKETTAGGING = "getbuckettagging";

--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/policy/S3PolicySpec.java
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/policy/S3PolicySpec.java
@@ -48,6 +48,7 @@ public interface S3PolicySpec {
   String S3_DELETEBUCKETWEBSITE = "deletebucketwebsite";
   String S3_DELETEOBJECT = "deleteobject";
   String S3_DELETEOBJECTVERSION = "deleteobjectversion";
+  String S3_GETBUCKETACCELERATECONFIGURATION = "getbucketaccelerateconfiguration";
   String S3_GETBUCKETACL = "getbucketacl";
   String S3_GETBUCKETCORS = "getbucketcors";
   String S3_GETBUCKETLOCATION = "getbucketlocation";

--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/util/ObjectStorageProperties.java
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/util/ObjectStorageProperties.java
@@ -282,7 +282,7 @@ public class ObjectStorageProperties {
   public enum SubResource {
     // Per the S3 Dev guide, these must be included in the canonicalized resource:
     acl(true), lifecycle, location, logging, notification, partNumber, policy, requestPayment, torrent(true), uploadId, uploads,
-    versionId, versioning, versions, website, cors, tagging, delete, accelerate, metrics, analytics, inventory, replication;
+    versionId, versioning, versions, website, cors, tagging, delete, accelerate, metrics, analytics, inventory, replication, encryption, object_lock;
 
     /** Indicates whether the SubResource is of this <a href="http://docs.aws.amazon.com/AmazonS3/latest/dev/ObjectAndSoubResource.html">type</a> */
     public final boolean isObjectSubResource;
@@ -466,7 +466,7 @@ public class ObjectStorageProperties {
     acl, location, prefix, maxkeys, delimiter, marker, torrent, logging, versioning, versions, versionidmarker,
     keymarker, cors, lifecycle, policy, notification, tagging, requestPayment, website, uploads, maxUploads,
     uploadIdMarker, delete, accelerate, metrics, analytics, inventory, replication, startafter, continuationtoken,
-    fetchowner, listtype
+    fetchowner, listtype, encryption, object_lock
   }
 
   public enum ObjectParameter {

--- a/clc/modules/object-storage-common/src/main/resources/osg-s3ns-binding-inc.xml
+++ b/clc/modules/object-storage-common/src/main/resources/osg-s3ns-binding-inc.xml
@@ -796,6 +796,14 @@
         usage="optional"/>
   </mapping>
 
+  <mapping name="GetBucketNotificationConfiguration"
+           class="com.eucalyptus.objectstorage.msgs.GetBucketNotificationConfigurationType"
+           extends="com.eucalyptus.objectstorage.msgs.ObjectStorageRequestType">
+    <structure
+        map-as="com.eucalyptus.objectstorage.msgs.ObjectStorageRequestType"
+        usage="optional"/>
+  </mapping>
+
   <mapping name="GetBucketRequestPayment"
            class="com.eucalyptus.objectstorage.msgs.GetBucketRequestPaymentType"
            extends="com.eucalyptus.objectstorage.msgs.ObjectStorageRequestType">

--- a/clc/modules/object-storage-common/src/main/resources/osg-s3ns-binding-inc.xml
+++ b/clc/modules/object-storage-common/src/main/resources/osg-s3ns-binding-inc.xml
@@ -786,5 +786,23 @@
            class="com.eucalyptus.objectstorage.msgs.DeleteBucketPolicyResponseType">
   </mapping>
 
+  <!-- BUCKET OTHER -->
+
+  <mapping name="GetBucketAccelerateConfiguration"
+           class="com.eucalyptus.objectstorage.msgs.GetBucketAccelerateConfigurationType"
+           extends="com.eucalyptus.objectstorage.msgs.ObjectStorageRequestType">
+    <structure
+        map-as="com.eucalyptus.objectstorage.msgs.ObjectStorageRequestType"
+        usage="optional"/>
+  </mapping>
+
+  <mapping name="GetBucketRequestPayment"
+           class="com.eucalyptus.objectstorage.msgs.GetBucketRequestPaymentType"
+           extends="com.eucalyptus.objectstorage.msgs.ObjectStorageRequestType">
+    <structure
+        map-as="com.eucalyptus.objectstorage.msgs.ObjectStorageRequestType"
+        usage="optional"/>
+  </mapping>
+
 </binding>
 

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageGateway.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageGateway.java
@@ -141,6 +141,8 @@ import com.eucalyptus.objectstorage.msgs.DeleteObjectResponseType;
 import com.eucalyptus.objectstorage.msgs.DeleteObjectType;
 import com.eucalyptus.objectstorage.msgs.DeleteVersionResponseType;
 import com.eucalyptus.objectstorage.msgs.DeleteVersionType;
+import com.eucalyptus.objectstorage.msgs.GetBucketAccelerateConfigurationResponseType;
+import com.eucalyptus.objectstorage.msgs.GetBucketAccelerateConfigurationType;
 import com.eucalyptus.objectstorage.msgs.GetBucketAccessControlPolicyResponseType;
 import com.eucalyptus.objectstorage.msgs.GetBucketAccessControlPolicyType;
 import com.eucalyptus.objectstorage.msgs.GetBucketCorsResponseType;
@@ -153,6 +155,8 @@ import com.eucalyptus.objectstorage.msgs.GetBucketLoggingStatusResponseType;
 import com.eucalyptus.objectstorage.msgs.GetBucketLoggingStatusType;
 import com.eucalyptus.objectstorage.msgs.GetBucketPolicyResponseType;
 import com.eucalyptus.objectstorage.msgs.GetBucketPolicyType;
+import com.eucalyptus.objectstorage.msgs.GetBucketRequestPaymentResponseType;
+import com.eucalyptus.objectstorage.msgs.GetBucketRequestPaymentType;
 import com.eucalyptus.objectstorage.msgs.GetBucketTaggingResponseType;
 import com.eucalyptus.objectstorage.msgs.GetBucketTaggingType;
 import com.eucalyptus.objectstorage.msgs.GetBucketVersioningStatusResponseType;
@@ -221,6 +225,7 @@ import com.eucalyptus.records.Logs;
 import com.eucalyptus.reporting.event.S3ObjectEvent;
 import com.eucalyptus.storage.common.DateFormatter;
 import com.eucalyptus.storage.config.ConfigurationCache;
+import com.eucalyptus.storage.msgs.s3.AccelerateConfiguration;
 import com.eucalyptus.storage.msgs.s3.AccessControlList;
 import com.eucalyptus.storage.msgs.s3.AccessControlPolicy;
 import com.eucalyptus.storage.msgs.s3.AllowedCorsMethods;
@@ -245,6 +250,7 @@ import com.eucalyptus.storage.msgs.s3.LoggingEnabled;
 import com.eucalyptus.storage.msgs.s3.Part;
 import com.eucalyptus.storage.msgs.s3.PreflightRequest;
 import com.eucalyptus.storage.msgs.s3.PreflightResponse;
+import com.eucalyptus.storage.msgs.s3.RequestPaymentConfiguration;
 import com.eucalyptus.storage.msgs.s3.TaggingConfiguration;
 import com.eucalyptus.storage.msgs.s3.TargetGrants;
 import com.eucalyptus.storage.msgs.s3.Upload;
@@ -2520,7 +2526,23 @@ public class ObjectStorageGateway implements ObjectStorageService {
     return reply;
   }
 
-  private Bucket getBucketAndCheckAuthorization( ObjectStorageRequestType request) throws S3Exception {
+  @Override
+  public GetBucketAccelerateConfigurationResponseType getBucketAccelerateConfiguration( final GetBucketAccelerateConfigurationType request ) throws S3Exception {
+    final GetBucketAccelerateConfigurationResponseType reply = request.getReply( );
+    getBucketAndCheckAuthorization( request );
+    reply.setAccelerateConfiguration( new AccelerateConfiguration( ) );
+    return reply;
+  }
+
+  @Override
+  public GetBucketRequestPaymentResponseType getBucketRequestPayment( final GetBucketRequestPaymentType request ) throws S3Exception {
+    final GetBucketRequestPaymentResponseType reply = request.getReply( );
+    getBucketAndCheckAuthorization( request );
+    reply.setPaymentConfiguration( new RequestPaymentConfiguration( ) );
+    return reply;
+  }
+
+  private Bucket getBucketAndCheckAuthorization(ObjectStorageRequestType request) throws S3Exception {
     logRequest(request);
     Bucket bucket = ensureBucketExists(request.getBucket());
     if (!authorizationHandler.operationAllowed(request, bucket, null, 0)) {

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageGateway.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageGateway.java
@@ -41,7 +41,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 
 import javax.annotation.Nonnull;
@@ -153,6 +152,8 @@ import com.eucalyptus.objectstorage.msgs.GetBucketLocationResponseType;
 import com.eucalyptus.objectstorage.msgs.GetBucketLocationType;
 import com.eucalyptus.objectstorage.msgs.GetBucketLoggingStatusResponseType;
 import com.eucalyptus.objectstorage.msgs.GetBucketLoggingStatusType;
+import com.eucalyptus.objectstorage.msgs.GetBucketNotificationConfigurationResponseType;
+import com.eucalyptus.objectstorage.msgs.GetBucketNotificationConfigurationType;
 import com.eucalyptus.objectstorage.msgs.GetBucketPolicyResponseType;
 import com.eucalyptus.objectstorage.msgs.GetBucketPolicyType;
 import com.eucalyptus.objectstorage.msgs.GetBucketRequestPaymentResponseType;
@@ -247,6 +248,7 @@ import com.eucalyptus.storage.msgs.s3.LifecycleConfiguration;
 import com.eucalyptus.storage.msgs.s3.LifecycleRule;
 import com.eucalyptus.storage.msgs.s3.ListAllMyBucketsList;
 import com.eucalyptus.storage.msgs.s3.LoggingEnabled;
+import com.eucalyptus.storage.msgs.s3.NotificationConfiguration;
 import com.eucalyptus.storage.msgs.s3.Part;
 import com.eucalyptus.storage.msgs.s3.PreflightRequest;
 import com.eucalyptus.storage.msgs.s3.PreflightResponse;
@@ -2531,6 +2533,14 @@ public class ObjectStorageGateway implements ObjectStorageService {
     final GetBucketAccelerateConfigurationResponseType reply = request.getReply( );
     getBucketAndCheckAuthorization( request );
     reply.setAccelerateConfiguration( new AccelerateConfiguration( ) );
+    return reply;
+  }
+
+  @Override
+  public GetBucketNotificationConfigurationResponseType getBucketNotificationConfiguration( final GetBucketNotificationConfigurationType request ) throws S3Exception {
+    final GetBucketNotificationConfigurationResponseType reply = request.getReply( );
+    getBucketAndCheckAuthorization( request );
+    reply.setNotificationConfiguration( new NotificationConfiguration( ) );
     return reply;
   }
 

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageService.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageService.java
@@ -54,6 +54,8 @@ import com.eucalyptus.objectstorage.msgs.DeleteObjectResponseType;
 import com.eucalyptus.objectstorage.msgs.DeleteObjectType;
 import com.eucalyptus.objectstorage.msgs.DeleteVersionResponseType;
 import com.eucalyptus.objectstorage.msgs.DeleteVersionType;
+import com.eucalyptus.objectstorage.msgs.GetBucketAccelerateConfigurationResponseType;
+import com.eucalyptus.objectstorage.msgs.GetBucketAccelerateConfigurationType;
 import com.eucalyptus.objectstorage.msgs.GetBucketAccessControlPolicyResponseType;
 import com.eucalyptus.objectstorage.msgs.GetBucketAccessControlPolicyType;
 import com.eucalyptus.objectstorage.msgs.GetBucketCorsResponseType;
@@ -66,6 +68,8 @@ import com.eucalyptus.objectstorage.msgs.GetBucketLoggingStatusResponseType;
 import com.eucalyptus.objectstorage.msgs.GetBucketLoggingStatusType;
 import com.eucalyptus.objectstorage.msgs.GetBucketPolicyResponseType;
 import com.eucalyptus.objectstorage.msgs.GetBucketPolicyType;
+import com.eucalyptus.objectstorage.msgs.GetBucketRequestPaymentResponseType;
+import com.eucalyptus.objectstorage.msgs.GetBucketRequestPaymentType;
 import com.eucalyptus.objectstorage.msgs.GetBucketTaggingResponseType;
 import com.eucalyptus.objectstorage.msgs.GetBucketTaggingType;
 import com.eucalyptus.objectstorage.msgs.GetBucketVersioningStatusResponseType;
@@ -219,4 +223,8 @@ public interface ObjectStorageService {
   DeleteBucketPolicyResponseType deleteBucketPolicy(DeleteBucketPolicyType request) throws S3Exception;
 
   DeleteMultipleObjectsResponseType deleteMultipleObjects(DeleteMultipleObjectsType request) throws S3Exception;
+
+  GetBucketAccelerateConfigurationResponseType getBucketAccelerateConfiguration(GetBucketAccelerateConfigurationType request) throws S3Exception;
+
+  GetBucketRequestPaymentResponseType getBucketRequestPayment(GetBucketRequestPaymentType request) throws S3Exception;
 }

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageService.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageService.java
@@ -66,6 +66,8 @@ import com.eucalyptus.objectstorage.msgs.GetBucketLocationResponseType;
 import com.eucalyptus.objectstorage.msgs.GetBucketLocationType;
 import com.eucalyptus.objectstorage.msgs.GetBucketLoggingStatusResponseType;
 import com.eucalyptus.objectstorage.msgs.GetBucketLoggingStatusType;
+import com.eucalyptus.objectstorage.msgs.GetBucketNotificationConfigurationResponseType;
+import com.eucalyptus.objectstorage.msgs.GetBucketNotificationConfigurationType;
 import com.eucalyptus.objectstorage.msgs.GetBucketPolicyResponseType;
 import com.eucalyptus.objectstorage.msgs.GetBucketPolicyType;
 import com.eucalyptus.objectstorage.msgs.GetBucketRequestPaymentResponseType;
@@ -225,6 +227,8 @@ public interface ObjectStorageService {
   DeleteMultipleObjectsResponseType deleteMultipleObjects(DeleteMultipleObjectsType request) throws S3Exception;
 
   GetBucketAccelerateConfigurationResponseType getBucketAccelerateConfiguration(GetBucketAccelerateConfigurationType request) throws S3Exception;
+
+  GetBucketNotificationConfigurationResponseType getBucketNotificationConfiguration(GetBucketNotificationConfigurationType request) throws S3Exception;
 
   GetBucketRequestPaymentResponseType getBucketRequestPayment(GetBucketRequestPaymentType request) throws S3Exception;
 }

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/binding/ObjectStorageGETBinding.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/binding/ObjectStorageGETBinding.java
@@ -75,6 +75,7 @@ public class ObjectStorageGETBinding extends ObjectStorageRESTBinding {
     .put(BUCKET + HttpMethod.GET + BucketParameter.cors.toString(), "GetBucketCors")
     .put(BUCKET + HttpMethod.GET + BucketParameter.policy.toString(), "GetBucketPolicy")
     .put(BUCKET + HttpMethod.GET + BucketParameter.accelerate.toString(), "GetBucketAccelerateConfiguration")
+    .put(BUCKET + HttpMethod.GET + BucketParameter.notification.toString(), "GetBucketNotificationConfiguration")
     .put(BUCKET + HttpMethod.GET + BucketParameter.requestPayment.toString().toLowerCase(), "GetBucketRequestPayment")
 
     // Multipart uploads
@@ -100,8 +101,6 @@ public class ObjectStorageGETBinding extends ObjectStorageRESTBinding {
 
   private static final ImmutableMap<String, String> UNSUPPORTED_OPS = ImmutableMap.<String,String>builder( )
     // Bucket operations
-    // Notification
-    .put(BUCKET + HttpMethod.GET + BucketParameter.notification.toString(), "GET Bucket notification")
     // Website
     .put(BUCKET + HttpMethod.GET + BucketParameter.website.toString(), OP_GET_BUCKET_WEBSITE)
     // Metrics

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/binding/ObjectStorageGETBinding.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/binding/ObjectStorageGETBinding.java
@@ -72,6 +72,8 @@ public class ObjectStorageGETBinding extends ObjectStorageRESTBinding {
     .put(BUCKET + HttpMethod.GET + BucketParameter.tagging.toString(), "GetBucketTagging")
     .put(BUCKET + HttpMethod.GET + BucketParameter.cors.toString(), "GetBucketCors")
     .put(BUCKET + HttpMethod.GET + BucketParameter.policy.toString(), "GetBucketPolicy")
+    .put(BUCKET + HttpMethod.GET + BucketParameter.accelerate.toString(), "GetBucketAccelerateConfiguration")
+    .put(BUCKET + HttpMethod.GET + BucketParameter.requestPayment.toString().toLowerCase(), "GetBucketRequestPayment")
 
     // Multipart uploads
     .put(BUCKET + HttpMethod.GET + BucketParameter.uploads.toString(), "ListMultipartUploads")
@@ -90,12 +92,8 @@ public class ObjectStorageGETBinding extends ObjectStorageRESTBinding {
     // Bucket operations
     // Notification
     .put(BUCKET + HttpMethod.GET + BucketParameter.notification.toString(), "GET Bucket notification")
-    // Request Payments // TODO HACK! binding code converts parameters to lower case. Fix that issue!
-    .put(BUCKET + HttpMethod.GET + BucketParameter.requestPayment.toString().toLowerCase(), "GET Bucket requestPayment")
     // Website
     .put(BUCKET + HttpMethod.GET + BucketParameter.website.toString(), "GET Bucket website")
-    // Accelerate
-    .put(BUCKET + HttpMethod.GET + BucketParameter.accelerate.toString(), "GET Bucket accelerate")
     // Metrics
     .put(BUCKET + HttpMethod.GET + BucketParameter.metrics.toString(), "GET Bucket metrics")
     // Analytics

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/binding/ObjectStorageRESTBinding.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/binding/ObjectStorageRESTBinding.java
@@ -672,8 +672,8 @@ public abstract class ObjectStorageRESTBinding extends RestfulMarshallingHandler
         continue;
       // Add subresource params to the operationKey
       for (ObjectStorageProperties.SubResource subResource : ObjectStorageProperties.SubResource.values()) {
-        if (keyString.toLowerCase().equals(subResource.toString().toLowerCase())) {
-          operationKey += keyString.toLowerCase();
+        if (keyString.toLowerCase().replace('-','_').equals(subResource.toString().toLowerCase())) {
+          operationKey += keyString.toLowerCase().replace('-','_');
           if ( Strings.isNullOrEmpty( value ) ) {
             paramsToRemove.add(key);
             continue params;
@@ -716,11 +716,7 @@ public abstract class ObjectStorageRESTBinding extends RestfulMarshallingHandler
             delimiter = "/";
           }
         }
-        NotImplementedException e = new NotImplementedException();
-        e.setResource(resource);
-        e.setResourceType(resourceType);
-        e.setMessage(unsupportedOp + " is not implemented");
-        throw e;
+        throw buildUnsupportedOperationError( unsupportedOp, resource, resourceType );
       }
     }
 
@@ -730,6 +726,18 @@ public abstract class ObjectStorageRESTBinding extends RestfulMarshallingHandler
         operationParams.put("LocationConstraint", locationConstraint);
     }
     return operationName;
+  }
+
+  protected S3Exception buildUnsupportedOperationError(
+      final String unsupportedOp,
+      final String resource,
+      final String resourceType
+  ) {
+    final NotImplementedException e = new NotImplementedException( );
+    e.setResource( resource );
+    e.setResourceType( resourceType );
+    e.setMessage( unsupportedOp + " is not implemented" );
+    return e;
   }
 
   private static final Ordering<String> STRING_COMPARATOR = Ordering.natural();

--- a/clc/modules/storage-common/src/main/java/com/eucalyptus/storage/msgs/s3/AccelerateConfiguration.java
+++ b/clc/modules/storage-common/src/main/java/com/eucalyptus/storage/msgs/s3/AccelerateConfiguration.java
@@ -1,0 +1,13 @@
+/**
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.storage.msgs.s3;
+
+import edu.ucsb.eucalyptus.msgs.EucalyptusData;
+
+
+public class AccelerateConfiguration extends EucalyptusData {
+
+}

--- a/clc/modules/storage-common/src/main/java/com/eucalyptus/storage/msgs/s3/NotificationConfiguration.java
+++ b/clc/modules/storage-common/src/main/java/com/eucalyptus/storage/msgs/s3/NotificationConfiguration.java
@@ -1,0 +1,13 @@
+/**
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.storage.msgs.s3;
+
+import edu.ucsb.eucalyptus.msgs.EucalyptusData;
+
+
+public class NotificationConfiguration extends EucalyptusData {
+
+}

--- a/clc/modules/storage-common/src/main/java/com/eucalyptus/storage/msgs/s3/RequestPaymentConfiguration.java
+++ b/clc/modules/storage-common/src/main/java/com/eucalyptus/storage/msgs/s3/RequestPaymentConfiguration.java
@@ -1,0 +1,13 @@
+/**
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.storage.msgs.s3;
+
+import edu.ucsb.eucalyptus.msgs.EucalyptusData;
+
+
+public class RequestPaymentConfiguration extends EucalyptusData {
+
+}

--- a/clc/modules/storage-common/src/main/resources/s3-2006-03-01-common-binding.xml
+++ b/clc/modules/storage-common/src/main/resources/s3-2006-03-01-common-binding.xml
@@ -313,4 +313,16 @@
         <value name="Code" field="code"/>
         <value name="Message" field="message"/>
     </mapping>
+
+    <!-- BUCKET ACCELERATION CONFIGURATION  -->
+
+    <mapping name="AccelerateConfiguration" class="com.eucalyptus.storage.msgs.s3.AccelerateConfiguration">
+    </mapping>
+
+    <!-- BUCKET REQUESTER PAYS  -->
+
+    <mapping name="RequestPaymentConfiguration" class="com.eucalyptus.storage.msgs.s3.RequestPaymentConfiguration">
+        <value name="Payer" constant="BucketOwner" usage="optional"/>
+    </mapping>
+
 </binding>

--- a/clc/modules/storage-common/src/main/resources/s3-2006-03-01-common-binding.xml
+++ b/clc/modules/storage-common/src/main/resources/s3-2006-03-01-common-binding.xml
@@ -319,6 +319,11 @@
     <mapping name="AccelerateConfiguration" class="com.eucalyptus.storage.msgs.s3.AccelerateConfiguration">
     </mapping>
 
+    <!-- BUCKET NOTIFICATION CONFIGURATION  -->
+
+    <mapping name="NotificationConfiguration" class="com.eucalyptus.storage.msgs.s3.NotificationConfiguration">
+    </mapping>
+
     <!-- BUCKET REQUESTER PAYS  -->
 
     <mapping name="RequestPaymentConfiguration" class="com.eucalyptus.storage.msgs.s3.RequestPaymentConfiguration">


### PR DESCRIPTION
Stub implementations are added for the S3 actions:

* GetBucketAccelerateConfiguration
* GetBucketNotificationConfiguration
* GetBucketRequestPayment

to return the default/unconfigured values.

The error codes and http status codes are updated for the S3 actions:

* GetBucketEncryption
* GetBucketReplication
* GetBucketWebsite
* GetObjectLockConfiguration

to match the default not found responses from AWS/S3.

Fixes corymbia/eucalyptus#253