### PR TITLE
CloudFormation support for elbv2

### DIFF
--- a/clc/modules/cloudformation/ivy.xml
+++ b/clc/modules/cloudformation/ivy.xml
@@ -37,6 +37,7 @@
         <dependency name="eucalyptus-cloudwatch-common" rev="latest.integration"/>
         <dependency name="eucalyptus-autoscaling-common" rev="latest.integration"/>
         <dependency name="eucalyptus-loadbalancing-common" rev="latest.integration"/>
+        <dependency name="eucalyptus-loadbalancingv2-common" rev="latest.integration"/>
         <dependency name="eucalyptus-object-storage-common" rev="latest.integration"/>
         <dependency name="eucalyptus-rds-common" rev="latest.integration"/>
         <dependency name="eucalyptus-route53-common" rev="latest.integration"/>

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSAutoScalingAutoScalingGroupResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSAutoScalingAutoScalingGroupResourceAction.java
@@ -59,6 +59,7 @@ import com.eucalyptus.autoscaling.common.msgs.SuspendedProcessType;
 import com.eucalyptus.autoscaling.common.msgs.TagDescription;
 import com.eucalyptus.autoscaling.common.msgs.TagType;
 import com.eucalyptus.autoscaling.common.msgs.Tags;
+import com.eucalyptus.autoscaling.common.msgs.TargetGroupArns;
 import com.eucalyptus.autoscaling.common.msgs.TerminateInstanceInAutoScalingGroupType;
 import com.eucalyptus.autoscaling.common.msgs.TerminationPolicies;
 import com.eucalyptus.autoscaling.common.msgs.UpdateAutoScalingGroupType;
@@ -225,6 +226,9 @@ public class AWSAutoScalingAutoScalingGroupResourceAction extends StepBasedResou
     if (!Objects.equals(properties.getLoadBalancerNames(), otherAction.properties.getLoadBalancerNames())) {
       updateType = UpdateType.max(updateType, UpdateType.NEEDS_REPLACEMENT);
     }
+    if (!Objects.equals(properties.getTargetGroupArns(), otherAction.properties.getTargetGroupArns())) {
+      updateType = UpdateType.max(updateType, UpdateType.NEEDS_REPLACEMENT);
+    }
     if (!Objects.equals(properties.getMaxSize(), otherAction.properties.getMaxSize())) {
       updateType = UpdateType.max(updateType, UpdateType.NO_INTERRUPTION);
     }
@@ -269,8 +273,11 @@ public class AWSAutoScalingAutoScalingGroupResourceAction extends StepBasedResou
         createAutoScalingGroupType.setHealthCheckGracePeriod(action.properties.getHealthCheckGracePeriod());
         createAutoScalingGroupType.setHealthCheckType(action.properties.getHealthCheckType());
         createAutoScalingGroupType.setLaunchConfigurationName(action.properties.getLaunchConfigurationName());
