### PR TITLE
S3 UploadPartCopy action

### DIFF
--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/msgs/UploadPartCopyResponseType.java
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/msgs/UploadPartCopyResponseType.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.objectstorage.msgs;
+
+import java.util.Date;
+
+public class UploadPartCopyResponseType extends ObjectStorageResponseType {
+
+  private String copySourceVersionId;
+  private String etag;
+  private Date lastModified;
+
+  public String getCopySourceVersionId() {
+    return copySourceVersionId;
+  }
+
+  public void setCopySourceVersionId(String copySourceVersionId) {
+    this.copySourceVersionId = copySourceVersionId;
+  }
+
+  public String getEtag() {
+    return etag;
+  }
+
+  public void setEtag(String etag) {
+    this.etag = etag;
+  }
+
+  public Date getLastModified() {
+    return lastModified;
+  }
+
+  public void setLastModified(Date lastModified) {
+    this.lastModified = lastModified;
+  }
+}

--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/msgs/UploadPartCopyType.java
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/msgs/UploadPartCopyType.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.objectstorage.msgs;
+
+import com.eucalyptus.objectstorage.policy.AdminOverrideAllowed;
+import com.eucalyptus.objectstorage.policy.RequiresACLPermission;
+import com.eucalyptus.objectstorage.policy.RequiresPermission;
+import com.eucalyptus.objectstorage.policy.ResourceType;
+import com.eucalyptus.objectstorage.policy.S3PolicySpec;
+import com.eucalyptus.objectstorage.util.ObjectStorageProperties;
+import com.eucalyptus.util.Strings;
+import com.google.common.collect.Maps;
+import io.vavr.Tuple;
+import io.vavr.Tuple2;
+import java.util.Date;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+@AdminOverrideAllowed
+@RequiresPermission( standard = S3PolicySpec.S3_PUTOBJECT )
+@ResourceType( S3PolicySpec.S3_RESOURCE_OBJECT )
+@RequiresACLPermission( object = { ObjectStorageProperties.Permission.READ }, bucket = {}, ownerOf = { ObjectStorageProperties.Resource.object } )
+public class UploadPartCopyType extends ObjectStorageDataRequestType {
+
+  private String uploadId;
+  private String partNumber;
+  private HashMap<String, String> copiedHeaders = Maps.newHashMap( );
+
+  private String sourceBucket;
+  private String sourceObject;
+  private String sourceVersionId;
+
+  private String copySourceRange;
+  private String copySourceIfMatch;
+  private String copySourceIfNoneMatch;
+  private Date copySourceIfModifiedSince;
+  private Date copySourceIfUnmodifiedSince;
+
+  public GetObjectType getGetObjectRequest( ) {
+    final GetObjectType request = new GetObjectType( );
+    request.setBucket( this.sourceBucket );
+    request.setKey( this.sourceObject );
+    request.setVersionId( this.sourceVersionId );
+
+    // common elements
+    request.setCorrelationId( this.getCorrelationId( ) );
+    request.setEffectiveUserId( this.getEffectiveUserId( ) );
+
+    return request;
+  }
+
+  @Nullable
+  public Tuple2<Long,Long> copySourceRangeAsTuple() {
+    Tuple2<Long,Long> range = null;
+    if (copySourceRange != null) {
+      final String bytesRange = Strings.trimPrefix("bytes=", copySourceRange);
+      final int dashIndex = bytesRange.indexOf('-');
+      if ( dashIndex > -1 && dashIndex < bytesRange.length() - 1) {
+        String firstByte = bytesRange.substring(0, dashIndex);
+        String lastByte = bytesRange.substring(dashIndex + 1);
+        range = Tuple.of(Long.parseLong(firstByte), Long.parseLong(lastByte));
+      }
+    }
+    return range;
+  }
+
+  public String getUploadId( ) {
+    return uploadId;
+  }
+
+  public void setUploadId( String uploadId ) {
+    this.uploadId = uploadId;
+  }
+
+  public String getPartNumber( ) {
+    return partNumber;
+  }
+
+  public void setPartNumber( String partNumber ) {
+    this.partNumber = partNumber;
+  }
+
+  public HashMap<String, String> getCopiedHeaders( ) {
+    return copiedHeaders;
+  }
+
+  public void setCopiedHeaders( HashMap<String, String> copiedHeaders ) {
+    this.copiedHeaders = copiedHeaders;
+  }
+
+  public String getSourceBucket( ) {
+    return sourceBucket;
+  }
+
+  public void setSourceBucket( String sourceBucket ) {
+    this.sourceBucket = sourceBucket;
+  }
+
+  public String getSourceObject( ) {
+    return sourceObject;
+  }
+
+  public void setSourceObject( String sourceObject ) {
+    this.sourceObject = sourceObject;
+  }
+
+  public String getSourceVersionId( ) {
+    return sourceVersionId;
+  }
+
+  public void setSourceVersionId( String sourceVersionId ) {
+    this.sourceVersionId = sourceVersionId;
+  }
+
+  public String getCopySourceRange( ) {
+    return copySourceRange;
+  }
+
+  public void setCopySourceRange( String copySourceRange ) {
+    this.copySourceRange = copySourceRange;
+  }
+
+  public String getCopySourceIfMatch( ) {
+    return copySourceIfMatch;
+  }
+
+  public void setCopySourceIfMatch( String copySourceIfMatch ) {
+    this.copySourceIfMatch = copySourceIfMatch;
+  }
+
+  public String getCopySourceIfNoneMatch( ) {
+    return copySourceIfNoneMatch;
+  }
+
+  public void setCopySourceIfNoneMatch( String copySourceIfNoneMatch ) {
+    this.copySourceIfNoneMatch = copySourceIfNoneMatch;
+  }
+
+  public Date getCopySourceIfModifiedSince( ) {
+    return copySourceIfModifiedSince;
+  }
+
+  public void setCopySourceIfModifiedSince( Date copySourceIfModifiedSince ) {
+    this.copySourceIfModifiedSince = copySourceIfModifiedSince;
+  }
+
+  public Date getCopySourceIfUnmodifiedSince( ) {
+    return copySourceIfUnmodifiedSince;
+  }
+
+  public void setCopySourceIfUnmodifiedSince( Date copySourceIfUnmodifiedSince ) {
+    this.copySourceIfUnmodifiedSince = copySourceIfUnmodifiedSince;
+  }
+}

