### PR TITLE
ELB https default policy for load balancer

### DIFF
--- a/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/workflow/LoadBalancingActivitiesImpl.java
+++ b/clc/modules/loadbalancing/src/main/java/com/eucalyptus/loadbalancing/workflow/LoadBalancingActivitiesImpl.java
@@ -1411,11 +1411,13 @@ public class LoadBalancingActivitiesImpl implements LoadBalancingActivities {
               attr.setAttributeName("Reference-Security-Policy");
               attr.setAttributeValue(LoadBalancerPolicyHelper.LATEST_SECURITY_POLICY_NAME);
               try {
-                LoadBalancerPolicyHelper.addLoadBalancerPolicy(
+                final LoadBalancerPolicyDescription policyDesc = LoadBalancerPolicyHelper.addLoadBalancerPolicy(
                     lb,
                     LoadBalancerPolicyHelper.LATEST_SECURITY_POLICY_NAME,
                     "SSLNegotiationPolicyType",
                     Lists.newArrayList(attr));
+                Entities.persist(policyDesc);
+                lb.getPolicyDescriptions().add(policyDesc);
               } catch (final LoadBalancingException ex) {
                 throw Exceptions.toUndeclared(ex);
               }


### PR DESCRIPTION
Fix regression in classic ELB functionality that prevents use of https listeners with a default ssl negotiation policy.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1227
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1228