### PR TITLE
ELBv2 service filtering for describe actions

### DIFF
--- a/clc/modules/core/src/main/java/com/eucalyptus/ws/Handlers.java
+++ b/clc/modules/core/src/main/java/com/eucalyptus/ws/Handlers.java
@@ -673,6 +673,14 @@ public class Handlers {
     pipeline.addLast( "msg-component-check", new ComponentMessageCheckHandler( componentIdClass ) );
   }
 
+  public static void updateComponentHandlers( final Class<? extends ComponentId> componentIdClass,
+                                              final ChannelPipeline pipeline,
+                                              final String addAfter ) {
+    pipeline.remove( "msg-component-check" );
+    pipeline.addAfter( addAfter, "msg-component-check",
+        new ComponentMessageCheckHandler( componentIdClass ) );
+  }
+
   public static void addSystemHandlers( final ChannelPipeline pipeline ) {
     pipeline.addLast( "service-state-check", internalServiceStateHandler( ) );
     pipeline.addLast( "service-specific-mangling", ServiceHackeryHandler.INSTANCE );

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/TargetGroups.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/TargetGroups.java
@@ -22,12 +22,20 @@ import com.google.common.base.Predicate;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
+import org.hibernate.criterion.Criterion;
 
 public interface TargetGroups {
 
   <T> T lookupByName(
       @Nullable OwnerFullName ownerFullName,
       String name,
+      Predicate<? super TargetGroup> filter,
+      Function<? super TargetGroup, T> transform
+  ) throws Loadbalancingv2MetadataException;
+
+  <T> List<T> list(
+      @Nullable OwnerFullName ownerFullName,
+      Criterion criterion,
       Predicate<? super TargetGroup> filter,
       Function<? super TargetGroup, T> transform
   ) throws Loadbalancingv2MetadataException;

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/entities/TargetGroup.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/entities/TargetGroup.java
@@ -191,8 +191,8 @@ public class TargetGroup extends UserMetadata<TargetGroup.State> implements Load
     return group;
   }
 
-  public static TargetGroup named(final OwnerFullName userFullName, final String lbName) {
-    final TargetGroup example = new TargetGroup(null, lbName);
+  public static TargetGroup named(final OwnerFullName userFullName, final String name) {
+    final TargetGroup example = new TargetGroup(null, name);
     if (userFullName != null) {
       example.setOwnerAccountNumber(userFullName.getAccountNumber());
     }

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/ws/Loadbalancingv2QueryPipeline.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/ws/Loadbalancingv2QueryPipeline.java
@@ -65,11 +65,8 @@ public class Loadbalancingv2QueryPipeline extends QueryPipeline {
                 "loadbalancingv2-query-binding",
                 "loadbalancingv1-query-binding",
                 new LoadBalancingQueryBinding());
-            //TODO:STEVE: better api for this
-            ctx.getPipeline().remove("msg-component-check");
-            Handlers.addComponentHandlers(LoadBalancing.class, ctx.getPipeline());
-            final ChannelHandler componentCheck = ctx.getPipeline().remove("msg-component-check");
-            ctx.getPipeline().addAfter("loadbalancingv1-query-binding", "msg-component-check", componentCheck);
+            Handlers.updateComponentHandlers(
+                LoadBalancing.class, ctx.getPipeline(), "loadbalancingv1-query-binding");
           }
         }
       }


### PR DESCRIPTION
ELBv2 clean up for pipeline versions and implement filtering for existing describe actions.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1257
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1258

Demo, filtering load balancers:

```
# aws elbv2 describe-load-balancers --names balancer-1 --load-balancer-arns arn:aws:elasticloadbalancing::000377280103:loadbalancer/app/balancer-1/e9790ae22a5f9f2f
LOADBALANCERS	2021-05-18T20:49:18.509Z	balancer-1-000377280103.lb.qa64.eucalyptuscloud.net	ipv4	arn:aws:elasticloadbalancing::000377280103:loadbalancer/app/balancer-1/e9790ae22a5f9f2f	balancer-1	internet-facing	application	vpc-95838924301b6fbbc
AVAILABILITYZONES	subnet-78e8d6246176f2db9
SECURITYGROUPS	sg-6b42af7ed1739a6c4
STATE	active
```

filtering target groups:

```
aws elbv2 describe-target-groups --names target-group-1
TARGETGROUPS	30	80	HTTP	arn:aws:elasticloadbalancing::000377280103:targetgroup/target-group-1/e2ead7352dd826d2	target-group-1	vpc-95838924301b6fbbc
```

filtering target health:

```
# aws elbv2 describe-target-health --target-group-arn arn:aws:elasticloadbalancing::000377280103:targetgroup/target-group-1/e2ead7352dd826d2 --targets Id=i-78941a5791f410c3d Id=i-c505e9b142696a6c2
TARGET	i-78941a5791f410c3d
TARGETHEALTH	Elb.InitialHealthChecking	initial
TARGET	i-c505e9b142696a6c2
TARGETHEALTH	Elb.InitialHealthChecking	initial
```

Relates to corymbia/eucalyptus#271