### PR TITLE
S3 UploadPartCopy action, source end range inclusive

### DIFF
--- a/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageGateway.java
+++ b/clc/modules/object-storage/src/main/java/com/eucalyptus/objectstorage/ObjectStorageGateway.java
@@ -2704,8 +2704,8 @@ public class ObjectStorageGateway implements ObjectStorageService {
         if (requestedSourceRange == null) {
           objectSize = maxObjectSize;
         } else {
-          objectSize = requestedSourceRange._2() - requestedSourceRange._1();
-          if (objectSize < 0 || objectSize > maxObjectSize) {
+          objectSize = (requestedSourceRange._2() - requestedSourceRange._1()) + 1;
+          if (objectSize < 1 || objectSize > maxObjectSize) {
             throw new Exception("Invalid copy source range");
           }
         }


### PR DESCRIPTION
Update to corymbia/eucalyptus#261 fixing an error in the part size calculation. The object size was off by one byte for each copied part.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1139
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1140

For issue corymbia/eucalyptus#260