### PR TITLE
EC2 ModifyVolume modify size

### DIFF
--- a/clc/modules/block-storage-common/src/main/java/com/eucalyptus/blockstorage/msgs/ModifyStorageVolumeResponseType.java
+++ b/clc/modules/block-storage-common/src/main/java/com/eucalyptus/blockstorage/msgs/ModifyStorageVolumeResponseType.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.blockstorage.msgs;
+
+public class ModifyStorageVolumeResponseType extends StorageResponseType {
+}

--- a/clc/modules/block-storage-common/src/main/java/com/eucalyptus/blockstorage/msgs/ModifyStorageVolumeType.java
+++ b/clc/modules/block-storage-common/src/main/java/com/eucalyptus/blockstorage/msgs/ModifyStorageVolumeType.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.blockstorage.msgs;
+
+public class ModifyStorageVolumeType extends StorageRequestType {
+
+  private String volumeId;
+  private Integer size;
+
+  public ModifyStorageVolumeType() {
+  }
+
+  public ModifyStorageVolumeType(String volumeId, Integer size) {
+    this.volumeId = volumeId;
+    this.size = size;
+  }
+
+  public String getVolumeId() {
+    return volumeId;
+  }
+
+  public void setVolumeId(String volumeId) {
+    this.volumeId = volumeId;
+  }
+
+  public Integer getSize() {
+    return size;
+  }
+
+  public void setSize(Integer size) {
+    this.size = size;
+  }
+}

--- a/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/BlockStorageController.java
+++ b/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/BlockStorageController.java
@@ -63,7 +63,6 @@ import com.eucalyptus.blockstorage.async.ThreadPoolSizeUpdater;
 import com.eucalyptus.blockstorage.async.VolumeCreator;
 import com.eucalyptus.blockstorage.async.VolumeDeleter;
 import com.eucalyptus.blockstorage.async.VolumeStateChecker;
-import com.eucalyptus.blockstorage.async.VolumesConvertor;
 import com.eucalyptus.blockstorage.entities.BlockStorageGlobalConfiguration;
 import com.eucalyptus.blockstorage.entities.SnapshotInfo;
 import com.eucalyptus.blockstorage.entities.StorageInfo;
@@ -99,6 +98,8 @@ import com.eucalyptus.blockstorage.msgs.GetStorageVolumeResponseType;
 import com.eucalyptus.blockstorage.msgs.GetStorageVolumeType;
 import com.eucalyptus.blockstorage.msgs.GetVolumeTokenResponseType;
 import com.eucalyptus.blockstorage.msgs.GetVolumeTokenType;
+import com.eucalyptus.blockstorage.msgs.ModifyStorageVolumeResponseType;
+import com.eucalyptus.blockstorage.msgs.ModifyStorageVolumeType;
 import com.eucalyptus.blockstorage.msgs.StorageSnapshot;
 import com.eucalyptus.blockstorage.msgs.StorageVolume;
 import com.eucalyptus.blockstorage.msgs.UnexportVolumeResponseType;
@@ -124,6 +125,7 @@ import com.eucalyptus.util.EucalyptusCloudException;
 import com.eucalyptus.util.metrics.MonitoredAction;
 import com.eucalyptus.util.metrics.ThruputMetrics;
 import com.google.common.base.Function;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