-        if (action.properties.getLoadBalancerNames() != null) {
+        if (action.properties.getLoadBalancerNames() != null && !action.properties.getLoadBalancerNames().isEmpty()) {
           createAutoScalingGroupType.setLoadBalancerNames(new LoadBalancerNames(action.properties.getLoadBalancerNames()));
+        }
+        if (action.properties.getTargetGroupArns() != null && !action.properties.getTargetGroupArns().isEmpty()) {
+          createAutoScalingGroupType.setTargetGroupArns(new TargetGroupArns(action.properties.getTargetGroupArns()));
         }
         createAutoScalingGroupType.setMaxSize(0);
         createAutoScalingGroupType.setMinSize(0);

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSElasticLoadBalancingV2ListenerResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSElasticLoadBalancingV2ListenerResourceAction.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.cloudformation.resources.standard.actions;
+
+import com.eucalyptus.cloudformation.ValidationErrorException;
+import com.eucalyptus.cloudformation.resources.ResourceAction;
+import com.eucalyptus.cloudformation.resources.ResourceInfo;
+import com.eucalyptus.cloudformation.resources.ResourceProperties;
+import com.eucalyptus.cloudformation.resources.standard.info.AWSElasticLoadBalancingV2ListenerResourceInfo;
+import com.eucalyptus.cloudformation.resources.standard.propertytypes.AWSElasticLoadBalancingV2ListenerProperties;
+import com.eucalyptus.cloudformation.resources.standard.propertytypes.ElasticLoadBalancingV2CertificateProperties;
+import com.eucalyptus.cloudformation.template.JsonHelper;
+import com.eucalyptus.cloudformation.util.MessageHelper;
+import com.eucalyptus.cloudformation.workflow.steps.Step;
+import com.eucalyptus.cloudformation.workflow.steps.StepBasedResourceAction;
+import com.eucalyptus.cloudformation.workflow.updateinfo.UpdateType;
+import com.eucalyptus.loadbalancingv2.common.Loadbalancingv2Api;
+import com.eucalyptus.loadbalancingv2.common.msgs.Action;
+import com.eucalyptus.loadbalancingv2.common.msgs.Actions;
+import com.eucalyptus.loadbalancingv2.common.msgs.Certificate;
+import com.eucalyptus.loadbalancingv2.common.msgs.CertificateList;
+import com.eucalyptus.loadbalancingv2.common.msgs.CreateListenerResponseType;
+import com.eucalyptus.loadbalancingv2.common.msgs.CreateListenerType;
+import com.eucalyptus.loadbalancingv2.common.msgs.DeleteListenerType;
+import com.eucalyptus.loadbalancingv2.common.msgs.Listener;
+import com.eucalyptus.util.async.AsyncExceptions;
+import com.eucalyptus.util.async.AsyncProxy;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.collect.ImmutableSet;
+import io.vavr.collection.Stream;
+import java.util.Set;
+import java.util.function.Function;
+import org.apache.log4j.Logger;
+
+public class AWSElasticLoadBalancingV2ListenerResourceAction extends StepBasedResourceAction {
+
+  public static final Logger LOG = Logger.getLogger(AWSElasticLoadBalancingV2ListenerResourceAction.class);
+
+  private static final Set<Function<AWSElasticLoadBalancingV2ListenerProperties,Object>>
+      PROP_REPLACE =
+      ImmutableSet.<Function<AWSElasticLoadBalancingV2ListenerProperties,Object>>builder()
+          .add(AWSElasticLoadBalancingV2ListenerProperties::getAlpnPolicy)
+          .add(AWSElasticLoadBalancingV2ListenerProperties::getDefaultActions)
+          .add(AWSElasticLoadBalancingV2ListenerProperties::getLoadBalancerArn)
+          .add(AWSElasticLoadBalancingV2ListenerProperties::getPort)
+          .add(AWSElasticLoadBalancingV2ListenerProperties::getProtocol)
+          .add(AWSElasticLoadBalancingV2ListenerProperties::getSslPolicy)
+          .build();
+
+  private static final Set<Function<AWSElasticLoadBalancingV2ListenerProperties,Object>> PROP_SOMEINTER =
+      ImmutableSet.<Function<AWSElasticLoadBalancingV2ListenerProperties,Object>>builder()
+          .build();
+
+  private static final Set<Function<AWSElasticLoadBalancingV2ListenerProperties,Object>> PROP_NOINTER =
+      ImmutableSet.<Function<AWSElasticLoadBalancingV2ListenerProperties,Object>>builder()
+          .build();
+
+  private AWSElasticLoadBalancingV2ListenerProperties properties = new AWSElasticLoadBalancingV2ListenerProperties();
+  private AWSElasticLoadBalancingV2ListenerResourceInfo info = new AWSElasticLoadBalancingV2ListenerResourceInfo();
+
+  public AWSElasticLoadBalancingV2ListenerResourceAction() {
+    super(fromEnum(CreateSteps.class), fromEnum(DeleteSteps.class), null, null );
+  }
+
+  @Override
+  public ResourceProperties getResourceProperties() {
+    return properties;
+  }
+
+  @Override
+  public void setResourceProperties(ResourceProperties resourceProperties) {
+    properties = (AWSElasticLoadBalancingV2ListenerProperties) resourceProperties;
+  }
+
+  @Override
+  public ResourceInfo getResourceInfo() {
+    return info;
+  }
+
+  @Override
+  public void setResourceInfo(ResourceInfo resourceInfo) {
+    info = (AWSElasticLoadBalancingV2ListenerResourceInfo) resourceInfo;
+  }
+
+  @Override
+  public UpdateType getUpdateType(ResourceAction resourceAction, boolean stackTagsChanged) {
+    final AWSElasticLoadBalancingV2ListenerResourceAction otherAction =
+        (AWSElasticLoadBalancingV2ListenerResourceAction) resourceAction;
+    return defaultUpdateType(
+        stackTagsChanged,
+        properties,
+        otherAction.properties,
+        PROP_REPLACE,
+        PROP_SOMEINTER,
+        PROP_NOINTER);
+  }
+
+  private enum CreateSteps implements Step {
+    CREATE_LISTENER {
+      @Override
+      public ResourceAction perform(ResourceAction resourceAction) throws Exception {
+        final AWSElasticLoadBalancingV2ListenerResourceAction action =
+            (AWSElasticLoadBalancingV2ListenerResourceAction) resourceAction;
+        final Loadbalancingv2Api elbv2 = AsyncProxy.client(
+            Loadbalancingv2Api.class, MessageHelper.userIdentity(action.info.getEffectiveUserId()));
+        final CreateListenerType createListener = new CreateListenerType();
+        createListener.setLoadBalancerArn(action.properties.getLoadBalancerArn());
+        createListener.setPort(action.properties.getPort());
+        createListener.setProtocol(action.properties.getProtocol());
+        final Actions actions = new Actions();
+        action.properties.getDefaultActions().forEach( elbAction -> {
+          //TODO:STEVE: full action suppport
+          final Action listenerAction = new Action();
+          listenerAction.setTargetGroupArn(elbAction.getTargetGroupArn());
+          listenerAction.setType(elbAction.getType());
+          actions.getMember().add(listenerAction);
+        });
+        createListener.setDefaultActions(actions);
+        if ("HTTPS".equals(action.properties.getProtocol()) || "TLS".equals(action.properties.getProtocol())) {
+          createListener.setSslPolicy(action.properties.getSslPolicy());
+          final String certificateArn = Stream.ofAll(action.properties.getCertificates()).headOption()
+              .map(ElasticLoadBalancingV2CertificateProperties::getCertificateArn).getOrNull();
+          if (certificateArn == null) {
+            throw new ValidationErrorException("Certificate required for HTTPS/TLS listener");
+          }
+          final CertificateList certificateList = new CertificateList();
+          final Certificate certificate = new Certificate();
+          certificate.setCertificateArn(certificateArn);
+          certificateList.getMember().add(certificate);
+          createListener.setCertificates(certificateList);
+        }
+        final CreateListenerResponseType createResponse = elbv2.createListener(createListener);
+        final Listener listener =
+            createResponse.getCreateListenerResult().getListeners().getMember().get(0);
+        action.info.setPhysicalResourceId(listener.getListenerArn());
+        action.info.setCreatedEnoughToDelete(true);
+        action.info.setListenerArn(JsonHelper.getStringFromJsonNode(new TextNode(listener.getListenerArn())));
+        action.info.setReferenceValueJson(JsonHelper.getStringFromJsonNode(new TextNode(action.info.getPhysicalResourceId())));
+        return action;
+      }
+    }
+  }
+
+  private enum DeleteSteps implements Step {
+    DELETE_LISTENER {
+      @Override
+      public ResourceAction perform(ResourceAction resourceAction) throws Exception {
+        final AWSElasticLoadBalancingV2ListenerResourceAction action =
+            (AWSElasticLoadBalancingV2ListenerResourceAction) resourceAction;
+        if (!Boolean.TRUE.equals(action.info.getCreatedEnoughToDelete())) return action;
+        final Loadbalancingv2Api elbv2 = AsyncProxy.client(
+            Loadbalancingv2Api.class, MessageHelper.userIdentity(action.info.getEffectiveUserId()));
+        final DeleteListenerType deleteListener = new DeleteListenerType();
+        deleteListener.setListenerArn(action.info.getPhysicalResourceId());
+        try {
+          elbv2.deleteListener(deleteListener);
+        } catch (final Exception e) {
+          if (!AsyncExceptions.isWebServiceErrorCode(e, "ListenerNotFound")) {
+            throw e;
+          }
+        }
+        return action;
+      }
+    }
+  }  
+}

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSElasticLoadBalancingV2LoadBalancerResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSElasticLoadBalancingV2LoadBalancerResourceAction.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.cloudformation.resources.standard.actions;
+
+import com.eucalyptus.cloudformation.resources.ResourceAction;
+import com.eucalyptus.cloudformation.resources.ResourceInfo;
+import com.eucalyptus.cloudformation.resources.ResourceProperties;
+import com.eucalyptus.cloudformation.resources.standard.info.AWSElasticLoadBalancingV2LoadBalancerResourceInfo;
+import com.eucalyptus.cloudformation.resources.standard.propertytypes.AWSElasticLoadBalancingV2LoadBalancerProperties;
+import com.eucalyptus.cloudformation.template.JsonHelper;
+import com.eucalyptus.cloudformation.util.MessageHelper;
+import com.eucalyptus.cloudformation.workflow.steps.Step;
+import com.eucalyptus.cloudformation.workflow.steps.StepBasedResourceAction;
+import com.eucalyptus.cloudformation.workflow.updateinfo.UpdateType;
+import com.eucalyptus.loadbalancingv2.common.Loadbalancingv2Api;
+import com.eucalyptus.loadbalancingv2.common.Loadbalancingv2ResourceName;
+import com.eucalyptus.loadbalancingv2.common.msgs.CreateLoadBalancerResponseType;
+import com.eucalyptus.loadbalancingv2.common.msgs.CreateLoadBalancerType;
+import com.eucalyptus.loadbalancingv2.common.msgs.DeleteLoadBalancerType;
+import com.eucalyptus.loadbalancingv2.common.msgs.LoadBalancer;
+import com.eucalyptus.loadbalancingv2.common.msgs.SecurityGroups;
+import com.eucalyptus.loadbalancingv2.common.msgs.Subnets;
+import com.eucalyptus.util.async.AsyncExceptions;
+import com.eucalyptus.util.async.AsyncProxy;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import java.util.Set;
+import java.util.function.Function;
+import org.apache.log4j.Logger;
+
+public class AWSElasticLoadBalancingV2LoadBalancerResourceAction extends StepBasedResourceAction {
+
+  public static final Logger LOG =
+      Logger.getLogger(AWSElasticLoadBalancingV2LoadBalancerResourceAction.class);
+
+  private static final Set<Function<AWSElasticLoadBalancingV2LoadBalancerProperties,Object>> PROP_REPLACE =
+      ImmutableSet.<Function<AWSElasticLoadBalancingV2LoadBalancerProperties,Object>>builder()
+          .add(AWSElasticLoadBalancingV2LoadBalancerProperties::getIpAddressType)
+          .add(AWSElasticLoadBalancingV2LoadBalancerProperties::getName)
+          .add(AWSElasticLoadBalancingV2LoadBalancerProperties::getScheme)
+          .add(AWSElasticLoadBalancingV2LoadBalancerProperties::getSecurityGroups)
+          .add(AWSElasticLoadBalancingV2LoadBalancerProperties::getSubnets)
+          .add(AWSElasticLoadBalancingV2LoadBalancerProperties::getType)
+          .build();
+
+  private static final Set<Function<AWSElasticLoadBalancingV2LoadBalancerProperties,Object>> PROP_SOMEINTER =
+      ImmutableSet.<Function<AWSElasticLoadBalancingV2LoadBalancerProperties,Object>>builder()
+          .build();
+
+  private static final Set<Function<AWSElasticLoadBalancingV2LoadBalancerProperties,Object>> PROP_NOINTER =
+      ImmutableSet.<Function<AWSElasticLoadBalancingV2LoadBalancerProperties,Object>>builder()
+          .add(AWSElasticLoadBalancingV2LoadBalancerProperties::getTags)
+          .build();
+
+  private AWSElasticLoadBalancingV2LoadBalancerProperties properties =
+      new AWSElasticLoadBalancingV2LoadBalancerProperties();
+  private AWSElasticLoadBalancingV2LoadBalancerResourceInfo info =
+      new AWSElasticLoadBalancingV2LoadBalancerResourceInfo();
+
+  public AWSElasticLoadBalancingV2LoadBalancerResourceAction() {
+    super(fromEnum(CreateSteps.class), fromEnum(DeleteSteps.class), null, null );
+  }
+
+  @Override
+  public ResourceProperties getResourceProperties() {
+    return properties;
+  }
+
+  @Override
+  public void setResourceProperties(ResourceProperties resourceProperties) {
+    properties = (AWSElasticLoadBalancingV2LoadBalancerProperties) resourceProperties;
+  }
+
+  @Override
+  public ResourceInfo getResourceInfo() {
+    return info;
+  }
+
+  @Override
+  public void setResourceInfo(ResourceInfo resourceInfo) {
+    info = (AWSElasticLoadBalancingV2LoadBalancerResourceInfo) resourceInfo;
+  }
+
+  @Override
+  public UpdateType getUpdateType(ResourceAction resourceAction, boolean stackTagsChanged) {
+    final AWSElasticLoadBalancingV2LoadBalancerResourceAction otherAction =
+        (AWSElasticLoadBalancingV2LoadBalancerResourceAction) resourceAction;
+    return defaultUpdateType(
+        stackTagsChanged,
+        properties,
+        otherAction.properties,
+        PROP_REPLACE,
+        PROP_SOMEINTER,
+        PROP_NOINTER);
+  }
+
+  private static String arnToFullName(final String arn) {
+    final Loadbalancingv2ResourceName resourceName =
+        Loadbalancingv2ResourceName.parse(arn, Loadbalancingv2ResourceName.Type.loadbalancer);
+    return String.format("%s/%s/%s",
+        resourceName.getSubType(Loadbalancingv2ResourceName.Type.loadbalancer),
+        resourceName.getName(),
+        resourceName.getId(Loadbalancingv2ResourceName.Type.loadbalancer));
+  }
+
+  private enum CreateSteps implements Step {
+    CREATE_LOAD_BALANCER {
+      @Override
+      public ResourceAction perform(ResourceAction resourceAction) throws Exception {
+        final AWSElasticLoadBalancingV2LoadBalancerResourceAction action =
+            (AWSElasticLoadBalancingV2LoadBalancerResourceAction) resourceAction;
+        final Loadbalancingv2Api elbv2 = AsyncProxy.client(
+            Loadbalancingv2Api.class, MessageHelper.userIdentity(action.info.getEffectiveUserId()));
+        final CreateLoadBalancerType createLoadBalancer = new CreateLoadBalancerType();
+        if (action.properties.getName() == null) {
+          createLoadBalancer.setName(action.getDefaultPhysicalResourceId(32));
+        } else {
+          createLoadBalancer.setName(action.properties.getName());
+        }
+        createLoadBalancer.setType(action.properties.getType());
+        createLoadBalancer.setScheme(action.properties.getScheme());
+        if (!action.properties.getSecurityGroups().isEmpty()) {
+          final SecurityGroups securityGroups = new SecurityGroups();
+          securityGroups.setMember(Lists.newArrayList(action.properties.getSecurityGroups()));
+          createLoadBalancer.setSecurityGroups(securityGroups);
+        }
+        if (!action.properties.getSubnets().isEmpty()) {
+          final Subnets subnets = new Subnets();
+          subnets.setMember(Lists.newArrayList(action.properties.getSubnets()));
+          createLoadBalancer.setSubnets(subnets);
+        }
+        final CreateLoadBalancerResponseType createResponse =
+            elbv2.createLoadBalancer(createLoadBalancer);
+        final LoadBalancer loadBalancer =
+            createResponse.getCreateLoadBalancerResult().getLoadBalancers().getMember().get(0);
+        final ArrayNode securityGroupsArrayNode = JsonHelper.createArrayNode();
+        if (loadBalancer.getSecurityGroups() != null) {
+          loadBalancer.getSecurityGroups().getMember().forEach(securityGroupsArrayNode::add);
+        }
+        action.info.setPhysicalResourceId(loadBalancer.getLoadBalancerArn());
+        action.info.setCreatedEnoughToDelete(true);
+        action.info.setCanonicalHostedZoneID(JsonHelper.getStringFromJsonNode(new TextNode(loadBalancer.getCanonicalHostedZoneId())));
+        action.info.setDnsName(JsonHelper.getStringFromJsonNode(new TextNode(loadBalancer.getDNSName())));
+        action.info.setLoadBalancerFullName(JsonHelper.getStringFromJsonNode(new TextNode(arnToFullName(loadBalancer.getLoadBalancerArn()))));
+        action.info.setLoadBalancerName(JsonHelper.getStringFromJsonNode(new TextNode(loadBalancer.getLoadBalancerName())));
+        action.info.setSecurityGroups(JsonHelper.getStringFromJsonNode(securityGroupsArrayNode));
+        action.info.setReferenceValueJson(JsonHelper.getStringFromJsonNode(new TextNode(action.info.getPhysicalResourceId())));
+        return action;
+      }
+    }
+  }
+
+  private enum DeleteSteps implements Step {
+    DELETE_LOAD_BALANCER {
+      @Override
+      public ResourceAction perform(ResourceAction resourceAction) throws Exception {
+        final AWSElasticLoadBalancingV2LoadBalancerResourceAction action =
+            (AWSElasticLoadBalancingV2LoadBalancerResourceAction) resourceAction;
+        if (!Boolean.TRUE.equals(action.info.getCreatedEnoughToDelete())) return action;
+        final Loadbalancingv2Api elbv2 = AsyncProxy.client(
+            Loadbalancingv2Api.class, MessageHelper.userIdentity(action.info.getEffectiveUserId()));
+        final DeleteLoadBalancerType deleteLoadBalancer = new DeleteLoadBalancerType();
+        deleteLoadBalancer.setLoadBalancerArn(action.info.getPhysicalResourceId());
+        try {
+          elbv2.deleteLoadBalancer(deleteLoadBalancer);
+        } catch (final Exception e) {
+          if (!AsyncExceptions.isWebServiceErrorCode(e, "LoadBalancerNotFound")) {
+            throw e;
+          }
+        }
+        return action;
+      }
+    }
+  }
+}

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSElasticLoadBalancingV2TargetGroupResourceAction.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/actions/AWSElasticLoadBalancingV2TargetGroupResourceAction.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.cloudformation.resources.standard.actions;
+
+import com.eucalyptus.cloudformation.resources.ResourceAction;
+import com.eucalyptus.cloudformation.resources.ResourceInfo;
+import com.eucalyptus.cloudformation.resources.ResourceProperties;
+import com.eucalyptus.cloudformation.resources.standard.info.AWSElasticLoadBalancingV2TargetGroupResourceInfo;
+import com.eucalyptus.cloudformation.resources.standard.propertytypes.AWSElasticLoadBalancingV2TargetGroupProperties;
+import com.eucalyptus.cloudformation.template.JsonHelper;
+import com.eucalyptus.cloudformation.util.MessageHelper;
+import com.eucalyptus.cloudformation.workflow.steps.Step;
+import com.eucalyptus.cloudformation.workflow.steps.StepBasedResourceAction;
+import com.eucalyptus.cloudformation.workflow.updateinfo.UpdateType;
+import com.eucalyptus.loadbalancingv2.common.Loadbalancingv2Api;
+import com.eucalyptus.loadbalancingv2.common.Loadbalancingv2ResourceName;
+import com.eucalyptus.loadbalancingv2.common.msgs.CreateTargetGroupResponseType;
+import com.eucalyptus.loadbalancingv2.common.msgs.CreateTargetGroupType;
+import com.eucalyptus.loadbalancingv2.common.msgs.DeleteTargetGroupType;
+import com.eucalyptus.loadbalancingv2.common.msgs.RegisterTargetsType;
+import com.eucalyptus.loadbalancingv2.common.msgs.TargetDescription;
+import com.eucalyptus.loadbalancingv2.common.msgs.TargetDescriptions;
+import com.eucalyptus.loadbalancingv2.common.msgs.TargetGroup;
+import com.eucalyptus.util.async.AsyncExceptions;
+import com.eucalyptus.util.async.AsyncProxy;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.collect.ImmutableSet;
+import io.vavr.collection.Stream;
+import java.util.Set;
+import java.util.function.Function;
+import org.apache.log4j.Logger;
+
+public class AWSElasticLoadBalancingV2TargetGroupResourceAction extends StepBasedResourceAction {
+
+  public static final Logger LOG = Logger.getLogger(AWSElasticLoadBalancingV2TargetGroupResourceAction.class);
+
+  private static final Set<Function<AWSElasticLoadBalancingV2TargetGroupProperties,Object>> PROP_REPLACE =
+      ImmutableSet.<Function<AWSElasticLoadBalancingV2TargetGroupProperties,Object>>builder()
+          .add(AWSElasticLoadBalancingV2TargetGroupProperties::getHealthCheckEnabled)
+          .add(AWSElasticLoadBalancingV2TargetGroupProperties::getHealthCheckIntervalSeconds)
+          .add(AWSElasticLoadBalancingV2TargetGroupProperties::getHealthCheckPath)
+          .add(AWSElasticLoadBalancingV2TargetGroupProperties::getHealthCheckPort)
+          .add(AWSElasticLoadBalancingV2TargetGroupProperties::getHealthCheckProtocol)
+          .add(AWSElasticLoadBalancingV2TargetGroupProperties::getHealthyThresholdCount)
+          .add(AWSElasticLoadBalancingV2TargetGroupProperties::getName)
+          .add(AWSElasticLoadBalancingV2TargetGroupProperties::getPort)
+          .add(AWSElasticLoadBalancingV2TargetGroupProperties::getProtocol)
+          .add(AWSElasticLoadBalancingV2TargetGroupProperties::getProtocolVersion)
+          .add(AWSElasticLoadBalancingV2TargetGroupProperties::getTargetType)
+          .add(AWSElasticLoadBalancingV2TargetGroupProperties::getUnhealthyThresholdCount)
+          .add(AWSElasticLoadBalancingV2TargetGroupProperties::getVpcId)
+          .build();
+
+  private static final Set<Function<AWSElasticLoadBalancingV2TargetGroupProperties,Object>> PROP_SOMEINTER =
+      ImmutableSet.<Function<AWSElasticLoadBalancingV2TargetGroupProperties,Object>>builder()
+          .build();
+
+  private static final Set<Function<AWSElasticLoadBalancingV2TargetGroupProperties,Object>> PROP_NOINTER =
+      ImmutableSet.<Function<AWSElasticLoadBalancingV2TargetGroupProperties,Object>>builder()
+          .add(AWSElasticLoadBalancingV2TargetGroupProperties::getTags)
+          .build();
+
+  private AWSElasticLoadBalancingV2TargetGroupProperties properties = new AWSElasticLoadBalancingV2TargetGroupProperties();
+  private AWSElasticLoadBalancingV2TargetGroupResourceInfo info = new AWSElasticLoadBalancingV2TargetGroupResourceInfo();
+
+  public AWSElasticLoadBalancingV2TargetGroupResourceAction() {
+    super(fromEnum(CreateSteps.class), fromEnum(DeleteSteps.class), null, null );
+  }
+
+  @Override
+  public ResourceProperties getResourceProperties() {
+    return properties;
+  }
+
+  @Override
+  public void setResourceProperties(ResourceProperties resourceProperties) {
+    properties = (AWSElasticLoadBalancingV2TargetGroupProperties) resourceProperties;
+  }
+
+  @Override
+  public ResourceInfo getResourceInfo() {
+    return info;
+  }
+
+  @Override
+  public void setResourceInfo(ResourceInfo resourceInfo) {
+    info = (AWSElasticLoadBalancingV2TargetGroupResourceInfo) resourceInfo;
+  }
+
+  @Override
+  public UpdateType getUpdateType(ResourceAction resourceAction, boolean stackTagsChanged) {
+    final AWSElasticLoadBalancingV2TargetGroupResourceAction otherAction =
+        (AWSElasticLoadBalancingV2TargetGroupResourceAction) resourceAction;
+    return defaultUpdateType(
+        stackTagsChanged,
+        properties,
+        otherAction.properties,
+        PROP_REPLACE,
+        PROP_SOMEINTER,
+        PROP_NOINTER);
+  }
+
+  private static String arnToFullName(final String arn) {
+    final Loadbalancingv2ResourceName resourceName =
+        Loadbalancingv2ResourceName.parse(arn, Loadbalancingv2ResourceName.Type.targetgroup);
+    return String.format("targetgroup/%s/%s",
+        resourceName.getName(),
+        resourceName.getId(Loadbalancingv2ResourceName.Type.targetgroup));
+  }
+
+  private enum CreateSteps implements Step {
+    CREATE_TARGET_GROUP {
+      @Override
+      public ResourceAction perform(ResourceAction resourceAction) throws Exception {
+        final AWSElasticLoadBalancingV2TargetGroupResourceAction action =
+            (AWSElasticLoadBalancingV2TargetGroupResourceAction) resourceAction;
+        final Loadbalancingv2Api elbv2 = AsyncProxy.client(
+            Loadbalancingv2Api.class, MessageHelper.userIdentity(action.info.getEffectiveUserId()));
+        final CreateTargetGroupType createTargetGroup = new CreateTargetGroupType();
+        if (action.properties.getName() == null) {
+          createTargetGroup.setName(action.getDefaultPhysicalResourceId(32));
+        } else {
+          createTargetGroup.setName(action.properties.getName());
+        }
+        createTargetGroup.setPort(action.properties.getPort());
+        createTargetGroup.setProtocol(action.properties.getProtocol());
+        createTargetGroup.setTargetType(action.properties.getTargetType());
+        createTargetGroup.setVpcId(action.properties.getVpcId());
+        final CreateTargetGroupResponseType createResponse =
+            elbv2.createTargetGroup(createTargetGroup);
+        final TargetGroup targetGroup =
+            createResponse.getCreateTargetGroupResult().getTargetGroups().getMember().get(0);
+        action.info.setPhysicalResourceId(targetGroup.getTargetGroupArn());
+        action.info.setCreatedEnoughToDelete(true);
+        action.info.setTargetGroupFullName(JsonHelper.getStringFromJsonNode(new TextNode(arnToFullName(targetGroup.getTargetGroupArn()))));
+        action.info.setTargetGroupName(JsonHelper.getStringFromJsonNode(new TextNode(targetGroup.getTargetGroupName())));
+        action.info.setReferenceValueJson(JsonHelper.getStringFromJsonNode(new TextNode(action.info.getPhysicalResourceId())));
+        return action;
+      }
+    },
+    REGISTER_TARGETS {
+      @Override
+      public ResourceAction perform(ResourceAction resourceAction) throws Exception {
+        final AWSElasticLoadBalancingV2TargetGroupResourceAction action =
+            (AWSElasticLoadBalancingV2TargetGroupResourceAction) resourceAction;
+        if (action.properties.getTargets().isEmpty()) return action;
+        final Loadbalancingv2Api elbv2 = AsyncProxy.client(
+            Loadbalancingv2Api.class, MessageHelper.userIdentity(action.info.getEffectiveUserId()));
+        final RegisterTargetsType registerTargets = new RegisterTargetsType();
+        registerTargets.setTargetGroupArn(action.info.getPhysicalResourceId());
+        final TargetDescriptions targetDescriptions = new TargetDescriptions();
+        targetDescriptions.getMember().addAll(Stream.ofAll(action.properties.getTargets()).map(elbTargetDescription -> {
+          final TargetDescription targetDescription = new TargetDescription();
+          targetDescription.setAvailabilityZone(elbTargetDescription.getAvailabilityZone());
+          targetDescription.setId(elbTargetDescription.getId());
+          targetDescription.setPort(elbTargetDescription.getPort());
+          return targetDescription;
+        }).toJavaList());
+        registerTargets.setTargets(targetDescriptions);
+        elbv2.registerTargets(registerTargets);
+        return action;
+      }
+    }
+    //TODO:STEVE: where to set ARNS? need to refresh after any listener changes
+    //final ArrayNode loadBalancerArnsArrayNode = JsonHelper.createArrayNode();
+    //if (loadBalancer.getSecurityGroups() != null) {
+    //  loadBalancer.getSecurityGroups().getMember().forEach(securityGroupsArrayNode::add);
+    //}
+    //action.info.setLoadBalancerArns(JsonHelper.getStringFromJsonNode(loadBalancerArnsArrayNode));
+  }
+
+  private enum DeleteSteps implements Step {
+    DELETE_TARGET_GROUP {
+      @Override
+      public ResourceAction perform(ResourceAction resourceAction) throws Exception {
+        final AWSElasticLoadBalancingV2TargetGroupResourceAction action =
+            (AWSElasticLoadBalancingV2TargetGroupResourceAction) resourceAction;
+        if (!Boolean.TRUE.equals(action.info.getCreatedEnoughToDelete())) return action;
+        final Loadbalancingv2Api elbv2 = AsyncProxy.client(
+            Loadbalancingv2Api.class, MessageHelper.userIdentity(action.info.getEffectiveUserId()));
+        final DeleteTargetGroupType deleteTargetGroup = new DeleteTargetGroupType();
+        deleteTargetGroup.setTargetGroupArn(action.info.getPhysicalResourceId());
+        try {
+          elbv2.deleteTargetGroup(deleteTargetGroup);
+        } catch (final Exception e) {
+          if (!AsyncExceptions.isWebServiceErrorCode(e, "TargetGroupNotFound")) {
+            throw e;
+          }
+        }
+        return action;
+      }
+    }
+  }
+}

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/info/AWSElasticLoadBalancingV2ListenerResourceInfo.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/info/AWSElasticLoadBalancingV2ListenerResourceInfo.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.cloudformation.resources.standard.info;
+
+import com.eucalyptus.cloudformation.resources.ResourceInfo;
+import com.eucalyptus.cloudformation.resources.annotations.AttributeJson;
+import com.google.common.base.MoreObjects;
+
+public class AWSElasticLoadBalancingV2ListenerResourceInfo extends ResourceInfo {
+                      
+  @AttributeJson
+  private String listenerArn;
+
+  public AWSElasticLoadBalancingV2ListenerResourceInfo( ) {
+    setType( "AWS::ElasticLoadBalancingV2::Listener" );
+  }
+
+  public String getListenerArn() {
+    return listenerArn;
+  }
+
+  public void setListenerArn(String listenerArn) {
+    this.listenerArn = listenerArn;
+  }
+
+  @Override public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("listenerArn", listenerArn)
+        .toString();
+  }
+}

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/info/AWSElasticLoadBalancingV2LoadBalancerResourceInfo.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/info/AWSElasticLoadBalancingV2LoadBalancerResourceInfo.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.cloudformation.resources.standard.info;
+
+import com.eucalyptus.cloudformation.resources.ResourceInfo;
+import com.eucalyptus.cloudformation.resources.annotations.AttributeJson;
+import com.google.common.base.MoreObjects;
+
+public class AWSElasticLoadBalancingV2LoadBalancerResourceInfo extends ResourceInfo {
+
+  @AttributeJson
+  private String canonicalHostedZoneID;
+
+  @AttributeJson( name = "DNSName" )
+  private String dnsName;
+
+  @AttributeJson
+  private String loadBalancerFullName;
+
+  @AttributeJson
+  private String loadBalancerName;
+
+  @AttributeJson
+  private String securityGroups;
+
+  public AWSElasticLoadBalancingV2LoadBalancerResourceInfo( ) {
+    setType( "AWS::ElasticLoadBalancingV2::LoadBalancer" );
+  }
+
+  @Override
+  public boolean supportsTags( ) {
+    return true;
+  }
+
+  public String getCanonicalHostedZoneID() {
+    return canonicalHostedZoneID;
+  }
+
+  public void setCanonicalHostedZoneID(String canonicalHostedZoneID) {
+    this.canonicalHostedZoneID = canonicalHostedZoneID;
+  }
+
+  public String getDnsName() {
+    return dnsName;
+  }
+
+  public void setDnsName(String dnsName) {
+    this.dnsName = dnsName;
+  }
+
+  public String getLoadBalancerFullName() {
+    return loadBalancerFullName;
+  }
+
+  public void setLoadBalancerFullName(String loadBalancerFullName) {
+    this.loadBalancerFullName = loadBalancerFullName;
+  }
+
+  public String getLoadBalancerName() {
+    return loadBalancerName;
+  }
+
+  public void setLoadBalancerName(String loadBalancerName) {
+    this.loadBalancerName = loadBalancerName;
+  }
+
+  public String getSecurityGroups() {
+    return securityGroups;
+  }
+
+  public void setSecurityGroups(String securityGroups) {
+    this.securityGroups = securityGroups;
+  }
+
+  @Override public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("canonicalHostedZoneID", canonicalHostedZoneID)
+        .add("dnsName", dnsName)
+        .add("loadBalancerFullName", loadBalancerFullName)
+        .add("loadBalancerName", loadBalancerName)
+        .add("securityGroups", securityGroups)
+        .toString();
+  }
+}

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/info/AWSElasticLoadBalancingV2TargetGroupResourceInfo.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/info/AWSElasticLoadBalancingV2TargetGroupResourceInfo.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.cloudformation.resources.standard.info;
+
+import com.eucalyptus.cloudformation.resources.ResourceInfo;
+import com.eucalyptus.cloudformation.resources.annotations.AttributeJson;
+import com.google.common.base.MoreObjects;
+
+public class AWSElasticLoadBalancingV2TargetGroupResourceInfo extends ResourceInfo {
+
+  @AttributeJson
+  private String loadBalancerArns;
+
+  @AttributeJson
+  private String targetGroupFullName;
+
+  @AttributeJson
+  private String targetGroupName;
+
+  public AWSElasticLoadBalancingV2TargetGroupResourceInfo( ) {
+    setType( "AWS::ElasticLoadBalancingV2::TargetGroup" );
+  }
+
+  @Override
+  public boolean supportsTags( ) {
+    return true;
+  }
+
+  public String getLoadBalancerArns() {
+    return loadBalancerArns;
+  }
+
+  public void setLoadBalancerArns(String loadBalancerArns) {
+    this.loadBalancerArns = loadBalancerArns;
+  }
+
+  public String getTargetGroupFullName() {
+    return targetGroupFullName;
+  }
+
+  public void setTargetGroupFullName(String targetGroupFullName) {
+    this.targetGroupFullName = targetGroupFullName;
+  }
+
+  public String getTargetGroupName() {
+    return targetGroupName;
+  }
+
+  public void setTargetGroupName(String targetGroupName) {
+    this.targetGroupName = targetGroupName;
+  }
+
+  @Override public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("loadBalancerArns", loadBalancerArns)
+        .add("targetGroupFullName", targetGroupFullName)
+        .add("targetGroupName", targetGroupName)
+        .toString();
+  }
+}

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/AWSAutoScalingAutoScalingGroupProperties.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/AWSAutoScalingAutoScalingGroupProperties.java
@@ -61,6 +61,9 @@ public class AWSAutoScalingAutoScalingGroupProperties implements ResourcePropert
   @Property
   private ArrayList<String> loadBalancerNames = Lists.newArrayList( );
 
