### PR TITLE
CloudFormation IAM maximum identifier lengths (master)

### DIFF
--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMGroupResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMGroupResourceAction.java
@@ -120,7 +120,7 @@ public class AWSIAMGroupResourceAction extends StepBasedResourceAction {
       public ResourceAction perform(ResourceAction resourceAction) throws Exception {
         AWSIAMGroupResourceAction action = (AWSIAMGroupResourceAction) resourceAction;
         ServiceConfiguration configuration = Topology.lookup(Euare.class);
-        String groupName = action.properties.getGroupName() != null ? action.properties.getGroupName() : action.getDefaultPhysicalResourceId();
+        String groupName = action.properties.getGroupName() != null ? action.properties.getGroupName() : action.getDefaultPhysicalResourceId(128);
         CreateGroupType createGroupType = MessageHelper.createMessage(CreateGroupType.class, action.info.getEffectiveUserId());
         createGroupType.setGroupName(groupName);
         createGroupType.setPath(MoreObjects.firstNonNull(action.properties.getPath(), DEFAULT_PATH));

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMInstanceProfileResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMInstanceProfileResourceAction.java
@@ -109,7 +109,7 @@ public class AWSIAMInstanceProfileResourceAction extends StepBasedResourceAction
         ServiceConfiguration configuration = Topology.lookup(Euare.class);
         String instanceProfileName = action.properties.getInstanceProfileName() != null ?
             action.properties.getInstanceProfileName() :
-            action.getDefaultPhysicalResourceId();
+            action.getDefaultPhysicalResourceId(128);
         CreateInstanceProfileType createInstanceProfileType = MessageHelper.createMessage(CreateInstanceProfileType.class, action.info.getEffectiveUserId());
         createInstanceProfileType.setPath(MoreObjects.firstNonNull(action.properties.getPath(), DEFAULT_PATH));
         createInstanceProfileType.setInstanceProfileName(instanceProfileName);

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMManagedPolicyResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMManagedPolicyResourceAction.java
@@ -130,7 +130,7 @@ public class AWSIAMManagedPolicyResourceAction extends StepBasedResourceAction {
       public ResourceAction perform(ResourceAction resourceAction) throws Exception {
         AWSIAMManagedPolicyResourceAction action = (AWSIAMManagedPolicyResourceAction) resourceAction;
         ServiceConfiguration configuration = Topology.lookup(Euare.class);
-        String policyName = action.properties.getManagedPolicyName() != null ? action.properties.getManagedPolicyName() : action.getDefaultPhysicalResourceId();
+        String policyName = action.properties.getManagedPolicyName() != null ? action.properties.getManagedPolicyName() : action.getDefaultPhysicalResourceId(128);
         CreatePolicyType createPolicyType = MessageHelper.createMessage(CreatePolicyType.class, action.info.getEffectiveUserId());
         if (action.properties.getDescription() != null) {
           createPolicyType.setDescription(action.properties.getDescription());

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMPolicyResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMPolicyResourceAction.java
@@ -108,7 +108,7 @@ public class AWSIAMPolicyResourceAction extends StepBasedResourceAction {
         AWSIAMPolicyResourceAction action = (AWSIAMPolicyResourceAction) resourceAction;
         ServiceConfiguration configuration = Topology.lookup(Euare.class);
         // just get fields
-        action.info.setPhysicalResourceId(action.getDefaultPhysicalResourceId());
+        action.info.setPhysicalResourceId(action.getDefaultPhysicalResourceId(128));
         action.info.setCreatedEnoughToDelete(true);
         action.info.setReferenceValueJson(JsonHelper.getStringFromJsonNode(new TextNode(action.info.getPhysicalResourceId())));
         return action;

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMRoleResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMRoleResourceAction.java
@@ -120,7 +120,7 @@ public class AWSIAMRoleResourceAction extends StepBasedResourceAction {
       public ResourceAction perform(ResourceAction resourceAction) throws Exception {
         AWSIAMRoleResourceAction action = (AWSIAMRoleResourceAction) resourceAction;
         ServiceConfiguration configuration = Topology.lookup(Euare.class);
-        String roleName = action.properties.getRoleName() != null ? action.properties.getRoleName() : action.getDefaultPhysicalResourceId();
+        String roleName = action.properties.getRoleName() != null ? action.properties.getRoleName() : action.getDefaultPhysicalResourceId(64);
         CreateRoleType createRoleType = MessageHelper.createMessage(CreateRoleType.class, action.info.getEffectiveUserId());
         createRoleType.setRoleName(roleName);
         createRoleType.setPath(action.properties.getPath());

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMUserResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSIAMUserResourceAction.java
@@ -142,7 +142,7 @@ public class AWSIAMUserResourceAction extends StepBasedResourceAction {
       public ResourceAction perform(ResourceAction resourceAction) throws Exception {
         AWSIAMUserResourceAction action = (AWSIAMUserResourceAction) resourceAction;
         ServiceConfiguration configuration = Topology.lookup(Euare.class);
-        String userName = action.properties.getUserName() != null ? action.properties.getUserName() : action.getDefaultPhysicalResourceId();
+        String userName = action.properties.getUserName() != null ? action.properties.getUserName() : action.getDefaultPhysicalResourceId(64);
         CreateUserType createUserType = MessageHelper.createMessage(CreateUserType.class, action.info.getEffectiveUserId());
         createUserType.setUserName(userName);
         createUserType.setPath(MoreObjects.firstNonNull(action.properties.getPath(), DEFAULT_PATH));


### PR DESCRIPTION
Merge to master for 5.2 fix.

> CloudFormation IAM names now limited to the maximum length permitted for each resource type.

Relates to corymbia/eucalyptus#293