--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/providers/ObjectStorageProviderClient.java
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/providers/ObjectStorageProviderClient.java
@@ -88,6 +88,8 @@ import com.eucalyptus.objectstorage.msgs.SetBucketVersioningStatusResponseType;
 import com.eucalyptus.objectstorage.msgs.SetBucketVersioningStatusType;
 import com.eucalyptus.objectstorage.msgs.SetObjectAccessControlPolicyResponseType;
 import com.eucalyptus.objectstorage.msgs.SetObjectAccessControlPolicyType;
+import com.eucalyptus.objectstorage.msgs.UploadPartCopyResponseType;
+import com.eucalyptus.objectstorage.msgs.UploadPartCopyType;
 import com.eucalyptus.objectstorage.msgs.UploadPartResponseType;
 import com.eucalyptus.objectstorage.msgs.UploadPartType;
 import com.eucalyptus.util.EucalyptusCloudException;
@@ -192,6 +194,8 @@ public interface ObjectStorageProviderClient {
   public abstract InitiateMultipartUploadResponseType initiateMultipartUpload(InitiateMultipartUploadType request) throws S3Exception;
 
   public abstract UploadPartResponseType uploadPart(UploadPartType request, InputStream dataContent) throws S3Exception;
+
+  public abstract UploadPartCopyResponseType uploadPartCopy(UploadPartCopyType request) throws S3Exception;
 
   public abstract CompleteMultipartUploadResponseType completeMultipartUpload(CompleteMultipartUploadType request) throws S3Exception;
 

--- a/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/util/ObjectStorageProperties.java
+++ b/clc/modules/object-storage-common/src/main/java/com/eucalyptus/objectstorage/util/ObjectStorageProperties.java
@@ -387,6 +387,10 @@ public class ObjectStorageProperties {
     CopySourceIfMatch, CopySourceIfNoneMatch, CopySourceIfUnmodifiedSince, CopySourceIfModifiedSince
   }
 
+  public enum PartCopyHeaders {
+    CopySourceIfMatch, CopySourceIfNoneMatch, CopySourceIfUnmodifiedSince, CopySourceIfModifiedSince, CopySourceRange
+  }
+
   public enum MetadataDirective {
     COPY, REPLACE
   }

--- a/clc/modules/object-storage-common/src/main/resources/osg-s3ns-binding-inc.xml
+++ b/clc/modules/object-storage-common/src/main/resources/osg-s3ns-binding-inc.xml
@@ -559,6 +559,25 @@
            class="com.eucalyptus.objectstorage.msgs.UploadPartResponseType">
   </mapping>
 
+  <mapping name="CopyPart"
+      class="com.eucalyptus.objectstorage.msgs.UploadPartCopyType">
+    <value name="SourceBucket" field="sourceBucket"/>
+    <value name="SourceObject" field="sourceObject"/>
+    <value name="SourceVersionId" field="sourceVersionId" usage="optional"/>
+    <value name="CopySourceRange" field="copySourceRange"/>
+    <value name="CopySourceIfMatch" field="copySourceIfMatch"/>
+    <value name="CopySourceIfNoneMatch" field="copySourceIfNoneMatch"/>
+    <value name="CopySourceIfModifiedSince" field="copySourceIfModifiedSince"/>
+    <value name="CopySourceIfUnmodifiedSince" field="copySourceIfUnmodifiedSince"/>
+    <value name="PartNumber" field="partNumber" usage="optional"/>
+    <value name="UploadId" field="uploadId" usage="optional"/>
+  </mapping>
+
+  <mapping name="CopyPartResult"
+           class="com.eucalyptus.objectstorage.msgs.UploadPartCopyResponseType">
+    <value name="ETag" field="etag" usage="optional"/>
+    <value name="LastModified" field="lastModified" usage="optional"/>
+  </mapping>
 
   <mapping name="CompleteMultipartUpload"
            class="com.eucalyptus.objectstorage.msgs.CompleteMultipartUploadType">

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectFactory.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectFactory.java
@@ -39,6 +39,7 @@ import com.eucalyptus.objectstorage.entities.ObjectEntity;
 import com.eucalyptus.objectstorage.entities.PartEntity;
 import com.eucalyptus.objectstorage.exceptions.s3.S3Exception;
 import com.eucalyptus.objectstorage.msgs.CopyObjectType;
+import com.eucalyptus.objectstorage.msgs.UploadPartCopyType;
 import com.eucalyptus.objectstorage.providers.ObjectStorageProviderClient;
 import com.eucalyptus.storage.msgs.s3.MetaDataEntry;
 import com.eucalyptus.storage.msgs.s3.Part;
@@ -98,6 +99,14 @@ public interface ObjectFactory {
    * @return the ObjectEntity object representing the successfully created object
    */
   public PartEntity createObjectPart(ObjectStorageProviderClient provider, ObjectEntity mpuEntity, PartEntity entity, InputStream content,
+      User requestUser) throws S3Exception;
+
+  /**
+   * Create the named object part in metadata and on the backend.
+   *
+   * @return the PartEntity object representing the successfully created part
+   */
+  public PartEntity copyObjectPart(ObjectStorageProviderClient provider, ObjectEntity mpuEntity, PartEntity entity, UploadPartCopyType request,
       User requestUser) throws S3Exception;
 
   /**

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageGateway.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageGateway.java
@@ -29,6 +29,7 @@
 
 package com.eucalyptus.objectstorage;
 
+import io.vavr.Tuple2;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -41,7 +42,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 
 import javax.annotation.Nonnull;
@@ -208,6 +208,8 @@ import com.eucalyptus.objectstorage.msgs.SetObjectAccessControlPolicyResponseTyp
 import com.eucalyptus.objectstorage.msgs.SetObjectAccessControlPolicyType;
 import com.eucalyptus.objectstorage.msgs.UpdateObjectStorageConfigurationResponseType;
 import com.eucalyptus.objectstorage.msgs.UpdateObjectStorageConfigurationType;
+import com.eucalyptus.objectstorage.msgs.UploadPartCopyResponseType;
+import com.eucalyptus.objectstorage.msgs.UploadPartCopyType;
 import com.eucalyptus.objectstorage.msgs.UploadPartResponseType;
 import com.eucalyptus.objectstorage.msgs.UploadPartType;
 import com.eucalyptus.objectstorage.providers.ObjectStorageProviderClient;
@@ -2609,6 +2611,159 @@ public class ObjectStorageGateway implements ObjectStorageService {
       }
     } else {
       throw new AccessDeniedException(request.getBucket() + "/" + request.getKey());
+    }
+  }
+
+  @Override
+  public UploadPartCopyResponseType uploadPartCopy(final UploadPartCopyType request) throws S3Exception {
+    logRequest(request);
+
+    String sourceBucket = request.getSourceBucket();
+    String sourceKey = request.getSourceObject();
+    String sourceVersionId = request.getSourceVersionId();
+    UserPrincipal requestUser = Contexts.lookup().getUser();
+
+    // Check for source bucket
+    final Bucket srcBucket = ensureBucketExists(sourceBucket);
+
+    // Check for source object
+    final ObjectEntity srcObject;
+    try {
+      srcObject = ObjectMetadataManagers.getInstance().lookupObject(srcBucket, sourceKey, sourceVersionId);
+    } catch (NoSuchElementException e) {
+      throw new NoSuchKeyException(sourceBucket + "/" + sourceKey);
+    } catch (Exception e) {
+      throw new InternalErrorException(sourceBucket);
+    }
+
+    // Check authorization for GET operation on source bucket and object
+    if (authorizationHandler.operationAllowed(request.getGetObjectRequest(), srcBucket, srcObject, 0)) {
+      Bucket bucket;
+      try {
+        bucket = BucketMetadataManagers.getInstance().lookupExtantBucket(request.getBucket());
+      } catch (NoSuchEntityException e) {
+        throw new NoSuchBucketException(request.getBucket());
+      } catch (Exception e) {
+        throw new InternalErrorException();
+      }
+
+      int partNumber;
+      if (!Strings.isNullOrEmpty(request.getPartNumber())) {
+        try {
+          partNumber = Integer.parseInt(request.getPartNumber());
+          if (partNumber < ObjectStorageProperties.MIN_PART_NUMBER || partNumber > ObjectStorageProperties.MAX_PART_NUMBER) {
+            throw new InvalidArgumentException("PartNumber", "Part number must be an integer between " + ObjectStorageProperties.MIN_PART_NUMBER
+                + " and " + ObjectStorageProperties.MAX_PART_NUMBER + ", inclusive");
+          }
+        } catch (NumberFormatException e) {
+          throw new InvalidArgumentException("PartNumber", "Part number must be an integer between " + ObjectStorageProperties.MIN_PART_NUMBER
+              + " and " + ObjectStorageProperties.MAX_PART_NUMBER + ", inclusive");
+        }
+      } else {
+        throw new InvalidArgumentException("PartNumber", "Part number must be an integer between " + ObjectStorageProperties.MIN_PART_NUMBER + " and "
+            + ObjectStorageProperties.MAX_PART_NUMBER + ", inclusive");
+      }
+
+      final long maxObjectSize = srcObject.getSize();
+      long objectSize;
+      try {
+        final Tuple2<Long,Long> requestedSourceRange = request.copySourceRangeAsTuple();
+        if (requestedSourceRange == null) {
+          objectSize = maxObjectSize;
+        } else {
+          objectSize = requestedSourceRange._2() - requestedSourceRange._1();
+          if (objectSize < 0 || objectSize > maxObjectSize) {
+            throw new Exception("Invalid copy source range");
+          }
+        }
+      } catch (Exception e) {
+        LOG.error("Could not parse copy source range: " + request.getCopySourceRange(), e);
+        throw new InvalidArgumentException(request.getBucket() + "/" + request.getKey())
+            .withArgumentName("x-amz-copy-source-range");
+      }
+
+      ObjectEntity objectEntity;
+      try {
+        objectEntity = ObjectMetadataManagers.getInstance().lookupUpload(bucket, request.getKey(), request.getUploadId());
+      } catch (NoSuchEntityException | NoSuchElementException e) {
+        throw new NoSuchUploadException(request.getUploadId());
+      } catch (Exception e) {
+        throw new InternalErrorException("Error during upload lookup: " + request.getBucket() + "/" + request.getKey() + "?uploadId="
+            + request.getUploadId(), e);
+      }
+
+      // upload part hast to be authorize based on account that initiated upload
+      if (authorizationHandler.operationAllowed(request, bucket, objectEntity, objectSize)) {
+        // Check copy conditions
+        final String copyIfMatch = request.getCopySourceIfMatch();
+        if (copyIfMatch != null) {
+          if (!copyIfMatch.equals(srcObject.geteTag())) {
+            throw new PreconditionFailedException(sourceKey + " CopySourceIfMatch: " + copyIfMatch);
+          }
+        }
+
+        final String copyIfNoneMatch = request.getCopySourceIfNoneMatch();
+        if (copyIfNoneMatch != null) {
+          if (copyIfNoneMatch.equals(srcObject.geteTag())) {
+            throw new PreconditionFailedException(sourceKey + " CopySourceIfNoneMatch: " + copyIfNoneMatch);
+          }
+        }
+
+        final Date copyIfUnmodifiedSince = request.getCopySourceIfUnmodifiedSince();
+        if (copyIfUnmodifiedSince != null) {
+          if (copyIfUnmodifiedSince.getTime() < srcObject.getObjectModifiedTimestamp().getTime()) {
+            throw new PreconditionFailedException(sourceKey + " CopySourceIfUnmodifiedSince: " + copyIfUnmodifiedSince.toString());
+          }
+        }
+
+        final Date copyIfModifiedSince = request.getCopySourceIfModifiedSince();
+        if (copyIfModifiedSince != null) {
+          if (copyIfModifiedSince.getTime() > srcObject.getObjectModifiedTimestamp().getTime()) {
+            throw new PreconditionFailedException(sourceKey + " CopySourceIfModifiedSince: " + copyIfModifiedSince.toString());
+          }
+        }
+
+        PartEntity partEntity;
+        try {
+          partEntity = PartEntity.newInitializedForCreate(bucket, request.getKey(), request.getUploadId(), partNumber, objectSize, requestUser);
+        } catch (Exception e) {
+          LOG.error("Error initializing entity for persisting part metadata for " + request.getBucket() + "/" + request.getKey() + " uploadId: "
+              + request.getUploadId() + " partNumber: " + partNumber);
+          throw new InternalErrorException(request.getBucket() + "/" + request.getKey());
+        }
+
+        // Prep the request to be sent to the backend
+        request.setSourceObject(srcObject.getObjectUuid());
+        request.setSourceBucket(srcBucket.getBucketUuid());
+        request.setSourceVersionId(ObjectStorageProperties.NULL_VERSION_ID);
+
+        try {
+          PartEntity updatedEntity = OsgObjectFactory.getFactory().copyObjectPart(
+              ospClient,
+              objectEntity,
+              partEntity,
+              request,
+              requestUser);
+          final UploadPartCopyResponseType response = request.getReply();
+          response.setLastModified(updatedEntity.getObjectModifiedTimestamp());
+          response.setEtag(updatedEntity.geteTag());
+          response.setCopySourceVersionId(sourceVersionId != null ?
+              sourceVersionId :
+              (!srcObject.getVersionId().equals(ObjectStorageProperties.NULL_VERSION_ID) ?
+                  srcObject.getVersionId() :
+                  null));
+          setCorsInfo(request, response, bucket);
+          return response;
+        } catch (Exception e) {
+          // Wrap the error from back-end with a 500 error
+          LOG.warn("CorrelationId: " + Contexts.lookup().getCorrelationId() + " Responding to client with 500 InternalError because of:", e);
+          throw new InternalErrorException(partEntity.getResourceFullName(), e);
+        }
+      } else {
+        throw new AccessDeniedException(sourceBucket + "/" + sourceKey);
+      }
+    } else {
+      throw new AccessDeniedException(sourceBucket + "/" + sourceKey);
     }
   }
 

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageService.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageService.java
@@ -118,6 +118,8 @@ import com.eucalyptus.objectstorage.msgs.SetObjectAccessControlPolicyResponseTyp
 import com.eucalyptus.objectstorage.msgs.SetObjectAccessControlPolicyType;
 import com.eucalyptus.objectstorage.msgs.UpdateObjectStorageConfigurationResponseType;
 import com.eucalyptus.objectstorage.msgs.UpdateObjectStorageConfigurationType;
+import com.eucalyptus.objectstorage.msgs.UploadPartCopyResponseType;
+import com.eucalyptus.objectstorage.msgs.UploadPartCopyType;
 import com.eucalyptus.objectstorage.msgs.UploadPartResponseType;
 import com.eucalyptus.objectstorage.msgs.UploadPartType;
 import com.eucalyptus.util.EucalyptusCloudException;
@@ -183,6 +185,8 @@ public interface ObjectStorageService {
   InitiateMultipartUploadResponseType initiateMultipartUpload(InitiateMultipartUploadType request) throws S3Exception;
 
   UploadPartResponseType uploadPart(UploadPartType request) throws S3Exception;
+
+  UploadPartCopyResponseType uploadPartCopy(UploadPartCopyType request) throws S3Exception;
 
   CompleteMultipartUploadResponseType completeMultipartUpload(CompleteMultipartUploadType request) throws S3Exception;
 

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/binding/ObjectStoragePUTBinding.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/binding/ObjectStoragePUTBinding.java
@@ -70,9 +70,30 @@ public class ObjectStoragePUTBinding extends ObjectStorageRESTBinding {
 
     // Multipart Uploads
     .put(OBJECT + HttpMethod.PUT + ObjectParameter.partNumber.toString().toLowerCase()
-        + ObjectParameter.uploadId.toString().toLowerCase(), "UploadPart")
+        + ObjectParameter.uploadId.toString().toLowerCase() , "UploadPart")
     .put(OBJECT + HttpMethod.PUT + ObjectParameter.uploadId.toString().toLowerCase()
         + ObjectParameter.partNumber.toString().toLowerCase(), "UploadPart")
+
+    .put(OBJECT + HttpMethod.PUT + ObjectParameter.uploadId.toString().toLowerCase()
+        + ObjectParameter.partNumber.toString().toLowerCase() + ObjectStorageProperties.COPY_SOURCE,
+        "UploadPartCopy")
+    .put(OBJECT + HttpMethod.PUT + ObjectParameter.uploadId.toString().toLowerCase()
+        + ObjectStorageProperties.COPY_SOURCE + ObjectParameter.partNumber.toString().toLowerCase(),
+        "UploadPartCopy")
+    .put(OBJECT + HttpMethod.PUT + ObjectParameter.partNumber.toString().toLowerCase()
+        + ObjectParameter.uploadId.toString().toLowerCase() + ObjectStorageProperties.COPY_SOURCE,
+        "UploadPartCopy")
+    .put(OBJECT + HttpMethod.PUT + ObjectParameter.partNumber.toString().toLowerCase()
+        + ObjectStorageProperties.COPY_SOURCE + ObjectParameter.uploadId.toString().toLowerCase(),
+        "UploadPartCopy")
+    .put(OBJECT + HttpMethod.PUT + ObjectStorageProperties.COPY_SOURCE
+        + ObjectParameter.uploadId.toString().toLowerCase()
+        + ObjectParameter.partNumber.toString().toLowerCase(),
+        "UploadPartCopy")
+    .put(OBJECT + HttpMethod.PUT + ObjectStorageProperties.COPY_SOURCE
+        + ObjectParameter.partNumber.toString().toLowerCase()
+        + ObjectParameter.uploadId.toString().toLowerCase(),
+        "UploadPartCopy")
 
     .put(OBJECT + HttpMethod.POST + ObjectParameter.uploads.toString(), "InitiateMultipartUpload")
     .put(OBJECT + HttpMethod.POST + ObjectParameter.uploadId.toString().toLowerCase(), "CompleteMultipartUpload")

--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/handlers/ObjectStorageOutboundHandler.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/pipeline/handlers/ObjectStorageOutboundHandler.java
@@ -66,6 +66,7 @@ import com.eucalyptus.objectstorage.msgs.SetBucketPolicyResponseType;
 import com.eucalyptus.objectstorage.msgs.SetBucketTaggingResponseType;
 import com.eucalyptus.objectstorage.msgs.SetBucketVersioningStatusResponseType;
 import com.eucalyptus.objectstorage.msgs.SetObjectAccessControlPolicyResponseType;
+import com.eucalyptus.objectstorage.msgs.UploadPartCopyResponseType;
 import com.eucalyptus.objectstorage.msgs.UploadPartResponseType;
 import com.eucalyptus.objectstorage.util.ObjectStorageProperties;
 import com.eucalyptus.objectstorage.util.OSGUtil;
@@ -141,6 +142,10 @@ public class ObjectStorageOutboundHandler extends MessageStackHandler {
           httpResponse.addHeader("x-amz-version-id", copyResponse.getVersionId());
         if (copyResponse.getCopySourceVersionId() != null)
           httpResponse.addHeader("x-amz-copy-source-version-id", copyResponse.getCopySourceVersionId());
+      } else if (msg instanceof UploadPartCopyResponseType) {
+        UploadPartCopyResponseType uploadPartCopyResponse = (UploadPartCopyResponseType) msg;
+        if (uploadPartCopyResponse.getCopySourceVersionId() != null)
+          httpResponse.addHeader("x-amz-copy-source-version-id", uploadPartCopyResponse.getCopySourceVersionId());
       } else if (msg instanceof CreateBucketResponseType) {
         httpResponse.setStatus(HttpResponseStatus.OK);
         removeResponseBody(msg, httpResponse);

--- a/clc/modules/object-storage/src/test/java/com/eucalyptus/objectstorage/providers/InMemoryProvider.java
+++ b/clc/modules/object-storage/src/test/java/com/eucalyptus/objectstorage/providers/InMemoryProvider.java
@@ -111,6 +111,8 @@ import com.eucalyptus.objectstorage.msgs.SetBucketVersioningStatusResponseType;
 import com.eucalyptus.objectstorage.msgs.SetBucketVersioningStatusType;
 import com.eucalyptus.objectstorage.msgs.SetObjectAccessControlPolicyResponseType;
 import com.eucalyptus.objectstorage.msgs.SetObjectAccessControlPolicyType;
+import com.eucalyptus.objectstorage.msgs.UploadPartCopyResponseType;
+import com.eucalyptus.objectstorage.msgs.UploadPartCopyType;
 import com.eucalyptus.objectstorage.msgs.UploadPartResponseType;
 import com.eucalyptus.objectstorage.msgs.UploadPartType;
 import com.eucalyptus.objectstorage.util.ObjectStorageProperties;
@@ -805,6 +807,12 @@ public class InMemoryProvider implements ObjectStorageProviderClient {
         throw new InternalErrorException(e);
       }
     }
+  }
+
+  @Override
+  public UploadPartCopyResponseType uploadPartCopy(UploadPartCopyType request)
+      throws S3Exception {
+    throw new NotImplementedException();
   }
 
   @Override


### PR DESCRIPTION
Object storage gateway support for `UploadPartCopy` action. This allows use of multipart copy with the ceph provider.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=907
Deploy: /job/eucalyptus-internal-5-ado-ansible-deploy/223/
Test: /job/eucalyptus-5-qa-fast/166/

Demo is that when using ceph clients using multipart copy now work.

Fixes corymbia/eucalyptus#260