+  @Property( name = "TargetGroupARNs" )
+  private ArrayList<String> targetGroupArns = Lists.newArrayList( );
+
   @Required
   @Property
   private Integer maxSize;
@@ -145,6 +148,14 @@ public class AWSAutoScalingAutoScalingGroupProperties implements ResourcePropert
     this.loadBalancerNames = loadBalancerNames;
   }
 
+  public ArrayList<String> getTargetGroupArns() {
+    return targetGroupArns;
+  }
+
+  public void setTargetGroupArns(ArrayList<String> targetGroupArns) {
+    this.targetGroupArns = targetGroupArns;
+  }
+
   public Integer getMaxSize( ) {
     return maxSize;
   }
@@ -204,6 +215,7 @@ public class AWSAutoScalingAutoScalingGroupProperties implements ResourcePropert
         .add( "instanceId", instanceId )
         .add( "launchConfigurationName", launchConfigurationName )
         .add( "loadBalancerNames", loadBalancerNames )
+        .add( "targetGroupArns", targetGroupArns )
         .add( "maxSize", maxSize )
         .add( "minSize", minSize )
         .add( "notificationConfigurations", notificationConfigurations )

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/AWSElasticLoadBalancingV2ListenerProperties.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/AWSElasticLoadBalancingV2ListenerProperties.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.cloudformation.resources.standard.propertytypes;
+
+import com.eucalyptus.cloudformation.resources.ResourceProperties;
+import com.eucalyptus.cloudformation.resources.annotations.Property;
+import com.eucalyptus.cloudformation.resources.annotations.Required;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+
+public class AWSElasticLoadBalancingV2ListenerProperties implements ResourceProperties {
+
+  @Property
+  @Required
+  private String loadBalancerArn;
+
+  @Property
+  private Integer port;
+
+  @Property
+  private String protocol;
+
+  @Property
+  private String sslPolicy;
+
+  @Property
+  private ArrayList<ElasticLoadBalancingV2CertificateProperties> certificates = Lists.newArrayList( );
+
+  @Property
+  private ArrayList<String> alpnPolicy = Lists.newArrayList( );
+
+  @Property
+  @Required
+  private ArrayList<ElasticLoadBalancingV2ActionProperties> defaultActions = Lists.newArrayList( );
+
+  public String getLoadBalancerArn() {
+    return loadBalancerArn;
+  }
+
+  public void setLoadBalancerArn(String loadBalancerArn) {
+    this.loadBalancerArn = loadBalancerArn;
+  }
+
+  public Integer getPort() {
+    return port;
+  }
+
+  public void setPort(Integer port) {
+    this.port = port;
+  }
+
+  public String getProtocol() {
+    return protocol;
+  }
+
+  public void setProtocol(String protocol) {
+    this.protocol = protocol;
+  }
+
+  public String getSslPolicy() {
+    return sslPolicy;
+  }
+
+  public void setSslPolicy(String sslPolicy) {
+    this.sslPolicy = sslPolicy;
+  }
+
+  public ArrayList<ElasticLoadBalancingV2CertificateProperties> getCertificates() {
+    return certificates;
+  }
+
+  public void setCertificates(
+      ArrayList<ElasticLoadBalancingV2CertificateProperties> certificates) {
+    this.certificates = certificates;
+  }
+
+  public ArrayList<String> getAlpnPolicy() {
+    return alpnPolicy;
+  }
+
+  public void setAlpnPolicy(ArrayList<String> alpnPolicy) {
+    this.alpnPolicy = alpnPolicy;
+  }
+
+  public ArrayList<ElasticLoadBalancingV2ActionProperties> getDefaultActions() {
+    return defaultActions;
+  }
+
+  public void setDefaultActions(
+      ArrayList<ElasticLoadBalancingV2ActionProperties> defaultActions) {
+    this.defaultActions = defaultActions;
+  }
+
+  @Override public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("loadBalancerArn", loadBalancerArn)
+        .add("port", port)
+        .add("protocol", protocol)
+        .add("sslPolicy", sslPolicy)
+        .add("certificates", certificates)
+        .add("alpnPolicy", alpnPolicy)
+        .add("defaultActions", defaultActions)
+        .toString();
+  }
+}

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/AWSElasticLoadBalancingV2LoadBalancerProperties.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/AWSElasticLoadBalancingV2LoadBalancerProperties.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.cloudformation.resources.standard.propertytypes;
+
+import com.eucalyptus.cloudformation.resources.ResourceProperties;
+import com.eucalyptus.cloudformation.resources.annotations.Property;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+
+public class AWSElasticLoadBalancingV2LoadBalancerProperties implements ResourceProperties {
+
+  @Property
+  private String name;
+
+  @Property
+  private String ipAddressType;
+
+  @Property
+  private String scheme;
+
+  @Property
+  private String type;
+
+  @Property
+  private ArrayList<String> securityGroups = Lists.newArrayList( );
+
+  @Property
+  private ArrayList<String> subnets = Lists.newArrayList( );
+
+  @Property
+  private ArrayList<ElasticLoadBalancingV2SubnetMappingProperties> subnetMappings =
+      Lists.newArrayList();
+
+  @Property
+  private ArrayList<ElasticLoadBalancingV2LoadBalancerAttributeProperties> loadBalancerAttributes =
+      Lists.newArrayList();
+
+  @Property
+  private ArrayList<CloudFormationResourceTag> tags = Lists.newArrayList( );
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getIpAddressType() {
+    return ipAddressType;
+  }
+
+  public void setIpAddressType(String ipAddressType) {
+    this.ipAddressType = ipAddressType;
+  }
+
+  public String getScheme() {
+    return scheme;
+  }
+
+  public void setScheme(String scheme) {
+    this.scheme = scheme;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public ArrayList<String> getSecurityGroups() {
+    return securityGroups;
+  }
+
+  public void setSecurityGroups(ArrayList<String> securityGroups) {
+    this.securityGroups = securityGroups;
+  }
+
+  public ArrayList<String> getSubnets() {
+    return subnets;
+  }
+
+  public void setSubnets(ArrayList<String> subnets) {
+    this.subnets = subnets;
+  }
+
+  public ArrayList<ElasticLoadBalancingV2SubnetMappingProperties> getSubnetMappings() {
+    return subnetMappings;
+  }
+
+  public void setSubnetMappings(
+      ArrayList<ElasticLoadBalancingV2SubnetMappingProperties> subnetMappings) {
+    this.subnetMappings = subnetMappings;
+  }
+
+  public ArrayList<ElasticLoadBalancingV2LoadBalancerAttributeProperties> getLoadBalancerAttributes() {
+    return loadBalancerAttributes;
+  }
+
+  public void setLoadBalancerAttributes(
+      ArrayList<ElasticLoadBalancingV2LoadBalancerAttributeProperties> loadBalancerAttributes) {
+    this.loadBalancerAttributes = loadBalancerAttributes;
+  }
+
+  public ArrayList<CloudFormationResourceTag> getTags() {
+    return tags;
+  }
+
+  public void setTags(
+      ArrayList<CloudFormationResourceTag> tags) {
+    this.tags = tags;
+  }
+
+  @Override public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("name", name)
+        .add("ipAddressType", ipAddressType)
+        .add("scheme", scheme)
+        .add("type", type)
+        .add("securityGroups", securityGroups)
+        .add("subnets", subnets)
+        .add("subnetMappings", subnetMappings)
+        .add("loadBalancerAttributes", loadBalancerAttributes)
+        .add("tags", tags)
+        .toString();
+  }
+}

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/AWSElasticLoadBalancingV2TargetGroupProperties.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/AWSElasticLoadBalancingV2TargetGroupProperties.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.cloudformation.resources.standard.propertytypes;
+
+import com.eucalyptus.cloudformation.resources.ResourceProperties;
+import com.eucalyptus.cloudformation.resources.annotations.Property;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+
+public class AWSElasticLoadBalancingV2TargetGroupProperties implements ResourceProperties {
+
+
+  @Property
+  private String name;
+
+  @Property
+  private Integer port;
+
+  @Property
+  private String protocol;
+
+  @Property
+  private String protocolVersion;
+
+  @Property
+  private Boolean healthCheckEnabled;
+
+  @Property
+  private Integer healthCheckIntervalSeconds;
+
+  @Property
+  private String healthCheckPath;
+
+  @Property
+  private String healthCheckPort;
+
+  @Property
+  private String healthCheckProtocol;
+
+  @Property
+  private Integer healthCheckTimeoutSeconds;
+
+  @Property
+  private Integer healthyThresholdCount;
+
+  @Property
+  private ElasticLoadBalancingV2MatcherProperties matcher;
+
+  @Property
+  private String targetType;
+
+  @Property
+  private ArrayList<ElasticLoadBalancingV2TargetDescriptionProperties> targets = Lists.newArrayList( );
+
+  @Property
+  private Integer unhealthyThresholdCount;
+
+  @Property
+  private String vpcId;
+
+  @Property
+  private ArrayList<ElasticLoadBalancingV2TargetGroupAttributeProperties> targetGroupAttributes =
+      Lists.newArrayList();
+
+  @Property
+  private ArrayList<CloudFormationResourceTag> tags = Lists.newArrayList( );
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Integer getPort() {
+    return port;
+  }
+
+  public void setPort(Integer port) {
+    this.port = port;
+  }
+
+  public String getProtocol() {
+    return protocol;
+  }
+
+  public void setProtocol(String protocol) {
+    this.protocol = protocol;
+  }
+
+  public String getProtocolVersion() {
+    return protocolVersion;
+  }
+
+  public void setProtocolVersion(String protocolVersion) {
+    this.protocolVersion = protocolVersion;
+  }
+
+  public Boolean getHealthCheckEnabled() {
+    return healthCheckEnabled;
+  }
+
+  public void setHealthCheckEnabled(Boolean healthCheckEnabled) {
+    this.healthCheckEnabled = healthCheckEnabled;
+  }
+
+  public Integer getHealthCheckIntervalSeconds() {
+    return healthCheckIntervalSeconds;
+  }
+
+  public void setHealthCheckIntervalSeconds(Integer healthCheckIntervalSeconds) {
+    this.healthCheckIntervalSeconds = healthCheckIntervalSeconds;
+  }
+
+  public String getHealthCheckPath() {
+    return healthCheckPath;
+  }
+
+  public void setHealthCheckPath(String healthCheckPath) {
+    this.healthCheckPath = healthCheckPath;
+  }
+
+  public String getHealthCheckPort() {
+    return healthCheckPort;
+  }
+
+  public void setHealthCheckPort(String healthCheckPort) {
+    this.healthCheckPort = healthCheckPort;
+  }
+
+  public String getHealthCheckProtocol() {
+    return healthCheckProtocol;
+  }
+
+  public void setHealthCheckProtocol(String healthCheckProtocol) {
+    this.healthCheckProtocol = healthCheckProtocol;
+  }
+
+  public Integer getHealthCheckTimeoutSeconds() {
+    return healthCheckTimeoutSeconds;
+  }
+
+  public void setHealthCheckTimeoutSeconds(Integer healthCheckTimeoutSeconds) {
+    this.healthCheckTimeoutSeconds = healthCheckTimeoutSeconds;
+  }
+
+  public Integer getHealthyThresholdCount() {
+    return healthyThresholdCount;
+  }
+
+  public void setHealthyThresholdCount(Integer healthyThresholdCount) {
+    this.healthyThresholdCount = healthyThresholdCount;
+  }
+
+  public ElasticLoadBalancingV2MatcherProperties getMatcher() {
+    return matcher;
+  }
+
+  public void setMatcher(
+      ElasticLoadBalancingV2MatcherProperties matcher) {
+    this.matcher = matcher;
+  }
+
+  public String getTargetType() {
+    return targetType;
+  }
+
+  public void setTargetType(String targetType) {
+    this.targetType = targetType;
+  }
+
+  public ArrayList<ElasticLoadBalancingV2TargetDescriptionProperties> getTargets() {
+    return targets;
+  }
+
+  public void setTargets(
+      ArrayList<ElasticLoadBalancingV2TargetDescriptionProperties> targets) {
+    this.targets = targets;
+  }
+
+  public Integer getUnhealthyThresholdCount() {
+    return unhealthyThresholdCount;
+  }
+
+  public void setUnhealthyThresholdCount(Integer unhealthyThresholdCount) {
+    this.unhealthyThresholdCount = unhealthyThresholdCount;
+  }
+
+  public String getVpcId() {
+    return vpcId;
+  }
+
+  public void setVpcId(String vpcId) {
+    this.vpcId = vpcId;
+  }
+
+  public ArrayList<ElasticLoadBalancingV2TargetGroupAttributeProperties> getTargetGroupAttributes() {
+    return targetGroupAttributes;
+  }
+
+  public void setTargetGroupAttributes(
+      ArrayList<ElasticLoadBalancingV2TargetGroupAttributeProperties> targetGroupAttributes) {
+    this.targetGroupAttributes = targetGroupAttributes;
+  }
+
+  public ArrayList<CloudFormationResourceTag> getTags() {
+    return tags;
+  }
+
+  public void setTags(
+      ArrayList<CloudFormationResourceTag> tags) {
+    this.tags = tags;
+  }
+
+  @Override public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("name", name)
+        .add("port", port)
+        .add("protocol", protocol)
+        .add("protocolVersion", protocolVersion)
+        .add("healthCheckEnabled", healthCheckEnabled)
+        .add("healthCheckIntervalSeconds", healthCheckIntervalSeconds)
+        .add("healthCheckPath", healthCheckPath)
+        .add("healthCheckPort", healthCheckPort)
+        .add("healthCheckProtocol", healthCheckProtocol)
+        .add("healthCheckTimeoutSeconds", healthCheckTimeoutSeconds)
+        .add("healthyThresholdCount", healthyThresholdCount)
+        .add("matcher", matcher)
+        .add("targetType", targetType)
+        .add("targets", targets)
+        .add("unhealthyThresholdCount", unhealthyThresholdCount)
+        .add("vpcId", vpcId)
+        .add("targetGroupAttributes", targetGroupAttributes)
+        .add("tags", tags)
+        .toString();
+  }
+}

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/ElasticLoadBalancingV2ActionProperties.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/ElasticLoadBalancingV2ActionProperties.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.cloudformation.resources.standard.propertytypes;
+
+import com.eucalyptus.cloudformation.resources.annotations.Property;
+import com.eucalyptus.cloudformation.resources.annotations.Required;
+import com.google.common.base.MoreObjects;
+
+public class ElasticLoadBalancingV2ActionProperties {
+
+  @Property
+  private ElasticLoadBalancingV2FixedResponseConfigProperties fixedResponseConfig;
+
+  @Property
+  private ElasticLoadBalancingV2ForwardConfigProperties forwardConfig;
+
+  @Property
+  private Integer order;
+
+  @Property
+  private ElasticLoadBalancingV2RedirectConfigProperties redirectConfig;
+
+  @Property
+  private String targetGroupArn;
+
+  @Property
+  @Required
+  private String type;
+
+  public ElasticLoadBalancingV2FixedResponseConfigProperties getFixedResponseConfig() {
+    return fixedResponseConfig;
+  }
+
+  public void setFixedResponseConfig(
+      ElasticLoadBalancingV2FixedResponseConfigProperties fixedResponseConfig) {
+    this.fixedResponseConfig = fixedResponseConfig;
+  }
+
+  public ElasticLoadBalancingV2ForwardConfigProperties getForwardConfig() {
+    return forwardConfig;
+  }
+
+  public void setForwardConfig(
+      ElasticLoadBalancingV2ForwardConfigProperties forwardConfig) {
+    this.forwardConfig = forwardConfig;
+  }
+
+  public Integer getOrder() {
+    return order;
+  }
+
+  public void setOrder(Integer order) {
+    this.order = order;
+  }
+
+  public ElasticLoadBalancingV2RedirectConfigProperties getRedirectConfig() {
+    return redirectConfig;
+  }
+
+  public void setRedirectConfig(
+      ElasticLoadBalancingV2RedirectConfigProperties redirectConfig) {
+    this.redirectConfig = redirectConfig;
+  }
+
+  public String getTargetGroupArn() {
+    return targetGroupArn;
+  }
+
+  public void setTargetGroupArn(String targetGroupArn) {
+    this.targetGroupArn = targetGroupArn;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  @Override public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("fixedResponseConfig", fixedResponseConfig)
+        .add("forwardConfig", forwardConfig)
+        .add("order", order)
+        .add("redirectConfig", redirectConfig)
+        .add("targetGroupArn", targetGroupArn)
+        .add("type", type)
+        .toString();
+  }
+}

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/ElasticLoadBalancingV2CertificateProperties.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/ElasticLoadBalancingV2CertificateProperties.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.cloudformation.resources.standard.propertytypes;
+
+import com.eucalyptus.cloudformation.resources.annotations.Property;
+import com.google.common.base.MoreObjects;
+
+public class ElasticLoadBalancingV2CertificateProperties {
+
+  @Property
+  private String certificateArn;
+
+  public String getCertificateArn() {
+    return certificateArn;
+  }
+
+  public void setCertificateArn(String certificateArn) {
+    this.certificateArn = certificateArn;
+  }
+
+  @Override public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("certificateArn", certificateArn)
+        .toString();
+  }
+}

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/ElasticLoadBalancingV2FixedResponseConfigProperties.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/ElasticLoadBalancingV2FixedResponseConfigProperties.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.cloudformation.resources.standard.propertytypes;
+
+import com.eucalyptus.cloudformation.resources.annotations.Property;
+import com.eucalyptus.cloudformation.resources.annotations.Required;
+import com.google.common.base.MoreObjects;
+
+public class ElasticLoadBalancingV2FixedResponseConfigProperties {
+
+  @Property
+  private String contentType;
+
+  @Property
+  private String messageBody;
+
+  @Property
+  @Required
+  private String statusCode;
+
+  public String getContentType() {
+    return contentType;
+  }
+
+  public void setContentType(String contentType) {
+    this.contentType = contentType;
+  }
+
+  public String getMessageBody() {
+    return messageBody;
+  }
+
+  public void setMessageBody(String messageBody) {
+    this.messageBody = messageBody;
+  }
+
+  public String getStatusCode() {
+    return statusCode;
+  }
+
+  public void setStatusCode(String statusCode) {
+    this.statusCode = statusCode;
+  }
+
+  @Override public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("contentType", contentType)
+        .add("messageBody", messageBody)
+        .add("statusCode", statusCode)
+        .toString();
+  }
+}

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/ElasticLoadBalancingV2ForwardConfigProperties.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/ElasticLoadBalancingV2ForwardConfigProperties.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.cloudformation.resources.standard.propertytypes;
+
+import com.eucalyptus.cloudformation.resources.annotations.Property;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+
+public class ElasticLoadBalancingV2ForwardConfigProperties {
+
+  @Property
+  private ArrayList<ElasticLoadBalancingV2TargetGroupTupleProperties> targetGroups =
+      Lists.newArrayList( );
+
+  @Property
+  private ElasticLoadBalancingV2TargetGroupStickinessConfigProperties targetGroupStickinessConfig;
+
+  public ArrayList<ElasticLoadBalancingV2TargetGroupTupleProperties> getTargetGroups() {
+    return targetGroups;
+  }
+
+  public void setTargetGroups(
+      ArrayList<ElasticLoadBalancingV2TargetGroupTupleProperties> targetGroups) {
+    this.targetGroups = targetGroups;
+  }
+
+  public ElasticLoadBalancingV2TargetGroupStickinessConfigProperties getTargetGroupStickinessConfig() {
+    return targetGroupStickinessConfig;
+  }
+
+  public void setTargetGroupStickinessConfig(
+      ElasticLoadBalancingV2TargetGroupStickinessConfigProperties targetGroupStickinessConfig) {
+    this.targetGroupStickinessConfig = targetGroupStickinessConfig;
+  }
+
+  @Override public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("targetGroups", targetGroups)
+        .add("targetGroupStickinessConfig", targetGroupStickinessConfig)
+        .toString();
+  }
+}

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/ElasticLoadBalancingV2LoadBalancerAttributeProperties.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/ElasticLoadBalancingV2LoadBalancerAttributeProperties.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.cloudformation.resources.standard.propertytypes;
+
+import com.eucalyptus.cloudformation.resources.annotations.Property;
+import com.google.common.base.MoreObjects;
+
+public class ElasticLoadBalancingV2LoadBalancerAttributeProperties {
+
+  @Property
+  private String key;
+
+  @Property
+  private String value;
+
+  public String getKey() {
+    return key;
+  }
+
+  public void setKey(String key) {
+    this.key = key;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+  @Override public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("key", key)
+        .add("value", value)
+        .toString();
+  }
+}

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/ElasticLoadBalancingV2MatcherProperties.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/ElasticLoadBalancingV2MatcherProperties.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.cloudformation.resources.standard.propertytypes;
+
+import com.eucalyptus.cloudformation.resources.annotations.Property;
+import com.google.common.base.MoreObjects;
+
+public class ElasticLoadBalancingV2MatcherProperties {
+
+  @Property
+  private String grpcCode;
+
+  @Property
+  private String httpCode;
+
+  public String getGrpcCode() {
+    return grpcCode;
+  }
+
+  public void setGrpcCode(String grpcCode) {
+    this.grpcCode = grpcCode;
+  }
+
+  public String getHttpCode() {
+    return httpCode;
+  }
+
+  public void setHttpCode(String httpCode) {
+    this.httpCode = httpCode;
+  }
+
+  @Override public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("grpcCode", grpcCode)
+        .add("httpCode", httpCode)
+        .toString();
+  }
+}

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/ElasticLoadBalancingV2RedirectConfigProperties.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/ElasticLoadBalancingV2RedirectConfigProperties.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.cloudformation.resources.standard.propertytypes;
+
+import com.eucalyptus.cloudformation.resources.annotations.Property;
+import com.eucalyptus.cloudformation.resources.annotations.Required;
+import com.google.common.base.MoreObjects;
+
+public class ElasticLoadBalancingV2RedirectConfigProperties {
+
+  @Property
+  private String host;
+
+  @Property
+  private String path;
+
+  @Property
+  private String port;
+
+  @Property
+  private String protocol;
+
+  @Property
+  private String query;
+
+  @Property
+  @Required
+  private String statusCode;
+
+  public String getHost() {
+    return host;
+  }
+
+  public void setHost(String host) {
+    this.host = host;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  public String getPort() {
+    return port;
+  }
+
+  public void setPort(String port) {
+    this.port = port;
+  }
+
+  public String getProtocol() {
+    return protocol;
+  }
+
+  public void setProtocol(String protocol) {
+    this.protocol = protocol;
+  }
+
+  public String getQuery() {
+    return query;
+  }
+
+  public void setQuery(String query) {
+    this.query = query;
+  }
+
+  public String getStatusCode() {
+    return statusCode;
+  }
+
+  public void setStatusCode(String statusCode) {
+    this.statusCode = statusCode;
+  }
+
+  @Override public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("host", host)
+        .add("path", path)
+        .add("port", port)
+        .add("protocol", protocol)
+        .add("query", query)
+        .add("statusCode", statusCode)
+        .toString();
+  }
+}

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/ElasticLoadBalancingV2SubnetMappingProperties.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/ElasticLoadBalancingV2SubnetMappingProperties.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.cloudformation.resources.standard.propertytypes;
+
+import com.eucalyptus.cloudformation.resources.annotations.Property;
+import com.google.common.base.MoreObjects;
+
+public class ElasticLoadBalancingV2SubnetMappingProperties {
+
+  @Property
+  private String allocationId;
+
+  @Property( name = "IPv6Address" )
+  private String ipv6Address;
+
+  @Property( name = "PrivateIPv4Address" )
+  private String privateIpv4Address;
+
+  @Property
+  private String subnetId;
+
+  public String getAllocationId() {
+    return allocationId;
+  }
+
+  public void setAllocationId(String allocationId) {
+    this.allocationId = allocationId;
+  }
+
+  public String getIpv6Address() {
+    return ipv6Address;
+  }
+
+  public void setIpv6Address(String ipv6Address) {
+    this.ipv6Address = ipv6Address;
+  }
+
+  public String getPrivateIpv4Address() {
+    return privateIpv4Address;
+  }
+
+  public void setPrivateIpv4Address(String privateIpv4Address) {
+    this.privateIpv4Address = privateIpv4Address;
+  }
+
+  public String getSubnetId() {
+    return subnetId;
+  }
+
+  public void setSubnetId(String subnetId) {
+    this.subnetId = subnetId;
+  }
+
+  @Override public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("allocationId", allocationId)
+        .add("ipv6Address", ipv6Address)
+        .add("privateIpv4Address", privateIpv4Address)
+        .add("subnetId", subnetId)
+        .toString();
+  }
+}

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/ElasticLoadBalancingV2TargetDescriptionProperties.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/ElasticLoadBalancingV2TargetDescriptionProperties.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.cloudformation.resources.standard.propertytypes;
+
+import com.eucalyptus.cloudformation.resources.annotations.Property;
+import com.eucalyptus.cloudformation.resources.annotations.Required;
+import com.google.common.base.MoreObjects;
+
+public class ElasticLoadBalancingV2TargetDescriptionProperties {
+
+  @Property
+  private String availabilityZone;
+
+  @Property
+  @Required
+  private String id;
+
+  @Property
+  private Integer port;
+
+  public String getAvailabilityZone() {
+    return availabilityZone;
+  }
+
+  public void setAvailabilityZone(String availabilityZone) {
+    this.availabilityZone = availabilityZone;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public Integer getPort() {
+    return port;
+  }
+
+  public void setPort(Integer port) {
+    this.port = port;
+  }
+
+  @Override public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("availabilityZone", availabilityZone)
+        .add("id", id)
+        .add("port", port)
+        .toString();
+  }
+}

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/ElasticLoadBalancingV2TargetGroupAttributeProperties.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/ElasticLoadBalancingV2TargetGroupAttributeProperties.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.cloudformation.resources.standard.propertytypes;
+
+import com.eucalyptus.cloudformation.resources.annotations.Property;
+import com.google.common.base.MoreObjects;
+
+public class ElasticLoadBalancingV2TargetGroupAttributeProperties {
+
+  @Property
+  private String key;
+
+  @Property
+  private String value;
+
+  public String getKey() {
+    return key;
+  }
+
+  public void setKey(String key) {
+    this.key = key;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+  @Override public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("key", key)
+        .add("value", value)
+        .toString();
+  }
+}

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/ElasticLoadBalancingV2TargetGroupStickinessConfigProperties.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/ElasticLoadBalancingV2TargetGroupStickinessConfigProperties.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.cloudformation.resources.standard.propertytypes;
+
+import com.eucalyptus.cloudformation.resources.annotations.Property;
+import com.google.common.base.MoreObjects;
+
+public class ElasticLoadBalancingV2TargetGroupStickinessConfigProperties {
+
+  @Property
+  private Integer durationSeconds;
+
+  @Property
+  private Boolean enabled;
+
+  public Integer getDurationSeconds() {
+    return durationSeconds;
+  }
+
+  public void setDurationSeconds(Integer durationSeconds) {
+    this.durationSeconds = durationSeconds;
+  }
+
+  public Boolean getEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(Boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  @Override public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("durationSeconds", durationSeconds)
+        .add("enabled", enabled)
+        .toString();
+  }
+}

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/ElasticLoadBalancingV2TargetGroupTupleProperties.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/resources/standard/propertytypes/ElasticLoadBalancingV2TargetGroupTupleProperties.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.cloudformation.resources.standard.propertytypes;
+
+import com.eucalyptus.cloudformation.resources.annotations.Property;
+import com.google.common.base.MoreObjects;
+
+public class ElasticLoadBalancingV2TargetGroupTupleProperties {
+
+  @Property
+  private String targetGroupArn;
+
+  @Property
+  private Integer weight;
+
+  public String getTargetGroupArn() {
+    return targetGroupArn;
+  }
+
+  public void setTargetGroupArn(String targetGroupArn) {
+    this.targetGroupArn = targetGroupArn;
+  }
+
+  public Integer getWeight() {
+    return weight;
+  }
+
+  public void setWeight(Integer weight) {
+    this.weight = weight;
+  }
+
+  @Override public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("targetGroupArn", targetGroupArn)
+        .add("weight", weight)
+        .toString();
+  }
+}

