### PR TITLE
ELBv2 route53 hosted zone for load balancers

### DIFF
--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/Loadbalancingv2Service.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/Loadbalancingv2Service.java
@@ -22,6 +22,7 @@ import com.eucalyptus.context.Context;
 import com.eucalyptus.context.Contexts;
 import com.eucalyptus.entities.Entities;
 import com.eucalyptus.entities.TransactionResource;
+import com.eucalyptus.loadbalancing.LoadBalancingHostedZoneManager;
 import com.eucalyptus.loadbalancingv2.common.msgs.CertificateList;
 import com.eucalyptus.loadbalancingv2.common.msgs.Listeners;
 import com.eucalyptus.loadbalancingv2.common.msgs.Rules;
@@ -119,6 +120,7 @@ import com.eucalyptus.util.CompatFunction;
 import com.eucalyptus.util.CompatSupplier;
 import com.eucalyptus.util.Exceptions;
 import com.eucalyptus.util.NonNullFunction;
+import com.eucalyptus.util.Pair;
 import com.eucalyptus.util.TypeMappers;
 import com.eucalyptus.util.async.AsyncProxy;
 import com.google.common.base.Enums;
@@ -130,6 +132,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import io.vavr.collection.Stream;
+import io.vavr.control.Option;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -314,6 +317,9 @@ public class Loadbalancingv2Service {
       throw new Loadbalancingv2ClientException("InvalidConfigurationRequest", "Inconsistent subnet vpc");
     }
 
+    final Option<Pair<String, String>> hostedZoneNameAndId =
+        LoadBalancingHostedZoneManager.getHostedZoneNameAndId();
+
     final LoadBalancer loadBalancer;
     try {
       @SuppressWarnings({"Guava", "Convert2Lambda"})
@@ -327,6 +333,7 @@ public class Loadbalancingv2Service {
           );
 
           newLoadBalancer.setIpAddressType(ipAddressType);
+          hostedZoneNameAndId.map(Pair::getRight).forEach(newLoadBalancer::setCanonicalHostedZoneId);
           newLoadBalancer.setSecurityGroupIds(
               Stream.ofAll(securityGroupItems).map(SecurityGroupItemType::getGroupId).toJavaList());
           newLoadBalancer.setSubnetIds(

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/LoadBalancers.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/LoadBalancers.java
@@ -113,7 +113,7 @@ public interface LoadBalancers {
         balancer.setLoadBalancerName(view.getDisplayName());
         balancer.setLoadBalancerArn(view.getArn());
         balancer.setCreatedTime(view.getCreationTimestamp());
-        //balancer.setCanonicalHostedZoneId(); //TODO:STEVE: hosted zone id
+        balancer.setCanonicalHostedZoneId(view.getCanonicalHostedZoneId());
         balancer.setDNSName(view.getScheme().schemev1().generate(
             view.getDisplayName(),
             view.getOwnerAccountNumber()));

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/entities/LoadBalancer.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/entities/LoadBalancer.java
@@ -110,6 +110,9 @@ public class LoadBalancer extends UserMetadata<LoadBalancer.State>
   @Column(name = "loadbalancer_vpc_id")
   private String vpcId;
 
+  @Column(name = "loadbalancer_hosted_zone_id")
+  private String canonicalHostedZoneId;
+
   @ElementCollection
   @CollectionTable( name = "metadata_v2_loadbalancer_security_groups", joinColumns = @JoinColumn( name = "metadata_loadbalancer_id" ) )
   @Column( name = "metadata_security_group_id" )
@@ -219,6 +222,14 @@ public class LoadBalancer extends UserMetadata<LoadBalancer.State>
 
   public void setVpcId(String vpcId) {
     this.vpcId = vpcId;
+  }
+
+  public String getCanonicalHostedZoneId() {
+    return canonicalHostedZoneId;
+  }
+
+  public void setCanonicalHostedZoneId(String canonicalHostedZoneId) {
+    this.canonicalHostedZoneId = canonicalHostedZoneId;
   }
 
   public List<String> getSecurityGroupIds() {

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/views/LoadBalancerView.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/views/LoadBalancerView.java
@@ -41,6 +41,8 @@ public interface LoadBalancerView {
 
   LoadBalancer.IpAddressType getIpAddressType();
 
+  String getCanonicalHostedZoneId();
+
   List<String> getSecurityGroupIds();
 
   List<String> getSubnetIds();


### PR DESCRIPTION
ELBv2 support for route53 alias target.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1289
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1290

Demo is that you can reference an elbv2 load balancer using a route53 alias target:

```
#
# dig +short balancer-1-000699839398.lb.qa64.eucalyptuscloud.net @10.111.10.64
10.111.10.179
#
#
# dig +short elb.example.com @10.111.10.64
10.111.10.179
#
#
```

where `example.com` is a route53 hosted zone with an alias target record for `elb.example.com`.

Relates to corymbia/eucalyptus#271