### PR TITLE
AutoScaling ELBv2 target group support

### DIFF
--- a/clc/modules/autoscaling-backend/ivy.xml
+++ b/clc/modules/autoscaling-backend/ivy.xml
@@ -8,6 +8,7 @@
         <dependency name="eucalyptus-compute-common" rev="latest.integration"/>
         <dependency name="eucalyptus-cluster-common" rev="latest.integration"/>
         <dependency name="eucalyptus-loadbalancing-common" rev="latest.integration"/>
+        <dependency name="eucalyptus-loadbalancingv2-common" rev="latest.integration"/>
         <dependency name="eucalyptus-core" rev="latest.integration"/>
     </dependencies>
 </ivy-module>

--- a/clc/modules/autoscaling-backend/src/main/java/com/eucalyptus/autoscaling/activities/Elbv2Client.java
+++ b/clc/modules/autoscaling-backend/src/main/java/com/eucalyptus/autoscaling/activities/Elbv2Client.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.autoscaling.activities;
+
+import com.eucalyptus.auth.principal.AccountFullName;
+import com.eucalyptus.loadbalancingv2.common.Loadbalancingv2;
+import com.eucalyptus.loadbalancingv2.common.msgs.Loadbalancingv2Message;
+import com.eucalyptus.util.DispatchingClient;
+
+public class Elbv2Client extends DispatchingClient<Loadbalancingv2Message, Loadbalancingv2> {
+
+  Elbv2Client( final AccountFullName accountFullName ) {
+    super( accountFullName, Loadbalancingv2.class );
+  }
+}

--- a/clc/modules/autoscaling-backend/src/main/java/com/eucalyptus/autoscaling/backend/AutoScalingBackendService.java
+++ b/clc/modules/autoscaling-backend/src/main/java/com/eucalyptus/autoscaling/backend/AutoScalingBackendService.java
@@ -364,6 +364,7 @@ public class AutoScalingBackendService {
               Consumers.atomic( subnetsByZone ),
               request.availabilityZones(),
               request.loadBalancerNames(),
+              request.targetGroupArns(),
               subnetIds
           );
           verifyUnsupportedReferences( referenceErrors, request.getPlacementGroup( ) );
@@ -391,6 +392,7 @@ public class AutoScalingBackendService {
                   request.getHealthCheckType()==null ? null : HealthCheckType.valueOf( request.getHealthCheckType() ) )
               .withNewInstancesProtectedFromScaleIn( request.getNewInstancesProtectedFromScaleIn( ) )
               .withLoadBalancerNames( request.loadBalancerNames() )