@@ -685,6 +687,41 @@ public class BlockStorageController implements BlockStorageService {
   }
 
   /**
+   * Enforce volume size limits when they are enabled.
+   *
+   * @param volumeId The volume being created or modified
+   * @param requestedVolumeSize The total size of the volume post operation
+   * @param requestedCapacity The requested storage capacity increase
+   * @throws VolumeSizeExceededException if a limit is exceeded
+   */
+  private static void checkEnforceUsageLimits(
+      final String volumeId,
+      final int requestedVolumeSize,
+      final int requestedCapacity
+  ) throws VolumeSizeExceededException {
+    if (StorageProperties.shouldEnforceUsageLimits) {
+      int totalVolumeSize = 0;
+      VolumeInfo volInfo = new VolumeInfo();
+      try (TransactionResource tran = Entities.transactionFor(VolumeInfo.class)) {
+        List<VolumeInfo> volInfos = Entities.query(volInfo);
+        for (VolumeInfo vInfo : volInfos) {
+          if (!vInfo.getStatus().equals(StorageProperties.Status.failed.toString())
+              && !vInfo.getStatus().equals(StorageProperties.Status.deleted.toString())) {
+            totalVolumeSize += vInfo.getSize();
+          }
+        }
+        tran.commit();
+      }
+      if (((totalVolumeSize + requestedCapacity) > StorageInfo.getStorageInfo().getMaxTotalVolumeSizeInGb())) {
+        throw new VolumeSizeExceededException(volumeId, "Total Volume Size Limit Exceeded");
+      }
+      if (requestedVolumeSize > StorageInfo.getStorageInfo().getMaxVolumeSizeInGB()) {
+        throw new VolumeSizeExceededException(volumeId, "Max Volume Size Limit Exceeded");
+      }
+    }
+  }
+
+  /**
    * Checks to see if a new snapshot of size volSize will exceed the quota
    * 
    * @param volSize
@@ -1034,27 +1071,8 @@ public class BlockStorageController implements BlockStorageService {
     if (size != null && sizeAsInt <= 0) {
       throw new InvalidParameterValueException("The parameter size (" + sizeAsInt + ") must be greater than zero.");
     }
-    if (StorageProperties.shouldEnforceUsageLimits) {
-      if (size != null) {
-        int totalVolumeSize = 0;
-        VolumeInfo volInfo = new VolumeInfo();
-        try (TransactionResource tran = Entities.transactionFor(VolumeInfo.class)) {
-          List<VolumeInfo> volInfos = Entities.query(volInfo);
-          for (VolumeInfo vInfo : volInfos) {
-            if (!vInfo.getStatus().equals(StorageProperties.Status.failed.toString())
-                && !vInfo.getStatus().equals(StorageProperties.Status.deleted.toString())) {
-              totalVolumeSize += vInfo.getSize();
-            }
-          }
-          tran.commit();
-        }
-        if (((totalVolumeSize + sizeAsInt) > StorageInfo.getStorageInfo().getMaxTotalVolumeSizeInGb())) {
-          throw new VolumeSizeExceededException(volumeId, "Total Volume Size Limit Exceeded");
-        }
-        if (sizeAsInt > StorageInfo.getStorageInfo().getMaxVolumeSizeInGB()) {
-          throw new VolumeSizeExceededException(volumeId, "Max Volume Size Limit Exceeded");
-        }
-      }
+    if (size != null) {
+        checkEnforceUsageLimits(volumeId, sizeAsInt, sizeAsInt);
     }
 
     try (TransactionResource tran = Entities.transactionFor(VolumeInfo.class)) {
@@ -1123,6 +1141,62 @@ public class BlockStorageController implements BlockStorageService {
       throw new EucalyptusCloudException("Failed to add creation task for " + volumeId + " to asynchronous thread pool", e);
     }
 
+    return reply;
+  }
+
+  @Override
+  public ModifyStorageVolumeResponseType ModifyStorageVolume(ModifyStorageVolumeType request) throws EucalyptusCloudException {
+    final ModifyStorageVolumeResponseType reply = request.getReply();
+    reply.set_return(false);
+    if (!StorageProperties.enableStorage) {
+      LOG.error("BlockStorage has been disabled. Please check your setup");
+      return reply;
+    }
+    final String volumeId = MoreObjects.firstNonNull(request.getVolumeId(), "none");
+    final int size = MoreObjects.firstNonNull(request.getSize(), -1);
+    LOG.info("Processing ModifyStorageVolume request for volume " + volumeId);
+
+    final VolumeInfo volumeInfo = new VolumeInfo();
+    volumeInfo.setVolumeId(volumeId);
+    try (TransactionResource tran = Entities.transactionFor(VolumeInfo.class)) {
+      VolumeInfo foundVolume = Entities.uniqueResult(volumeInfo);
+
+      // enforce limits
+      if (size > foundVolume.getSize()) {
+        checkEnforceUsageLimits(volumeId, size, size - foundVolume.getSize());
+      }
+
+      // check its status
+      String status = foundVolume.getStatus();
+      if (status == null) {
+        throw new EucalyptusCloudException("Invalid volume status: null");
+      } else if (status.equals(StorageProperties.Status.available.toString())) {
+        if (size == -1 || size > foundVolume.getSize()) {
+          int newSize = blockManager.resizeVolume(foundVolume.getVolumeId(), size);
+          if (newSize > 0) {
+            foundVolume.setSize(newSize);
+          } else if (newSize == -1){
+            throw new EucalyptusCloudException("Size modification not supported");
+          }
+        }
+      } else if (status.equals(StorageProperties.Status.deleting.toString())
+          || status.equals(StorageProperties.Status.deleted.toString())
+          || status.equals(StorageProperties.Status.failed.toString())) {
+        throw new EucalyptusCloudException("Invalid volume status: " + status);
+      } else {
+        throw new EucalyptusCloudException("Cannot modify volume in state: " + status + ". Please retry later");
+      }
+      reply.set_return(true);
+      tran.commit();
+    } catch (NoSuchElementException e) {
+      LOG.warn("Got modify request, but unable to find volume in SC database: " + volumeId);
+    } catch (EucalyptusCloudException e) {
+      LOG.error("Error modifying volume " + volumeId + ": " + e.getMessage());
+      throw e;
+    } catch (final Throwable e) {
+      LOG.error("Exception looking up volume for modification: " + volumeId, e);
+      throw new EucalyptusCloudException(e);
+    }
     return reply;
   }
 

--- a/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/BlockStorageService.java
+++ b/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/BlockStorageService.java
@@ -55,6 +55,8 @@ import com.eucalyptus.blockstorage.msgs.GetStorageVolumeResponseType;
 import com.eucalyptus.blockstorage.msgs.GetStorageVolumeType;
 import com.eucalyptus.blockstorage.msgs.GetVolumeTokenResponseType;
 import com.eucalyptus.blockstorage.msgs.GetVolumeTokenType;
+import com.eucalyptus.blockstorage.msgs.ModifyStorageVolumeResponseType;
+import com.eucalyptus.blockstorage.msgs.ModifyStorageVolumeType;
 import com.eucalyptus.blockstorage.msgs.UnexportVolumeResponseType;
 import com.eucalyptus.blockstorage.msgs.UnexportVolumeType;
 import com.eucalyptus.blockstorage.msgs.UpdateStorageConfigurationResponseType;
@@ -93,6 +95,9 @@ public interface BlockStorageService {
       throws EucalyptusCloudException;
 
   CreateStorageVolumeResponseType CreateStorageVolume( CreateStorageVolumeType request )
+      throws EucalyptusCloudException;
+
+  ModifyStorageVolumeResponseType ModifyStorageVolume( ModifyStorageVolumeType request )
       throws EucalyptusCloudException;
 
   DescribeStorageVolumesResponseType DescribeStorageVolumes( DescribeStorageVolumesType request )

--- a/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/DASManager.java
+++ b/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/DASManager.java
@@ -429,6 +429,10 @@ public class DASManager implements LogicalStorageManager {
     }
   }
 
+  public int resizeVolume(String volumeId, int size) throws EucalyptusCloudException {
+    return -1;
+  }
+
   @Override
   public void cloneVolume(String volumeId, String parentVolumeId) throws EucalyptusCloudException {
     updateVolumeGroup();

--- a/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/LogicalStorageManager.java
+++ b/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/LogicalStorageManager.java
@@ -88,6 +88,8 @@ public interface LogicalStorageManager {
 
   public int createVolume(String volumeId, String snapshotId, int size) throws EucalyptusCloudException;
 
+  public int resizeVolume(String volumeId, int size) throws EucalyptusCloudException;
+
   public void cloneVolume(String volumeId, String parentVolumeId) throws EucalyptusCloudException;
 
   public void addSnapshot(String snapshotId) throws EucalyptusCloudException;

--- a/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/ceph/CephRbdAdapter.java
+++ b/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/ceph/CephRbdAdapter.java
@@ -63,6 +63,15 @@ public interface CephRbdAdapter {
   public String createImage(String imageName, long imageSize);
 
   /**
+   * Change the size of an existing RBD image
+   *
+   * @param imageName Name of the image to modify
+   * @param poolName Name of the pool to which the image belongs
+   * @param imageSize Desired size of the image in bytes
+   */
+  public void resizeImage(String imageName, String poolName, long imageSize);
+
+  /**
    * Delete RBD image
    * 
    * @param imageName Name of the image to be deleted

--- a/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/san/common/SANProvider.java
+++ b/clc/modules/block-storage/src/main/java/com/eucalyptus/blockstorage/san/common/SANProvider.java
@@ -106,6 +106,16 @@ public interface SANProvider {
   public String cloneVolume(String volumeId, String parentVolumeId, String parentVolumeIqn) throws EucalyptusCloudException;
 
   /**
+   * Change the size of a volume.
+   *
+   * @param volumeId The volume to change
+   * @param size The new size for the volume in gigabytes (-1 to get current size only)
+   * @return The current or updated size in gigabytes
+   * @throws EucalyptusCloudException If the volume resize fails
+   */
+  public int resizeVolume(String volumeId, String volumeIqn, int size) throws EucalyptusCloudException;
+
+  /**
    * Connect to the lun specified by the given iqn.
    * 
    * <p>

--- a/clc/modules/block-storage/src/test/java/com/eucalyptus/blockstorage/BlockStorageUnitTestSupport.java
+++ b/clc/modules/block-storage/src/test/java/com/eucalyptus/blockstorage/BlockStorageUnitTestSupport.java
@@ -322,6 +322,11 @@ public class BlockStorageUnitTestSupport {
       }
 
       @Override
+      public int resizeVolume(String volumeId, int size) throws EucalyptusCloudException {
+        return -1;
+      }
+
+      @Override
       public void cloneVolume(String volumeId, String parentVolumeId) throws EucalyptusCloudException {
 
       }

--- a/clc/modules/block-storage/src/test/java/com/eucalyptus/blockstorage/NoOpStorageManager.java
+++ b/clc/modules/block-storage/src/test/java/com/eucalyptus/blockstorage/NoOpStorageManager.java
@@ -122,6 +122,11 @@ public class NoOpStorageManager implements LogicalStorageManager {
   }
 
   @Override
+  public int resizeVolume(String volumeId, int size) throws EucalyptusCloudException {
+    return -1;
+  }
+
+  @Override
   public void cloneVolume(String volumeId, String parentVolumeId) throws EucalyptusCloudException {
     // TODO Auto-generated method stub
 

--- a/clc/modules/block-storage/src/test/java/com/eucalyptus/blockstorage/ProbabalisticFailureStorageManager.java
+++ b/clc/modules/block-storage/src/test/java/com/eucalyptus/blockstorage/ProbabalisticFailureStorageManager.java
@@ -111,6 +111,11 @@ public class ProbabalisticFailureStorageManager implements LogicalStorageManager
   }
 
   @Override
+  public int resizeVolume(String volumeId, int size) throws EucalyptusCloudException {
+    return -1;
+  }
+
+  @Override
   public void cloneVolume(String volumeId, String parentVolumeId) throws EucalyptusCloudException {
     // TODO Auto-generated method stub
 

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyVolumeType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifyVolumeType.java
@@ -8,7 +8,7 @@ package com.eucalyptus.compute.common;
 import javax.annotation.Nonnull;
 
 
-public class ModifyVolumeType extends ComputeMessage {
+public class ModifyVolumeType extends BlockVolumeMessage {
 
   private Integer iops;
   private Integer size;

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/backend/ModifyVolumeResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/backend/ModifyVolumeResponseType.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.compute.common.backend;
+
+public class ModifyVolumeResponseType extends com.eucalyptus.compute.common.ModifyVolumeResponseType implements ComputeBackendMessage {
+}

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/backend/ModifyVolumeType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/backend/ModifyVolumeType.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.compute.common.backend;
+
+public class ModifyVolumeType extends com.eucalyptus.compute.common.ModifyVolumeType implements ComputeBackendMessage {
+}

--- a/clc/modules/compute-common-msgs/src/main/resources/ec2-ebs-volumes-16-11-15.xml
+++ b/clc/modules/compute-common-msgs/src/main/resources/ec2-ebs-volumes-16-11-15.xml
@@ -224,23 +224,23 @@
 
   <mapping class="com.eucalyptus.compute.common.VolumeIdStringList" abstract="true">
     <collection field="member">
-      <value name="VolumeId" type="java.lang.String"/>
+      <value name="volumeId" type="java.lang.String"/>
     </collection>
   </mapping>
 
   <mapping class="com.eucalyptus.compute.common.VolumeModification" abstract="true">
-    <value name="EndTime" get-method="getEndTime" set-method="setEndTime" usage="optional"/>
-    <value name="ModificationState" get-method="getModificationState" set-method="setModificationState" usage="optional"/>
-    <value name="OriginalIops" get-method="getOriginalIops" set-method="setOriginalIops" usage="optional"/>
-    <value name="OriginalSize" get-method="getOriginalSize" set-method="setOriginalSize" usage="optional"/>
-    <value name="OriginalVolumeType" get-method="getOriginalVolumeType" set-method="setOriginalVolumeType" usage="optional"/>
-    <value name="Progress" get-method="getProgress" set-method="setProgress" usage="optional"/>
-    <value name="StartTime" get-method="getStartTime" set-method="setStartTime" usage="optional"/>
-    <value name="StatusMessage" get-method="getStatusMessage" set-method="setStatusMessage" usage="optional"/>
-    <value name="TargetIops" get-method="getTargetIops" set-method="setTargetIops" usage="optional"/>
-    <value name="TargetSize" get-method="getTargetSize" set-method="setTargetSize" usage="optional"/>
-    <value name="TargetVolumeType" get-method="getTargetVolumeType" set-method="setTargetVolumeType" usage="optional"/>
-    <value name="VolumeId" get-method="getVolumeId" set-method="setVolumeId" usage="optional"/>
+    <value name="endTime" get-method="getEndTime" set-method="setEndTime" usage="optional"/>
+    <value name="modificationState" get-method="getModificationState" set-method="setModificationState" usage="optional"/>
+    <value name="originalIops" get-method="getOriginalIops" set-method="setOriginalIops" usage="optional"/>
+    <value name="originalSize" get-method="getOriginalSize" set-method="setOriginalSize" usage="optional"/>
+    <value name="originalVolumeType" get-method="getOriginalVolumeType" set-method="setOriginalVolumeType" usage="optional"/>
+    <value name="progress" get-method="getProgress" set-method="setProgress" usage="optional"/>
+    <value name="startTime" get-method="getStartTime" set-method="setStartTime" usage="optional"/>
+    <value name="statusMessage" get-method="getStatusMessage" set-method="setStatusMessage" usage="optional"/>
+    <value name="targetIops" get-method="getTargetIops" set-method="setTargetIops" usage="optional"/>
+    <value name="targetSize" get-method="getTargetSize" set-method="setTargetSize" usage="optional"/>
+    <value name="targetVolumeType" get-method="getTargetVolumeType" set-method="setTargetVolumeType" usage="optional"/>
+    <value name="volumeId" get-method="getVolumeId" set-method="setVolumeId" usage="optional"/>
   </mapping>
 
   <mapping class="com.eucalyptus.compute.common.VolumeModificationList" abstract="true">
@@ -257,31 +257,31 @@
         <structure name="item" map-as="com.eucalyptus.compute.common.Filter" />
       </collection>
     </structure>
-    <value name="MaxResults" get-method="getMaxResults" set-method="setMaxResults" usage="optional"/>
-    <value name="NextToken" get-method="getNextToken" set-method="setNextToken" usage="optional"/>
-    <structure get-method="getVolumeIds" set-method="setVolumeIds" usage="optional" type="com.eucalyptus.compute.common.VolumeIdStringList" name="VolumeIds"/>
+    <value name="maxResults" get-method="getMaxResults" set-method="setMaxResults" usage="optional"/>
+    <value name="nextToken" get-method="getNextToken" set-method="setNextToken" usage="optional"/>
+    <structure get-method="getVolumeIds" set-method="setVolumeIds" usage="optional" type="com.eucalyptus.compute.common.VolumeIdStringList" name="volumeIds"/>
   </mapping>
 
   <mapping name="DescribeVolumesModificationsResponse" class="com.eucalyptus.compute.common.DescribeVolumesModificationsResponseType"
            extends="com.eucalyptus.compute.common.ComputeMessage">
     <structure map-as="com.eucalyptus.compute.common.ComputeMessage"/>
-    <value name="NextToken" get-method="getNextToken" set-method="setNextToken" usage="optional"/>
-    <structure get-method="getVolumesModifications" set-method="setVolumesModifications" usage="optional" type="com.eucalyptus.compute.common.VolumeModificationList" name="VolumesModifications"/>
+    <value name="nextToken" get-method="getNextToken" set-method="setNextToken" usage="optional"/>
+    <structure get-method="getVolumesModifications" set-method="setVolumesModifications" usage="optional" type="com.eucalyptus.compute.common.VolumeModificationList" name="volumeModificationSet"/>
   </mapping>
 
   <mapping name="ModifyVolume" class="com.eucalyptus.compute.common.ModifyVolumeType"
            extends="com.eucalyptus.compute.common.ComputeMessage">
     <structure map-as="com.eucalyptus.compute.common.ComputeMessage"/>
-    <value name="Iops" get-method="getIops" set-method="setIops" usage="optional"/>
-    <value name="Size" get-method="getSize" set-method="setSize" usage="optional"/>
-    <value name="VolumeId" get-method="getVolumeId" set-method="setVolumeId" usage="optional"/>
-    <value name="VolumeType" get-method="getVolumeType" set-method="setVolumeType" usage="optional"/>
+    <value name="iops" get-method="getIops" set-method="setIops" usage="optional"/>
+    <value name="size" get-method="getSize" set-method="setSize" usage="optional"/>
+    <value name="volumeId" get-method="getVolumeId" set-method="setVolumeId" usage="optional"/>
+    <value name="volumeType" get-method="getVolumeType" set-method="setVolumeType" usage="optional"/>
   </mapping>
 
   <mapping name="ModifyVolumeResponse" class="com.eucalyptus.compute.common.ModifyVolumeResponseType"
            extends="com.eucalyptus.compute.common.ComputeMessage">
     <structure map-as="com.eucalyptus.compute.common.ComputeMessage"/>
-    <structure get-method="getVolumeModification" set-method="setVolumeModification" usage="optional" type="com.eucalyptus.compute.common.VolumeModification" name="VolumeModification"/>
+    <structure get-method="getVolumeModification" set-method="setVolumeModification" usage="optional" type="com.eucalyptus.compute.common.VolumeModification" name="volumeModification"/>
   </mapping>
 
 </binding>

--- a/clc/modules/compute-service/src/main/java/com/eucalyptus/compute/service/ComputeService.java
+++ b/clc/modules/compute-service/src/main/java/com/eucalyptus/compute/service/ComputeService.java
@@ -2092,12 +2092,6 @@ public class ComputeService {
     return request.getReply( );
   }
 
-  public ModifyVolumeResponseType modifyVolume(
-      ModifyVolumeType request
-  ) {
-    return request.getReply( );
-  }
-
   public ModifyVpcEndpointConnectionNotificationResponseType modifyVpcEndpointConnectionNotification(
       ModifyVpcEndpointConnectionNotificationType request
   ) {


### PR DESCRIPTION
Initial support for EC2 modify volume action for increasing the size of a volume when using ceph storage.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1034
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1037

Demo of resize using ceph with cloud-in-a-box deployment:

```
#
# rbd --pool eucavolumes info  vol-f2a801e6f802d70f3
rbd image 'vol-f2a801e6f802d70f3':
	size 5 GiB in 1280 objects
	order 22 (4 MiB objects)
	snapshot_count: 0
	id: 111b61bc63be
	block_name_prefix: rbd_data.111b61bc63be
	format: 2
	features: layering
	op_features: 
	flags: 
	create_timestamp: Thu Apr  8 22:55:14 2021
	access_timestamp: Thu Apr  8 22:55:14 2021
	modify_timestamp: Thu Apr  8 22:55:14 2021
#
#
# aws ec2 modify-volume --volume-id vol-f2a801e6f802d70f3 --size 6
VOLUMEMODIFICATION	2021-04-08T22:59:23.865Z	completed	5	standard	2021-04-08T22:59:23.785Z	6	standard	vol-f2a801e6f802d70f3
#
#
# rbd --pool eucavolumes info  vol-f2a801e6f802d70f3
rbd image 'vol-f2a801e6f802d70f3':
	size 6 GiB in 1536 objects
	order 22 (4 MiB objects)
	snapshot_count: 0
	id: 111b61bc63be
	block_name_prefix: rbd_data.111b61bc63be
	format: 2
	features: layering
	op_features: 
	flags: 
	create_timestamp: Thu Apr  8 22:55:14 2021
	access_timestamp: Thu Apr  8 22:55:14 2021
	modify_timestamp: Thu Apr  8 22:55:14 2021
#
#
# aws ec2 modify-volume --volume-id vol-f2a801e6f802d70f3 --size 101

An error occurred (VolumeLimitExceeded) when calling the ModifyVolume operation: Max Volume Size Limit Exceeded volume: vol-f2a801e6f802d70f3
#
#
# aws ec2 modify-volume --volume-id vol-f2a801e6f802d70f3 --size 501

An error occurred (VolumeLimitExceeded) when calling the ModifyVolume operation: Total Volume Size Limit Exceeded volume: vol-f2a801e6f802d70f3
#
#
```

demo shows a successful resize for an `available` volume and that per-volume and total storage limits are enforced for modifications.

Relates to: corymbia/eucalytpus#267