### PR TITLE
ELBv2 https/tls listener server certificate

### DIFF
--- a/clc/modules/euare-common/src/main/java/com/eucalyptus/auth/euare/common/EuareApi.java
+++ b/clc/modules/euare-common/src/main/java/com/eucalyptus/auth/euare/common/EuareApi.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.auth.euare.common;
+
+import com.eucalyptus.auth.euare.common.msgs.GetServerCertificateResponseType;
+import com.eucalyptus.auth.euare.common.msgs.GetServerCertificateType;
+import com.eucalyptus.auth.euare.common.msgs.ListRolesResponseType;
+import com.eucalyptus.auth.euare.common.msgs.ListRolesType;
+import com.eucalyptus.auth.euare.common.msgs.ListServerCertificatesResponseType;
+import com.eucalyptus.auth.euare.common.msgs.ListServerCertificatesType;
+import com.eucalyptus.auth.euare.common.msgs.PutRolePolicyResponseType;
+import com.eucalyptus.auth.euare.common.msgs.PutRolePolicyType;
+import com.eucalyptus.component.annotation.ComponentPart;
+import com.eucalyptus.component.id.Euare;
+
+@ComponentPart(Euare.class)
+public interface EuareApi {
+
+  // API
+
+  GetServerCertificateResponseType getServerCertificate( GetServerCertificateType request );
+
+  ListRolesResponseType listRoles( ListRolesType request );
+
+  ListServerCertificatesResponseType listServerCertificates( ListServerCertificatesType request );
+
+  PutRolePolicyResponseType putRolePolicy( PutRolePolicyType request );
+
+  // Helpers
+
+  default GetServerCertificateResponseType getServerCertificate(final String name) {
+    final GetServerCertificateType request = new GetServerCertificateType();
+    request.setServerCertificateName(name);
+    return getServerCertificate(request);
+  }
+
+  default ListRolesResponseType listRoles() {
+    return listRoles(new ListRolesType());
+  }
+
+  default ListRolesResponseType listRoles(final String pathPrefix) {
+    final ListRolesType request = new ListRolesType();
+    request.setPathPrefix(pathPrefix);
+    return listRoles(request);
+  }
+
+  default ListServerCertificatesResponseType listServerCertificates() {
+    return listServerCertificates(new ListServerCertificatesType());
+  }
+
+  default PutRolePolicyResponseType putRolePolicy(
+      final String roleName,
+      final String policyName,
+      final String policyDocument
+  ) {
+    final PutRolePolicyType request = new PutRolePolicyType();
+    request.setRoleName(roleName);
+    request.setPolicyName(policyName);
+    request.setPolicyDocument(policyDocument);
+    return putRolePolicy(request);
+  }
+
+}

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/Loadbalancingv2Service.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/Loadbalancingv2Service.java
@@ -5,7 +5,10 @@
  */
 package com.eucalyptus.loadbalancingv2.service;
 
+import com.eucalyptus.auth.Accounts;
 import com.eucalyptus.auth.AuthQuotaException;
+import com.eucalyptus.auth.euare.common.EuareApi;
+import com.eucalyptus.auth.policy.ern.Ern;
 import com.eucalyptus.auth.principal.AccountFullName;
 import com.eucalyptus.auth.principal.OwnerFullName;
 import com.eucalyptus.component.annotation.ComponentNamed;
@@ -19,6 +22,7 @@ import com.eucalyptus.context.Context;
 import com.eucalyptus.context.Contexts;
 import com.eucalyptus.entities.Entities;
 import com.eucalyptus.entities.TransactionResource;
+import com.eucalyptus.loadbalancingv2.common.msgs.CertificateList;
 import com.eucalyptus.loadbalancingv2.common.msgs.Listeners;
 import com.eucalyptus.loadbalancingv2.common.msgs.Rules;
 import com.eucalyptus.loadbalancingv2.common.msgs.SubnetMapping;
@@ -118,6 +122,7 @@ import com.eucalyptus.util.TypeMappers;
 import com.eucalyptus.util.async.AsyncProxy;
 import com.google.common.base.Enums;
 import com.google.common.base.Functions;