--- a/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/util/MessageHelper.java
+++ b/clc/modules/cloudformation/src/main/java/com/eucalyptus/cloudformation/util/MessageHelper.java
@@ -31,6 +31,7 @@ package com.eucalyptus.cloudformation.util;
 import com.eucalyptus.cloudformation.CloudFormationException;
 import com.eucalyptus.cloudformation.InternalFailureException;
 import edu.ucsb.eucalyptus.msgs.BaseMessage;
+import java.util.function.Function;
 import org.apache.log4j.Logger;
 
 
@@ -61,4 +62,18 @@ public class MessageHelper {
     }
   }
 
+  public static Function<BaseMessage,BaseMessage> userIdentity(final String effectiveUserId) {
+    return message -> {
+      message.setEffectiveUserId(effectiveUserId);
+      return message;
+    };
+  }
+
+  public static Function<BaseMessage,BaseMessage> privilegedUserIdentity(final String effectiveUserId) {
+    return message -> {
+      message.setEffectiveUserId(effectiveUserId);
+      message.markPrivileged();
+      return message;
+    };
+  }
 }

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/Loadbalancingv2Service.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/Loadbalancingv2Service.java
@@ -540,7 +540,7 @@ public class Loadbalancingv2Service {
           }
       );
     } catch ( final Loadbalancingv2MetadataNotFoundException e ) {
-      throw listenerNotFound().get();
+      throw loadbalancerNotFound().get();
     } catch ( final Exception e ) {
       handleException( e, __ -> new Loadbalancingv2ClientException("ResourceInUse", "Loadbalancer in use") );
     }


### PR DESCRIPTION
Initial cloudformation support for elbv2 resources:

* `AWS::ElasticLoadBalancingV2::Listener`
* `AWS::ElasticLoadBalancingV2::LoadBalancer`
* `AWS::ElasticLoadBalancingV2::TargetGroup`

and the `TargetGroupARNs` property of `AWS::AutoScaling::AutoScalingGroup` for autoscaling backed load balancers.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1282
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1283

Manual testing covered templates with:

* http load balancer with cloudformation registered target instance
* https loadbalancer with cloudformation registered target instance
* http loadbalancer with autoscaling registered target instance

Relates to corymbia/eucalyptus#271