+              .withTargetGroupArns( request.targetGroupArns() )
               .withTerminationPolicyTypes( request.terminationPolicies() == null ? null :
                   Collections2.filter( Collections2.transform(
                           request.terminationPolicies(), FUtils.valueOfFunction( TerminationPolicyType.class ) ),
@@ -985,6 +987,7 @@ public class AutoScalingBackendService {
                 Consumers.atomic( subnetsByZone ),
                 request.availabilityZones( ),
                 Collections.emptyList(), // load balancer names cannot be updated
+                Collections.emptyList(), // target group arns cannot be updated
                 subnetIds
             );
             verifyUnsupportedReferences( referenceErrors, request.getPlacementGroup() );

--- a/clc/modules/autoscaling-backend/src/test/java/com/eucalyptus/autoscaling/AutoScalingServiceTest.groovy
+++ b/clc/modules/autoscaling-backend/src/test/java/com/eucalyptus/autoscaling/AutoScalingServiceTest.groovy
@@ -864,6 +864,7 @@ class AutoScalingServiceTest {
                                        Consumer<? super Map<String,String>> availabilityZoneToSubnetMapConsumer,
                                        Iterable<String> availabilityZones,
                                        Iterable<String> loadBalancerNames,
+                                       Iterable<String> targetGroupArns,
                                        Iterable<String> subnetIds ) {
         if ( subnetIds?.iterator( )?.hasNext( ) ) {
           availabilityZoneToSubnetMapConsumer.accept( ImmutableMap.of( subnetIds.iterator().next(), 'zone-1' ) )

--- a/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/AutoScalingMessageValidation.java
+++ b/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/AutoScalingMessageValidation.java
@@ -114,6 +114,7 @@ public class AutoScalingMessageValidation {
 
     // ELB
     ELB_NAME( "(?s).{1,255}" ),
+    ELB_TARGETGROUPARN( "arn:aws:elasticloadbalancing:[!-~]{1,483}" ),
 
     // IAM
     IAM_NAME_OR_ARN( "[a-zA-Z0-9+=,.@-]{1,128}|arn:aws:iam:[!-~]{1,1588}" ),

--- a/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/internal/groups/AutoScalingGroup.java
+++ b/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/internal/groups/AutoScalingGroup.java
@@ -155,6 +155,13 @@ public class AutoScalingGroup extends AbstractOwnedPersistent implements AutoSca
   private List<String> loadBalancerNames = Lists.newArrayList();
 
   @ElementCollection
+  @CollectionTable( name = "metadata_auto_scaling_group_target_groups" )
+  @Column( name = "metadata_target_group_arn", length = 512 )
+  @JoinColumn( name = "metadata_auto_scaling_group_id" )
+  @OrderColumn( name = "metadata_target_group_index")
+  private List<String> targetGroupArns = Lists.newArrayList();
+
+  @ElementCollection
   @CollectionTable( name = "metadata_auto_scaling_group_suspended_processes" )
   @JoinColumn( name = "metadata_auto_scaling_group_id" )
   private Set<SuspendedProcess> suspendedProcesses = Sets.newHashSet();
@@ -319,6 +326,14 @@ public class AutoScalingGroup extends AbstractOwnedPersistent implements AutoSca
     this.loadBalancerNames = loadBalancerNames;
   }
 
+  public List<String> getTargetGroupArns() {
+    return targetGroupArns;
+  }
+
+  public void setTargetGroupArns(List<String> targetGroupArns) {
+    this.targetGroupArns = targetGroupArns;
+  }
+
   public Set<SuspendedProcess> getSuspendedProcesses() {
     return suspendedProcesses;
   }
@@ -475,6 +490,7 @@ public class AutoScalingGroup extends AbstractOwnedPersistent implements AutoSca
     private Map<String,String> subnetsByZone = Maps.newHashMap();
     private Set<TerminationPolicyType> terminationPolicies = Sets.newLinkedHashSet();
     private Set<String> loadBalancerNames = Sets.newLinkedHashSet();
+    private Set<String> targetGroupArns = Sets.newLinkedHashSet();
     private List<AutoScalingGroupTag> tags = Lists.newArrayList();
 
     BaseBuilder( final OwnerFullName ownerFullName,
@@ -544,6 +560,13 @@ public class AutoScalingGroup extends AbstractOwnedPersistent implements AutoSca
       return builder();
     }
 
+    public T withTargetGroupArns( final Iterable<String> targetGroupArns ) {
+      if ( targetGroupArns != null ) {
+        Iterables.addAll( this.targetGroupArns, targetGroupArns );
+      }
+      return builder();
+    }
+
     public T withTags( final Iterable<AutoScalingGroupTag> tags ) {
       if ( tags != null ) {
         Iterables.addAll( this.tags, tags );
@@ -565,6 +588,7 @@ public class AutoScalingGroup extends AbstractOwnedPersistent implements AutoSca
           Collections.singletonList(TerminationPolicyType.Default) :
           Lists.newArrayList( terminationPolicies ) );
       group.setLoadBalancerNames( Lists.newArrayList( loadBalancerNames ) );
+      group.setTargetGroupArns( Lists.newArrayList( targetGroupArns ) );
       group.setScalingRequired( group.getDesiredCapacity() > 0 );
       return group;
     }

--- a/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/internal/groups/AutoScalingGroupCoreView.java
+++ b/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/internal/groups/AutoScalingGroupCoreView.java
@@ -38,6 +38,7 @@ public class AutoScalingGroupCoreView extends AutoScalingGroupMinimumView {
 
   private final ImmutableList<String> availabilityZones;
   private final ImmutableList<String> loadBalancerNames;
+  private final ImmutableList<String> targetGroupArns;
   private final ImmutableList<GroupScalingCause> scalingCauses;
   private final ImmutableList<SuspendedProcess> suspendedProcesses;
 
@@ -45,6 +46,7 @@ public class AutoScalingGroupCoreView extends AutoScalingGroupMinimumView {
     super( group );
     this.availabilityZones = ImmutableList.copyOf( group.getAvailabilityZones() );
     this.loadBalancerNames = ImmutableList.copyOf( group.getLoadBalancerNames() );
+    this.targetGroupArns = ImmutableList.copyOf( group.getTargetGroupArns() );
     this.scalingCauses = ImmutableList.copyOf( group.getScalingCauses() );
     this.suspendedProcesses = ImmutableList.copyOf( group.getSuspendedProcesses() );
   }
@@ -63,5 +65,9 @@ public class AutoScalingGroupCoreView extends AutoScalingGroupMinimumView {
 
   public List<String> getLoadBalancerNames() {
     return loadBalancerNames;
+  }
+
+  public ImmutableList<String> getTargetGroupArns() {
+    return targetGroupArns;
   }
 }

--- a/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/internal/groups/AutoScalingGroups.java
+++ b/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/internal/groups/AutoScalingGroups.java
@@ -45,6 +45,7 @@ import com.eucalyptus.autoscaling.common.msgs.ProcessType;
 import com.eucalyptus.autoscaling.common.msgs.SuspendedProcessType;
 import com.eucalyptus.autoscaling.common.msgs.SuspendedProcesses;
 import com.eucalyptus.autoscaling.common.msgs.TagType;
+import com.eucalyptus.autoscaling.common.msgs.TargetGroupArns;
 import com.eucalyptus.autoscaling.common.msgs.TerminationPolicies;
 import com.eucalyptus.autoscaling.common.internal.configurations.LaunchConfiguration;
 import com.eucalyptus.autoscaling.common.internal.instances.AutoScalingInstance;
@@ -169,6 +170,7 @@ public abstract class AutoScalingGroups {
       type.setHealthCheckType( Strings.toString( group.getHealthCheckType() ) );
       type.setLaunchConfigurationName( AutoScalingMetadatas.toDisplayName().apply( group.getLaunchConfiguration() ) );
       type.setLoadBalancerNames( new LoadBalancerNames( group.getLoadBalancerNames() ) );
+      type.setTargetGroupArns( new TargetGroupArns( group.getTargetGroupArns() ) );
       type.setMaxSize( group.getMaxSize() );
       type.setMinSize( group.getMinSize() );
       type.setNewInstancesProtectedFromScaleIn( group.getNewInstancesProtectedFromScaleIn( ) );

--- a/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/msgs/AutoScalingGroupType.java
+++ b/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/msgs/AutoScalingGroupType.java
@@ -43,6 +43,7 @@ public class AutoScalingGroupType extends EucalyptusData {
   private Integer defaultCooldown;
   private AvailabilityZones availabilityZones;
   private LoadBalancerNames loadBalancerNames;
+  private TargetGroupArns targetGroupArns;
   private String healthCheckType;
   private Integer healthCheckGracePeriod;
   private Instances instances;
@@ -130,6 +131,14 @@ public class AutoScalingGroupType extends EucalyptusData {
 
   public void setLoadBalancerNames( LoadBalancerNames loadBalancerNames ) {
     this.loadBalancerNames = loadBalancerNames;
+  }
+
+  public TargetGroupArns getTargetGroupArns() {
+    return targetGroupArns;
+  }
+
+  public void setTargetGroupArns(TargetGroupArns targetGroupArns) {
+    this.targetGroupArns = targetGroupArns;
   }
 
   public String getHealthCheckType( ) {

--- a/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/msgs/CreateAutoScalingGroupType.java
+++ b/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/msgs/CreateAutoScalingGroupType.java
@@ -54,6 +54,8 @@ public class CreateAutoScalingGroupType extends AutoScalingMessage {
   private Integer defaultCooldown;
   private AvailabilityZones availabilityZones;
   private LoadBalancerNames loadBalancerNames;
+  @HttpParameterMapping( parameter = "TargetGroupARNs" )
+  private TargetGroupArns targetGroupArns;
   @AutoScalingMessageValidation.FieldRegex( AutoScalingMessageValidation.FieldRegexValue.HEALTH_CHECK )
   private String healthCheckType;
   @AutoScalingMessageValidation.FieldRange
@@ -75,6 +77,11 @@ public class CreateAutoScalingGroupType extends AutoScalingMessage {
   public Collection<String> loadBalancerNames( ) {
     final LoadBalancerNames names = loadBalancerNames;
     return ( names == null ? null : names.getMember( ) );
+  }
+
+  public Collection<String> targetGroupArns( ) {
+    final TargetGroupArns arns = targetGroupArns;
+    return ( arns == null ? null : arns.getMember( ) );
   }
 
   public Collection<String> terminationPolicies( ) {
@@ -170,6 +177,14 @@ public class CreateAutoScalingGroupType extends AutoScalingMessage {
 
   public void setLoadBalancerNames( LoadBalancerNames loadBalancerNames ) {
     this.loadBalancerNames = loadBalancerNames;
+  }
+
+  public TargetGroupArns getTargetGroupArns( ) {
+    return targetGroupArns;
+  }
+
+  public void setTargetGroupArns( TargetGroupArns targetGroupArns ) {
+    this.targetGroupArns = targetGroupArns;
   }
 
   public String getHealthCheckType( ) {

--- a/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/msgs/TargetGroupArns.java
+++ b/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/msgs/TargetGroupArns.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.autoscaling.common.msgs;
+
+import com.eucalyptus.autoscaling.common.AutoScalingMessageValidation;
+import com.eucalyptus.binding.HttpParameterMapping;
+import edu.ucsb.eucalyptus.msgs.EucalyptusData;
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class TargetGroupArns extends EucalyptusData {
+
+  @AutoScalingMessageValidation.FieldRegex( AutoScalingMessageValidation.FieldRegexValue.ELB_TARGETGROUPARN )
+  @HttpParameterMapping( parameter = "member" )
+  private ArrayList<String> member = new ArrayList<String>( );
+
+  public TargetGroupArns( ) {
+  }
+
+  public TargetGroupArns( Collection<String> arns ) {
+    if ( arns != null ) member.addAll( arns );
+  }
+
+  public ArrayList<String> getMember( ) {
+    return member;
+  }
+
+  public void setMember( ArrayList<String> member ) {
+    this.member = member;
+  }
+}

--- a/clc/modules/autoscaling-common/src/main/resources/autoscaling-binding.xml
+++ b/clc/modules/autoscaling-common/src/main/resources/autoscaling-binding.xml
@@ -129,6 +129,7 @@
     <value name="DefaultCooldown" field="defaultCooldown" usage="optional"/>
     <structure name="AvailabilityZones" field="availabilityZones" usage="required" type="com.eucalyptus.autoscaling.common.msgs.AvailabilityZones"/>
     <structure name="LoadBalancerNames" field="loadBalancerNames" usage="optional" type="com.eucalyptus.autoscaling.common.msgs.LoadBalancerNames"/>
+    <structure name="TargetGroupARNs" field="targetGroupArns" usage="optional" type="com.eucalyptus.autoscaling.common.msgs.TargetGroupArns"/>
     <value name="HealthCheckType" field="healthCheckType" usage="optional"/>
     <value name="HealthCheckGracePeriod" field="healthCheckGracePeriod" usage="optional"/>
     <value name="PlacementGroup" field="placementGroup" usage="optional"/>
@@ -491,6 +492,11 @@
       <value name="member" type="java.lang.String"/>
     </collection>
   </mapping>
+  <mapping class="com.eucalyptus.autoscaling.common.msgs.TargetGroupArns" abstract="true">
+    <collection field="member">
+      <value name="member" type="java.lang.String"/>
+    </collection>
+  </mapping>
   <mapping class="com.eucalyptus.autoscaling.common.msgs.TagType" abstract="true">
     <value name="ResourceId" field="resourceId" usage="optional"/>
     <value name="ResourceType" field="resourceType" usage="optional"/>
@@ -545,6 +551,7 @@
     <value name="DefaultCooldown" field="defaultCooldown" usage="required"/>
     <structure name="AvailabilityZones" field="availabilityZones" usage="required" type="com.eucalyptus.autoscaling.common.msgs.AvailabilityZones"/>
     <structure name="LoadBalancerNames" field="loadBalancerNames" usage="optional" type="com.eucalyptus.autoscaling.common.msgs.LoadBalancerNames"/>
+    <structure name="TargetGroupARNs" field="targetGroupArns" usage="optional" type="com.eucalyptus.autoscaling.common.msgs.TargetGroupArns"/>
     <value name="HealthCheckType" field="healthCheckType" usage="required"/>
     <value name="HealthCheckGracePeriod" field="healthCheckGracePeriod" usage="optional"/>
     <structure name="Instances" field="instances" usage="optional" type="com.eucalyptus.autoscaling.common.msgs.Instances"/>


### PR DESCRIPTION
AutoScaling update to support registration of instances against elbv2 target groups.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1254
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1255

Demo is that you can specify target groups for an autoscaling group on creation:

```
# aws autoscaling create-auto-scaling-group \
  --vpc-zone-identifier subnet-78e8d6246176f2db9 \
  --availability-zones cloud-1a \
  --min-size 0 \
  --max-size 1 \
  --desired-capacity 1 \
  --target-group-arns arn:aws:elasticloadbalancing::000377280103:targetgroup/target-group-1/e2ead7352dd826d2 \
  --launch-configuration-name config-1 \
  --auto-scaling-group-name group-1
```

and instances created for the group are then registered with the target group (load balancer):

```
# aws elbv2 describe-target-health --target-group-arn arn:aws:elasticloadbalancing::000377280103:targetgroup/target-group-1/e2ead7352dd826d2
TARGET	i-78941a5791f410c3d
TARGETHEALTH	Elb.InitialHealthChecking	initial
```

deregistration occurs when an instance is no longer required or the autoscaling group is forcefully deleted.