### PR TITLE
CloudFormation support for instance profile resource name

### DIFF
--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMInstanceProfileResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMInstanceProfileResourceAction.java
@@ -53,6 +53,7 @@ import com.eucalyptus.cloudformation.workflow.steps.Step;
 import com.eucalyptus.cloudformation.workflow.steps.StepBasedResourceAction;
 import com.eucalyptus.cloudformation.workflow.steps.UpdateStep;
 import com.eucalyptus.cloudformation.workflow.updateinfo.UpdateType;
+import com.eucalyptus.cloudformation.workflow.updateinfo.UpdateTypeAndDirection;
 import com.eucalyptus.component.ServiceConfiguration;
 import com.eucalyptus.component.Topology;
 import com.eucalyptus.component.id.Euare;
@@ -61,7 +62,9 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
 
+import com.google.common.collect.Maps;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -75,6 +78,11 @@ public class AWSIAMInstanceProfileResourceAction extends StepBasedResourceAction
 
   public AWSIAMInstanceProfileResourceAction() {
     super(fromEnum(CreateSteps.class), fromEnum(DeleteSteps.class),fromUpdateEnum(UpdateNoInterruptionSteps.class), null);
+    // In this case, update with replacement has a precondition check before essentially the same steps as "create".  We add both.
+    Map<String, UpdateStep> updateWithReplacementMap = Maps.newLinkedHashMap();
+    updateWithReplacementMap.putAll(fromUpdateEnum(AWSIAMInstanceProfileResourceAction.UpdateWithReplacementPreCreateSteps.class));
+    updateWithReplacementMap.putAll(createStepsToUpdateWithReplacementSteps(fromEnum(AWSIAMInstanceProfileResourceAction.CreateSteps.class)));
+    setUpdateSteps(UpdateTypeAndDirection.UPDATE_WITH_REPLACEMENT, updateWithReplacementMap);
   }
 
   @Override
@@ -87,6 +95,9 @@ public class AWSIAMInstanceProfileResourceAction extends StepBasedResourceAction
     if (!Objects.equals(properties.getRoles(), otherAction.properties.getRoles())) {
       updateType = UpdateType.max(updateType, UpdateType.NO_INTERRUPTION);
     }
+    if (!Objects.equals(properties.getInstanceProfileName(), otherAction.properties.getInstanceProfileName())) {
+      updateType = UpdateType.max(updateType, UpdateType.NEEDS_REPLACEMENT);
+    }
     return updateType;
   }
 
@@ -96,7 +107,9 @@ public class AWSIAMInstanceProfileResourceAction extends StepBasedResourceAction
       public ResourceAction perform(ResourceAction resourceAction) throws Exception {
         AWSIAMInstanceProfileResourceAction action = (AWSIAMInstanceProfileResourceAction) resourceAction;
         ServiceConfiguration configuration = Topology.lookup(Euare.class);
-        String instanceProfileName = action.getDefaultPhysicalResourceId();
+        String instanceProfileName = action.properties.getInstanceProfileName() != null ?
+            action.properties.getInstanceProfileName() :
+            action.getDefaultPhysicalResourceId();
         CreateInstanceProfileType createInstanceProfileType = MessageHelper.createMessage(CreateInstanceProfileType.class, action.info.getEffectiveUserId());
         createInstanceProfileType.setPath(MoreObjects.firstNonNull(action.properties.getPath(), DEFAULT_PATH));
         createInstanceProfileType.setInstanceProfileName(instanceProfileName);
@@ -209,6 +222,21 @@ public class AWSIAMInstanceProfileResourceAction extends StepBasedResourceAction
             addRoleToInstanceProfileType.setRoleName(roleName);
             AsyncRequests.<AddRoleToInstanceProfileType,AddRoleToInstanceProfileResponseType> sendSync(configuration, addRoleToInstanceProfileType);
           }
