### PR TITLE
Use major rather than full version for compatibility

### DIFF
--- a/clc/modules/core/src/main/java/com/eucalyptus/bootstrap/BillOfMaterials.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/bootstrap/BillOfMaterials.java
@@ -198,6 +198,14 @@ public class BillOfMaterials {
     return RequiredFields.VERSION.getValue( );
   }
 
+  public static String getMajorVersion( ) {
+    final String version = getVersion();
+    final int dotIndex = version.indexOf('.');
+    return dotIndex > 0 ?
+        version.substring(0, dotIndex) :
+        version;
+  }
+
   public static String getExtraVersion( ) {
     return RequiredFields.EXTRA_VERSION.getValue( );
   }

--- a/clc/modules/core/src/main/java/com/eucalyptus/bootstrap/SystemIds.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/bootstrap/SystemIds.java
@@ -67,7 +67,7 @@ public class SystemIds {
   public static String createCloudUniqueName( String subName ) {
     return Joiner.on( "." ).join(
         Eucalyptus.class.getSimpleName( ),
-        BillOfMaterials.getVersion( ),
+        BillOfMaterials.getMajorVersion( ),
         subName,
         Signatures.SHA256withRSA.trySign( Eucalyptus.class, subName.getBytes( ) ) );
   }
@@ -76,7 +76,7 @@ public class SystemIds {
     try {
       return Joiner.on( "." ).join(
           Eucalyptus.class.getSimpleName( ),
-          BillOfMaterials.getVersion( ),
+          BillOfMaterials.getMajorVersion( ),
           subName,
           Digest.SHA256.digestHex( Signatures.SHA256withRSA.signBinary( Eucalyptus.class, subName.getBytes( ) ) ) );
     } catch ( Exception e ) {


### PR DESCRIPTION
The major version number is now used where necessary for compatibility between different minor versions in a deployment.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1014
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1016

Demo is that only the major version is used (from `cloud-debug.log`):

```
Thu Apr 1 22:46:36 2021  INFO [Hosts:main] Started membership channel Eucalyptus.6.membership.e2cf61dfe1c66d45d87c386b11dd4beacc504d942257c2c669e60eff3b4f74e0
```

Note `Eucalyptus.6.membership` not `Eucalyptus.6.0.0.membership`.