+import com.google.common.base.Optional;
 import com.google.common.base.Predicates;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Lists;
@@ -130,6 +135,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import javax.inject.Inject;
 import org.apache.log4j.Logger;
 import org.hibernate.exception.ConstraintViolationException;
@@ -181,10 +187,34 @@ public class Loadbalancingv2Service {
     final Integer port = request.getPort();
     final Listener.Protocol protocol = request.getProtocol()==null ?
         null :
-        Enums.getIfPresent(Listener.Protocol.class, request.getProtocol()).orNull();
+        get(Enums.getIfPresent(Listener.Protocol.class, request.getProtocol()), protocolUnsupported());
+
+    final String certificateArn;
+    if (protocol != null && protocol.requiresCertificate()) {
+      CertificateList certificateList = request.getCertificates();
+      if (certificateList==null ||
+          certificateList.getMember().size()!=1 ||
+          certificateList.getMember().get(0).getCertificateArn()==null) {
+        throw new Loadbalancingv2ClientException("InvalidConfigurationRequest", "One certificate ARN required");
+      }
+      certificateArn = certificateList.getMember().get(0).getCertificateArn();
+    } else {
+      certificateArn = null;
+    }
 
     final com.eucalyptus.loadbalancingv2.common.msgs.Listener resultListener;
     try {
+      if (certificateArn != null) {
+        final Ern ern = get(() -> Ern.parse(certificateArn), invalidCertificateArn());
+        final String certificateAccount = ern.getAccount();
+        final String certificateName = Accounts.getNameFromFullName(ern.getResourceName());
+        if (!"iam:server-certificate".equals(ern.getResourceType()) || !ctx.getAccountNumber().equals(certificateAccount)) {
+          throw invalidCertificateArn().get();
+        }
+        final EuareApi euareApi = AsyncProxy.client(EuareApi.class);
+        get(() -> euareApi.getServerCertificate(certificateName), certificateNotFound());
+      }
+
       resultListener = loadBalancers.updateByExample(
           LoadBalancer.named(ownerFullName, arn.getName()),
           ownerFullName,
@@ -192,8 +222,10 @@ public class Loadbalancingv2Service {
           Loadbalancingv2Metadatas.filterPrivileged(),
           loadbalancer -> {
             final Listener listener = Listener.create(loadbalancer, port, protocol);
+            listener.setDefaultServerCertificateArn(certificateArn);
             listener.setDefaultActions(JsonEncoding.write(request.getDefaultActions()));
             loadbalancer.getListeners().add(listener);
+            loadbalancer.setUpdateRequired(true);
             return TypeMappers.transform(
                 listener, com.eucalyptus.loadbalancingv2.common.msgs.Listener.class);
           }
@@ -1010,8 +1042,39 @@ public class Loadbalancingv2Service {
     return () -> new Loadbalancingv2ClientException("InvalidTarget", "Target invalid");
   }
 
+  private static CompatSupplier<Loadbalancingv2ClientException> protocolUnsupported() {
+    return () -> new Loadbalancingv2ClientException("UnsupportedProtocol", "Protocol not supported");
+  }
+
+  private static CompatSupplier<Loadbalancingv2ClientException> certificateNotFound() {
+    return () -> new Loadbalancingv2ClientException("CertificateNotFound", "Certificate not found");
+  }
+
+  private static CompatSupplier<Loadbalancingv2ClientException> invalidCertificateArn() {
+    return () -> new Loadbalancingv2ClientException("InvalidConfigurationRequest", "Invalid certificate ARN");
+  }
+
   private static CompatSupplier<RuntimeException> runtime(CompatSupplier<? extends Exception> supplier) {
     return () -> Exceptions.toUndeclared(supplier.get());
+  }
+
+  private static <V, T extends Throwable> V get(final Optional<V> optionalValue, Supplier<T> thrown) throws T {
+    if (optionalValue == null || !optionalValue.isPresent()) {
+      throw thrown.get();
+    }
+    return optionalValue.get();
+  }
+
+  private static <V, T extends Throwable> V get(final Callable<V> callable, Supplier<T> thrown) throws T {
+    if (callable == null) {
+      throw thrown.get();
+    } else {
+      try {
+        return callable.call();
+      } catch (final Exception e) {
+        throw thrown.get();
+      }
+    }
   }
 
   /**

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/LoadBalancers.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/LoadBalancers.java
@@ -15,9 +15,14 @@ import com.eucalyptus.loadbalancingv2.common.msgs.AvailabilityZones;
 import com.eucalyptus.loadbalancingv2.common.msgs.LoadBalancerState;
 import com.eucalyptus.loadbalancingv2.common.msgs.SecurityGroups;
 import com.eucalyptus.loadbalancingv2.service.persist.entities.LoadBalancer;
+import com.eucalyptus.loadbalancingv2.service.persist.views.ImmutableListenerView;
+import com.eucalyptus.loadbalancingv2.service.persist.views.ImmutableLoadBalancerListenersView;
+import com.eucalyptus.loadbalancingv2.service.persist.views.ImmutableLoadBalancerView;
 import com.eucalyptus.loadbalancingv2.service.persist.views.ListenerRuleView;
 import com.eucalyptus.loadbalancingv2.service.persist.views.ListenerView;
+import com.eucalyptus.loadbalancingv2.service.persist.views.LoadBalancerListenersView;
 import com.eucalyptus.loadbalancingv2.service.persist.views.LoadBalancerView;
+import com.eucalyptus.util.CompatFunction;
 import com.eucalyptus.util.RestrictedTypes;
 import com.eucalyptus.util.TypeMapper;
 import com.google.common.base.Function;
@@ -31,6 +36,12 @@ import org.hibernate.criterion.Criterion;
 public interface LoadBalancers {
 
   long EXPIRY_AGE = 900_000L;
+
+  CompatFunction<LoadBalancer, LoadBalancerListenersView> LISTENERS_VIEW =
+      loadBalancer -> ImmutableLoadBalancerListenersView.builder()
+          .loadBalancer(ImmutableLoadBalancerView.copyOf(loadBalancer))
+          .listeners(Stream.ofAll(loadBalancer.getListeners()).map(ImmutableListenerView::copyOf))
+          .build();
 
   <T> T lookupByExample(
       LoadBalancer example,

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/entities/Listener.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/entities/Listener.java
@@ -35,12 +35,27 @@ public class Listener extends AbstractOwnedPersistent implements Loadbalancingv2
 
   public enum Protocol {
     HTTP,
-    HTTPS,
+    HTTPS(true),
     TCP,
-    TLS,
+    TLS(true),
     UDP,
     TCP_UDP,
     GENEVE,
+    ;
+
+    private final boolean requiresCertificate;
+
+    Protocol() {
+      this(false);
+    }
+
+    Protocol(final boolean requiresCertificate) {
+      this.requiresCertificate = requiresCertificate;
+    }
+
+    public boolean requiresCertificate() {
+      return requiresCertificate;
+    }
   }
 
   @ManyToOne
@@ -63,6 +78,9 @@ public class Listener extends AbstractOwnedPersistent implements Loadbalancingv2
   @Column(name = "protocol")
   @Enumerated(EnumType.STRING)
   private Protocol protocol;
+
+  @Column(name = "default_server_certificate_arn", length = 1024)
+  private String defaultServerCertificateArn;
 
   @Column(name = "ssl_policy")
   private String sslPolicy;
@@ -154,6 +172,14 @@ public class Listener extends AbstractOwnedPersistent implements Loadbalancingv2
   public void setProtocol(
       Protocol protocol) {
     this.protocol = protocol;
+  }
+
+  public String getDefaultServerCertificateArn() {
+    return defaultServerCertificateArn;
+  }
+
+  public void setDefaultServerCertificateArn(String defaultServerCertificateArn) {
+    this.defaultServerCertificateArn = defaultServerCertificateArn;
   }
 
   public String getSslPolicy() {

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/entities/LoadBalancer.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/entities/LoadBalancer.java
@@ -92,6 +92,9 @@ public class LoadBalancer extends UserMetadata<LoadBalancer.State>
     ipv4,
   }
 
+  @Column( name = "update_required" )
+  private Boolean updateRequired;
+
   @Column(name = "loadbalancer_type", nullable = false, updatable = false)
   @Enumerated(EnumType.STRING)
   private LoadBalancer.Type type;
@@ -142,6 +145,7 @@ public class LoadBalancer extends UserMetadata<LoadBalancer.State>
     LoadBalancer loadBalancer = new LoadBalancer(owner, displayName);
     loadBalancer.setNaturalId(Loadbalancingv2ResourceName.generateId());
     loadBalancer.setState(State.provisioning);
+    loadBalancer.setUpdateRequired(false);
     loadBalancer.setType(type);
     loadBalancer.setScheme(scheme);
     return loadBalancer;
@@ -162,13 +166,26 @@ public class LoadBalancer extends UserMetadata<LoadBalancer.State>
   }
 
   public static LoadBalancer exampleWithState(final LoadBalancer.State state) {
+    return exampleWithState(state, null);
+  }
+
+  public static LoadBalancer exampleWithState(final LoadBalancer.State state, final Boolean updateRequired) {
     final LoadBalancer example = new LoadBalancer();
     if (state != null) {
       example.setState(state);
       example.setLastState(null);
       example.setStateChangeStack(null);
     }
+    example.setUpdateRequired(updateRequired);
     return example;
+  }
+
+  public Boolean getUpdateRequired() {
+    return updateRequired;
+  }
+
+  public void setUpdateRequired(Boolean updateRequired) {
+    this.updateRequired = updateRequired;
   }
 
   public Type getType() {

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/views/ListenerView.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/views/ListenerView.java
@@ -9,6 +9,7 @@ import com.eucalyptus.loadbalancingv2.common.msgs.Actions;
 import com.eucalyptus.loadbalancingv2.service.persist.JsonEncoding;
 import com.eucalyptus.loadbalancingv2.service.persist.entities.Listener;
 import com.eucalyptus.loadbalancingv2.service.persist.entities.LoadBalancer;
+import javax.annotation.Nullable;
 import org.immutables.value.Value;
 
 
@@ -48,9 +49,13 @@ public interface ListenerView {
 
   Listener.Protocol getProtocol();
 
+  @Nullable
   String getSslPolicy();
 
   String getDefaultActions();
+
+  @Nullable
+  String getDefaultServerCertificateArn();
 
   default Actions getListenerDefaultActions() {
     return JsonEncoding.read(Actions.class, getDefaultActions()).getOrElse(Actions::new);

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/views/LoadBalancerListenersView.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/views/LoadBalancerListenersView.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.loadbalancingv2.service.persist.views;
+
+import java.util.List;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface LoadBalancerListenersView {
+
+  LoadBalancerView getLoadBalancer();
+
+  List<ListenerView> getListeners();
+}

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/views/LoadBalancerView.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/views/LoadBalancerView.java
@@ -31,6 +31,8 @@ public interface LoadBalancerView {
 
   Date getCreationTimestamp();
 
+  Date getLastUpdateTimestamp();
+
   LoadBalancer.Type getType();
 
   LoadBalancer.Scheme getScheme();

--- a/clc/modules/loadbalancingv2/src/main/resources/com/eucalyptus/loadbalancingv2/service/loadbalancer-app-zone.yaml
+++ b/clc/modules/loadbalancingv2/src/main/resources/com/eucalyptus/loadbalancingv2/service/loadbalancer-app-zone.yaml
@@ -18,6 +18,7 @@
 #
 # - Instance type
 # - SSH key name allowing debug connection to db instance
+# - Server certificate ARNs that the loadbalancer can use for HTTPS
 #
 AWSTemplateFormatVersion: 2010-09-09
 Description: Application LoadBalancer zone template
@@ -41,6 +42,11 @@ Parameters:
   SecurityGroupId:
     Description: The security group to use
     Type: String
+
+  ServerCertificateArns:
+    Description: The server certificates the loadbalancer is authorized to access
+    Type: List<String>
+    Default: ''
 
   SubnetId:
     Description: The subnet to use
@@ -79,11 +85,19 @@ Conditions:
       - !Ref KeyName
       - ''
 
+  UseServerCertificateArnsParameter: !Not
+    - !Equals
+      - !Join
+        - ''
+        - !Ref ServerCertificateArns
+      - ''
+
 Resources:
 
   Role:
     Type: AWS::IAM::Role
     Properties:
+      Path: !Sub /${ServoLoadBalancerId}/
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -111,10 +125,20 @@ Resources:
               - swf:RespondActivityTaskFailed
               - swf:RecordActivityTaskHeartbeat
             Resource: '*'
+          - Effect: !If
+              - UseServerCertificateArnsParameter
+              - Allow
+              - Deny
+            Action: iam:DownloadServerCertificate
+            Resource: !If
+              - UseServerCertificateArnsParameter
+              - !Ref ServerCertificateArns
+              - '*'
 
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
+      Path: !Sub /${ServoLoadBalancerId}/
       Roles:
         - !Ref Role
 
@@ -132,6 +156,7 @@ Resources:
         - !Ref SecurityGroupId
       UserData:
         Fn::Base64: !Sub |
+          euca-c2V0dXAtY3JlZGVudGlhbA==:3650
           #!/bin/bash
           # System generated Load Balancer Servo config
           mkdir -p /etc/load-balancer-servo/

--- a/clc/modules/loadbalancingv2/src/main/resources/com/eucalyptus/loadbalancingv2/service/loadbalancer-net-zone.yaml
+++ b/clc/modules/loadbalancingv2/src/main/resources/com/eucalyptus/loadbalancingv2/service/loadbalancer-net-zone.yaml
@@ -18,6 +18,7 @@
 #
 # - Instance type
 # - SSH key name allowing debug connection to db instance
+# - Server certificate ARNs that the loadbalancer can use for TLS
 #
 AWSTemplateFormatVersion: 2010-09-09
 Description: Network LoadBalancer zone template
@@ -41,6 +42,11 @@ Parameters:
   SecurityGroupId:
     Description: The security group to use
     Type: String
+
+  ServerCertificateArns:
+    Description: The server certificates the loadbalancer is authorized to access
+    Type: List<String>
+    Default: ''
 
   SubnetId:
     Description: The subnet to use
@@ -79,11 +85,19 @@ Conditions:
       - !Ref KeyName
       - ''
 
+  UseServerCertificateArnsParameter: !Not
+    - !Equals
+      - !Join
+        - ''
+        - !Ref ServerCertificateArns
+      - ''
+
 Resources:
 
   Role:
     Type: AWS::IAM::Role
     Properties:
+      Path: !Sub /${ServoLoadBalancerId}/
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -111,10 +125,20 @@ Resources:
               - swf:RespondActivityTaskFailed
               - swf:RecordActivityTaskHeartbeat
             Resource: '*'
+          - Effect: !If
+              - UseServerCertificateArnsParameter
+              - Allow
+              - Deny
+            Action: iam:DownloadServerCertificate
+            Resource: !If
+              - UseServerCertificateArnsParameter
+              - !Ref ServerCertificateArns
+              - '*'
 
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
+      Path: !Sub /${ServoLoadBalancerId}/
       Roles:
         - !Ref Role
 
@@ -132,6 +156,7 @@ Resources:
         - !Ref SecurityGroupId
       UserData:
         Fn::Base64: !Sub |
+          euca-c2V0dXAtY3JlZGVudGlhbA==:3650
           #!/bin/bash
           # System generated Load Balancer Servo config
           mkdir -p /etc/load-balancer-servo/


### PR DESCRIPTION
ELBv2 support for creation of listeners with a server certificate for https/tls.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1263
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1264

Demo:

```
# aws elbv2 create-listener \
  --load-balancer-arn arn:aws:elasticloadbalancing::000186855777:loadbalancer/app/balancer-1/932cbc625b79bb3e \
  --port 443 \
  --protocol HTTPS \
  --certificates CertificateArn=arn:aws:iam::000186855777:server-certificate/1ab13b3f-f5f9-0/1ab13b3f-f5f9-elb \
  --default-actions Type=forward,TargetGroupArn=arn:aws:elasticloadbalancing::000186855777:targetgroup/target-group-1/b2589b768b605043
```

Relates to corymbia/eucalyptus#271