+        }
+        return newAction;
+      }
+    }
+  }
+
+
+  private enum UpdateWithReplacementPreCreateSteps implements UpdateStep {
+    CHECK_CHANGED_PROFILE_NAME {
+      @Override
+      public ResourceAction perform(ResourceAction oldResourceAction, ResourceAction newResourceAction) throws Exception {
+        AWSIAMInstanceProfileResourceAction oldAction = (AWSIAMInstanceProfileResourceAction) oldResourceAction;
+        AWSIAMInstanceProfileResourceAction newAction = (AWSIAMInstanceProfileResourceAction) newResourceAction;
+        if (Objects.equals(oldAction.properties.getInstanceProfileName(), newAction.properties.getInstanceProfileName()) && oldAction.properties.getInstanceProfileName() != null) {
+          throw new ValidationErrorException("CloudFormation cannot update a stack when a custom-named resource requires replacing. Rename "+oldAction.properties.getInstanceProfileName()+" and update the stack again.");
         }
         return newAction;
       }

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/info/AWSIAMInstanceProfileResourceInfo.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/info/AWSIAMInstanceProfileResourceInfo.java
@@ -48,7 +48,11 @@ public class AWSIAMInstanceProfileResourceInfo extends ResourceInfo {
   @Override
   public Collection<String> getRequiredCapabilities( JsonNode propertiesJson ) {
     ArrayList<String> capabilities = new ArrayList<String>( );
-    capabilities.add( Capabilities.CAPABILITY_IAM.toString( ) );
+    if ( propertiesJson != null && propertiesJson.isObject( ) && propertiesJson.has( "InstanceProfileName" ) ) {
+      capabilities.add( Capabilities.CAPABILITY_NAMED_IAM.toString( ) );
+    } else {
+      capabilities.add( Capabilities.CAPABILITY_IAM.toString( ) );
+    }
     return capabilities;
   }
 

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/AWSIAMInstanceProfileProperties.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/AWSIAMInstanceProfileProperties.java
@@ -44,6 +44,9 @@ public class AWSIAMInstanceProfileProperties implements ResourceProperties {
   @Property
   private ArrayList<String> roles = Lists.newArrayList( );
 
+  @Property
+  private String instanceProfileName;
+
   public String getPath( ) {
     return path;
   }
@@ -60,11 +63,20 @@ public class AWSIAMInstanceProfileProperties implements ResourceProperties {
     this.roles = roles;
   }
 
+  public String getInstanceProfileName( ) {
+    return instanceProfileName;
+  }
+
+  public void setInstanceProfileName( String instanceProfileName ) {
+    this.instanceProfileName = instanceProfileName;
+  }
+
   @Override
   public String toString( ) {
     return MoreObjects.toStringHelper( this )
         .add( "path", path )
         .add( "roles", roles )
+        .add( "instanceProfileName", instanceProfileName )
         .toString( );
   }
 }


### PR DESCRIPTION
CloudFormation support for instance profile resource name when using `CAPABILITY_NAMED_IAM`.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=897
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/217/
Test: /job/eucalyptus-5-qa-fast/165/

Demo is that named instance profiles can now be created:

```
# 
# cat rds-registry-resources.yaml | grep -A 4 IAM::InstanceProfile
    Type: AWS::IAM::InstanceProfile
    Properties:
      InstanceProfileName: registry-admin
      Roles:
        - !Ref AdminRole
--
    Type: AWS::IAM::InstanceProfile
    Properties:
      InstanceProfileName: registry-read
      Roles:
        - !Ref ReadOnlyRole
# 
# 
# euform-create-stack --template-file rds-registry-resources.yaml --capabilities CAPABILITY_NAMED_IAM rds-registry-resources-1
arn:aws:cloudformation::000916168637:stack/rds-registry-resources-1/b095620f-e4aa-41cb-8444-c7fedbe301b8
# 
# 
# euform-describe-stacks rds-registry-resources-1
STACK	rds-registry-resources-1	CREATE_COMPLETE		RDS container registry bucket and related IAM resources	2021-02-23T19:43:42.674Z
OUTPUT	Bucket	rds-registry-resources-1-bucket-b8xjhc9ox3ox0
OUTPUT	InstanceProfileAdmin	registry-admin
OUTPUT	InstanceProfileRead	registry-read
# 
# 
# euare-instanceprofilelistbypath 
arn:aws:iam::000916168637:instance-profile/registry-admin
arn:aws:iam::000916168637:instance-profile/registry-read
``` 

Fixes corymbia/eucalyptus#258