### PR TITLE
clcadmin-assume-system-credentials can select incorrect key

### DIFF
--- a/tools/clcadmin-assume-system-credentials
+++ b/tools/clcadmin-assume-system-credentials
@@ -48,7 +48,7 @@ elif [ $(id -u) -ne 0 ]; then
     exit 1
 fi
 
-export PGPASSWORD=$(echo -n eucalyptus | openssl dgst -sha256 -sign <(openssl pkcs12 -in "$KEYSTORE_PATH" -passin pass:eucalyptus -nodes -nomacver | sed -n '/friendlyName: eucalyptus/,/friendlyName:/{/-----BEGIN.*PRIVATE/,/-----END.*PRIVATE/p}') | sha256sum | sed 's/ .*//')
+export PGPASSWORD=$(echo -n eucalyptus | openssl dgst -sha256 -sign <(openssl pkcs12 -in "$KEYSTORE_PATH" -passin pass:eucalyptus -nodes -nomacver | sed -n '/friendlyName: eucalyptus$/,/friendlyName:/{/-----BEGIN.*PRIVATE/,/-----END.*PRIVATE/p}') | sha256sum | sed 's/ .*//')
 n_creds=$(psql -Aqt -F : -h $DB_HOST -p 8777 -U eucalyptus -w eucalyptus_shared -c "SELECT COUNT(*)     $KEY_QUERY")
 creds=$(  psql -Aqt -F : -h $DB_HOST -p 8777 -U eucalyptus -w eucalyptus_shared -c "SELECT $KEY_COLUMNS $KEY_QUERY LIMIT 1")
 key_id=$(echo $creds | cut -d: -f1)


### PR DESCRIPTION
The `clcadmin-assume-system-credentials` command can use the wrong key when there are multiple keys with the aliases prefix `eucalyptus`.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=860
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/204/
Test: /job/eucalyptus-5-qa-fast/155/

The demo is that the `clcadmin-assume-system-credentials` script works as expected.