### PR TITLE
Use azure artifacts and maven central

### DIFF
--- a/clc/build.gradle
+++ b/clc/build.gradle
@@ -82,7 +82,10 @@ subprojects {
   }
 
   repositories {
-    jcenter( )
+    mavenCentral( )
+    maven {
+      url 'https://pkgs.dev.azure.com/sjones4/eucalyptus/_packaging/maven/maven/v1'
+    }
   }
 
   configurations {


### PR DESCRIPTION
Use azure artifacts hosted glisten rather than bintray/jcenter.

> Repositories Hosted on Bintray
Your repositories for module types including Docker, Maven (Java), Npm, NuGet, RPM, Vagrant, and Generic will need to be migrated off of Bintray service on or before May 1st to avoid any disruption in service.

The gradle build is not used for releases, it is only for developer use so this change is not covered by any tests.