### PR TITLE
ELBv2 limits

### DIFF
--- a/clc/modules/loadbalancingv2-common/src/main/java/com/eucalyptus/loadbalancingv2/common/msgs/Limit.java
+++ b/clc/modules/loadbalancingv2-common/src/main/java/com/eucalyptus/loadbalancingv2/common/msgs/Limit.java
@@ -6,9 +6,21 @@
 package com.eucalyptus.loadbalancingv2.common.msgs;
 
 import edu.ucsb.eucalyptus.msgs.EucalyptusData;
-
+import java.util.Objects;
 
 public class Limit extends EucalyptusData {
+
+  public Limit(){
+  }
+
+  public Limit(final String name, final String max) {
+    this.max = max;
+    this.name = name;
+  }
+
+  public static Limit of(final String name, final Integer max) {
+    return new Limit(name, Objects.toString(max, null));
+  }
 
   private String max;
 

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/Loadbalancingv2LimitProperties.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/Loadbalancingv2LimitProperties.java
@@ -75,6 +75,26 @@ public class Loadbalancingv2LimitProperties {
     public int value() {
       return limitSupplier.get();
     }
+
+    private <T extends Throwable> void check(final long current, final Supplier<T> thrown) throws T {
+      if (current >= value()) {
+        throw thrown.get();
+      }
+    }
+  }
+
+  public static <T extends Throwable> void check(
+      final Limit limit,
+      final long current,
+      final Supplier<T> thrown
+  ) throws T {
+    if (limit != null) {
+      limit.check(current, thrown);
+    }
+  }
+
+  public static int getMaxTags() {
+    return MAX_TAGS;
   }
 
   @ConfigurableField(

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/Loadbalancingv2LimitProperties.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/Loadbalancingv2LimitProperties.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.loadbalancingv2.service;
+
+import com.eucalyptus.configurable.ConfigurableClass;
+import com.eucalyptus.configurable.ConfigurableField;
+import com.eucalyptus.configurable.PropertyChangeListeners;
+import java.util.function.Supplier;
+
+@ConfigurableClass(root = "services.loadbalancingv2.limit", description = "Parameters for loadbalancing limits")
+public class Loadbalancingv2LimitProperties {
+
+  public enum Limit {
+    application_load_balancers(() ->
+        APPLICATION_LOAD_BALANCERS),
+    certificates_per_application_load_balancer(() ->
+        CERTIFICATES_PER_APPLICATION_LOAD_BALANCER),
+    certificates_per_network_load_balancer(() ->
+        CERTIFICATES_PER_NETWORK_LOAD_BALANCER),
+    condition_values_per_alb_rule(() ->
+        CONDITION_VALUES_PER_ALB_RULE),
+    condition_wildcards_per_alb_rule(() ->
+        CONDITION_WILDCARDS_PER_ALB_RULE),
+    gateway_load_balancers(() ->
+        20),
+    gateway_load_balancers_per_vpc(() ->
+        10),
+    geneve_target_groups(() ->
+        50),
+    listeners_per_application_load_balancer(() ->
+        LISTENERS_PER_APPLICATION_LOAD_BALANCER),
+    listeners_per_network_load_balancer(() ->
+        LISTENERS_PER_NETWORK_LOAD_BALANCER),
+    network_load_balancer_enis_per_vpc(() ->
+        NETWORK_LOAD_BALANCER_ENIS_PER_VPC),
+    network_load_balancers(() ->
+        NETWORK_LOAD_BALANCERS),
+    rules_per_application_load_balancer(() ->
+        RULES_PER_APPLICATION_LOAD_BALANCER),
+    target_groups(() ->
+        TARGET_GROUPS),
+    target_groups_per_action_on_application_load_balancer(() ->
+        TARGET_GROUPS_PER_ACTION_ON_APPLICATION_LOAD_BALANCER),
+    target_groups_per_action_on_network_load_balancer(() ->
+        TARGET_GROUPS_PER_ACTION_ON_NETWORK_LOAD_BALANCER),
+    target_groups_per_application_load_balancer(() ->
+        TARGET_GROUPS_PER_APPLICATION_LOAD_BALANCER),
+    target_id_registrations_per_application_load_balancer(() ->
+        TARGET_ID_REGISTRATIONS_PER_APPLICATION_LOAD_BALANCER),
+    targets_per_application_load_balancer(() ->
+        TARGETS_PER_APPLICATION_LOAD_BALANCER),
+    targets_per_availability_zone_per_gateway_load_balancer(() ->
+        TARGETS_PER_AVAILABILITY_ZONE_PER_GATEWAY_LOAD_BALANCER),
+    targets_per_availability_zone_per_network_load_balancer(() ->
+        TARGETS_PER_AVAILABILITY_ZONE_PER_NETWORK_LOAD_BALANCER),
+    targets_per_network_load_balancer(() ->
+        TARGETS_PER_NETWORK_LOAD_BALANCER),
+    targets_per_target_group(() ->
+        TARGETS_PER_TARGET_GROUP),
+    ;
+
+    private final Supplier<Integer> limitSupplier;
+
+    Limit(final Supplier<Integer> limitSupplier) {
+      this.limitSupplier = limitSupplier;
+    }
+
+    public String display() {
+      return name().replace('_', '-');
+    }
+
+    public int value() {
+      return limitSupplier.get();
+    }
+  }
+
+  @ConfigurableField(
+      initial = "50",
+      description = "Maximum number of application load balancers.",
+      changeListener = PropertyChangeListeners.IsNonNegativeInteger.class)
+  public static volatile int APPLICATION_LOAD_BALANCERS = 50;
+
+  @ConfigurableField(
+      initial = "25",
+      description = "Maximum number of certificates per application load balancer.",
+      changeListener = PropertyChangeListeners.IsNonNegativeInteger.class)
+  public static volatile int CERTIFICATES_PER_APPLICATION_LOAD_BALANCER = 25;
+
+  @ConfigurableField(
+      initial = "25",
+      description = "Maximum number of certificates per network load balancer.",
+      changeListener = PropertyChangeListeners.IsNonNegativeInteger.class)
+  public static volatile int CERTIFICATES_PER_NETWORK_LOAD_BALANCER = 25;
+
+  @ConfigurableField(
+      initial = "5",
+      description = "Maximum number of condition values per application load balancer rule.",
+      changeListener = PropertyChangeListeners.IsNonNegativeInteger.class)
+  public static volatile int CONDITION_VALUES_PER_ALB_RULE = 5;
+
+  @ConfigurableField(
+      initial = "5",
+      description = "Maximum number of condition wildcards per application load balancer rule.",
+      changeListener = PropertyChangeListeners.IsNonNegativeInteger.class)
+  public static volatile int CONDITION_WILDCARDS_PER_ALB_RULE = 5;
+
+  @ConfigurableField(
+      initial = "50",
+      description = "Maximum number of listeners per application load balancer.",
+      changeListener = PropertyChangeListeners.IsNonNegativeInteger.class)
+  public static volatile int LISTENERS_PER_APPLICATION_LOAD_BALANCER = 50;
+
+  @ConfigurableField(
+      initial = "50",
+      description = "Maximum number of listeners per network load balancer.",
+      changeListener = PropertyChangeListeners.IsNonNegativeInteger.class)
+  public static volatile int LISTENERS_PER_NETWORK_LOAD_BALANCER = 50;
+
+  @ConfigurableField(
+      initial = "300",
+      description = "Maximum number of network load balancer ENIs per VPC.",
+      changeListener = PropertyChangeListeners.IsNonNegativeInteger.class)
+  public static volatile int NETWORK_LOAD_BALANCER_ENIS_PER_VPC = 300;
+
+  @ConfigurableField(
+      initial = "50",
+      description = "Maximum number of network load balancers.",
+      changeListener = PropertyChangeListeners.IsNonNegativeInteger.class)
+  public static volatile int NETWORK_LOAD_BALANCERS = 50;
+
+  @ConfigurableField(
+      initial = "100",
+      description = "Maximum number of rules per application load balancer.",
+      changeListener = PropertyChangeListeners.IsNonNegativeInteger.class)
+  public static volatile int RULES_PER_APPLICATION_LOAD_BALANCER = 100;
+
+  @ConfigurableField(
+      initial = "3000",
+      description = "Maximum number of target groups.",
+      changeListener = PropertyChangeListeners.IsNonNegativeInteger.class)
+  public static volatile int TARGET_GROUPS = 3000;
+
+  @ConfigurableField(
+      initial = "5",
+      description = "Maximum number of target groups per application load balancer action.",
+      changeListener = PropertyChangeListeners.IsNonNegativeInteger.class)
+  public static volatile int TARGET_GROUPS_PER_ACTION_ON_APPLICATION_LOAD_BALANCER = 5;
+
+  @ConfigurableField(
+      initial = "1",
+      description = "Maximum number of target groups per network load balancer action..",
+      changeListener = PropertyChangeListeners.IsNonNegativeInteger.class)
+  public static volatile int TARGET_GROUPS_PER_ACTION_ON_NETWORK_LOAD_BALANCER = 1;
+
+  @ConfigurableField(
+      initial = "100",
+      description = "Maximum number of target groups per application load balancer.",
+      changeListener = PropertyChangeListeners.IsNonNegativeInteger.class)
+  public static volatile int TARGET_GROUPS_PER_APPLICATION_LOAD_BALANCER = 100;
+
+  @ConfigurableField(
+      initial = "100",
+      description = "Maximum number of target identifier registrations per application load balancer.",
+      changeListener = PropertyChangeListeners.IsNonNegativeInteger.class)
+  public static volatile int TARGET_ID_REGISTRATIONS_PER_APPLICATION_LOAD_BALANCER = 100;
+
+  @ConfigurableField(
+      initial = "1000",
+      description = "Maximum number of targets per application load balancer.",
+      changeListener = PropertyChangeListeners.IsNonNegativeInteger.class)
+  public static volatile int TARGETS_PER_APPLICATION_LOAD_BALANCER = 1000;
+
+  @ConfigurableField(
+      initial = "300",
+      description = "Maximum number of targets per zone per gateway load balancer.",
+      changeListener = PropertyChangeListeners.IsNonNegativeInteger.class)
+  public static volatile int TARGETS_PER_AVAILABILITY_ZONE_PER_GATEWAY_LOAD_BALANCER = 300;
+
+  @ConfigurableField(
+      initial = "500",
+      description = "Maximum number of targets per zone per network load balancer.",
+      changeListener = PropertyChangeListeners.IsNonNegativeInteger.class)
+  public static volatile int TARGETS_PER_AVAILABILITY_ZONE_PER_NETWORK_LOAD_BALANCER = 500;
+
+  @ConfigurableField(
+      initial = "3000",
+      description = "Maximum number of targets per network load balancer.",
+      changeListener = PropertyChangeListeners.IsNonNegativeInteger.class)
+  public static volatile int TARGETS_PER_NETWORK_LOAD_BALANCER = 3000;
+
+  @ConfigurableField(
+      initial = "1000",
+      description = "Maximum number of targets per target group.",
+      changeListener = PropertyChangeListeners.IsNonNegativeInteger.class)
+  public static volatile int TARGETS_PER_TARGET_GROUP = 1000;
+
+  @ConfigurableField(
+      initial = "50",
+      description = "Maximum number of user defined tags for a resource.",
+      changeListener = PropertyChangeListeners.IsNonNegativeInteger.class)
+  public static volatile int MAX_TAGS = 50;
+
+}

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/Loadbalancingv2Service.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/Loadbalancingv2Service.java
@@ -27,15 +27,25 @@ import com.eucalyptus.entities.AbstractPersistent_;
 import com.eucalyptus.entities.Entities;
 import com.eucalyptus.entities.TransactionResource;
 import com.eucalyptus.loadbalancing.LoadBalancingHostedZoneManager;
-import com.eucalyptus.loadbalancing.LoadBalancingServiceProperties;
 import com.eucalyptus.loadbalancingv2.common.Loadbalancingv2Metadata;
 import com.eucalyptus.loadbalancingv2.common.msgs.Action;
+import com.eucalyptus.loadbalancingv2.common.msgs.Actions;
 import com.eucalyptus.loadbalancingv2.common.msgs.CertificateList;
 import com.eucalyptus.loadbalancingv2.common.msgs.ForwardActionConfig;
+import com.eucalyptus.loadbalancingv2.common.msgs.HostHeaderConditionConfig;
+import com.eucalyptus.loadbalancingv2.common.msgs.HttpHeaderConditionConfig;
+import com.eucalyptus.loadbalancingv2.common.msgs.HttpRequestMethodConditionConfig;
 import com.eucalyptus.loadbalancingv2.common.msgs.Limit;
 import com.eucalyptus.loadbalancingv2.common.msgs.Limits;
+import com.eucalyptus.loadbalancingv2.common.msgs.ListOfString;
 import com.eucalyptus.loadbalancingv2.common.msgs.Listeners;
+import com.eucalyptus.loadbalancingv2.common.msgs.PathPatternConditionConfig;
+import com.eucalyptus.loadbalancingv2.common.msgs.QueryStringConditionConfig;
+import com.eucalyptus.loadbalancingv2.common.msgs.QueryStringKeyValuePairList;
+import com.eucalyptus.loadbalancingv2.common.msgs.RuleCondition;
+import com.eucalyptus.loadbalancingv2.common.msgs.RuleConditionList;
 import com.eucalyptus.loadbalancingv2.common.msgs.Rules;
+import com.eucalyptus.loadbalancingv2.common.msgs.SourceIpConditionConfig;
 import com.eucalyptus.loadbalancingv2.common.msgs.SubnetMapping;
 import com.eucalyptus.loadbalancingv2.common.msgs.Tag;
 import com.eucalyptus.loadbalancingv2.common.msgs.TagDescription;
@@ -337,6 +347,7 @@ public class Loadbalancingv2Service {
             loadbalancer.getListeners().add(listener);
             loadbalancer.getTargetGroups().addAll(targetGroupList);
             loadbalancer.setUpdateRequired(true);
+            validateLimits(loadbalancer);
             return TypeMappers.transform(
                 listener, com.eucalyptus.loadbalancingv2.common.msgs.Listener.class);
           }
@@ -423,6 +434,10 @@ public class Loadbalancingv2Service {
     final Option<Pair<String, String>> hostedZoneNameAndId =
         LoadBalancingHostedZoneManager.getHostedZoneNameAndId();
 
+    final Loadbalancingv2LimitProperties.Limit limit = type == LoadBalancer.Type.application ?
+        Loadbalancingv2LimitProperties.Limit.application_load_balancers :
+        Loadbalancingv2LimitProperties.Limit.network_load_balancers;
+
     final LoadBalancer loadBalancer;
     try {
       @SuppressWarnings({"Guava", "Convert2Lambda"})
@@ -444,8 +459,12 @@ public class Loadbalancingv2Service {
           newLoadBalancer.setVpcId(vpcIds.iterator().next());
 
           try (final TransactionResource tx = Entities.transactionFor(newLoadBalancer)) {
+            Loadbalancingv2LimitProperties.check(limit,
+                loadBalancers.countByOwnerAndType(ctx.getUserFullName(), type),
+                runtime(limitExceeded("TooManyLoadBalancers")));
             final LoadBalancer persisted = loadBalancers.save(newLoadBalancer);
             addTags(persisted, request.getTags());
+            validateLimits(persisted);
             tx.commit();
             return persisted;
           } catch (Loadbalancingv2MetadataException e) {
@@ -490,6 +509,22 @@ public class Loadbalancingv2Service {
 
     final Integer priority = request.getPriority();
 
+    final Set<String> targetGroupArns = Sets.newHashSet();
+    for (final Action action : request.getActions().getMember()) {
+      Option.of(action.getTargetGroupArn()).forEach(targetGroupArns::add);
+      Option.of(action.getForwardConfig())
+          .map(ForwardActionConfig::getTargetGroups)
+          .map(TargetGroupList::getMember)
+          .map(Stream::ofAll)
+          .getOrElse(Stream.empty())
+          .map(TargetGroupTuple::getTargetGroupArn)
+          .filter(Objects::nonNull)
+          .forEach(targetGroupArns::add);
+    }
+    final Set<String> targetGroupIds = ids(targetGroupArns,
+        Loadbalancingv2ResourceName.Type.targetgroup, arn.getNamespace(),
+        targetNotFound());
+
     final com.eucalyptus.loadbalancingv2.common.msgs.Rule resultRule;
     try {
       resultRule = loadBalancers.updateByExample(
@@ -500,13 +535,43 @@ public class Loadbalancingv2Service {
           loadbalancer -> {
             final Listener listener =
                 loadbalancer.findListener(listenerId).getOrElseThrow(runtime(listenerNotFound()));
+
+            final List<TargetGroup> targetGroupList;
+            try {
+              targetGroupList = targetGroups.list(
+                  ownerFullName,
+                  Restrictions.in("naturalId", targetGroupIds),
+                  Loadbalancingv2Metadatas.filterPrivileged(),
+                  Functions.identity());
+              if (targetGroupList.size() != targetGroupIds.size()) {
+                throw targetNotFound().get();
+              }
+              //TODO when rule targets are used update state here
+              //targetGroupList.forEach(group -> group.getTargets().forEach(target -> {
+              //  if (target.getTargetHealthState() == Target.State.unused) {
+              //    Target.State.initial.apply(target);
+              //  }
+              //}));
+            } catch (final Exception ex) {
+              throw Exceptions.toUndeclared(ex);
+            }
+
             final ListenerRule rule = ListenerRule.create(listener, priority);
             rule.setActions(JsonEncoding.write(request.getActions()));
             rule.setConditions(JsonEncoding.write(request.getConditions()));
+            rule.getTargetGroups().addAll(targetGroupList);
             addTags(Entities.persist(rule), request.getTags());
+            listener.getListenerRules().forEach(existing -> {
+              if (Objects.equals(priority, existing.getPriority())) {
+                throw Exceptions.toUndeclared(
+                    new Loadbalancingv2ClientException("PriorityInUse", "Priority in use"));
+              }
+            });
             listener.getListenerRules().add(rule);
             listener.updateTimeStamps();
+            loadbalancer.getTargetGroups().addAll(targetGroupList);
             loadbalancer.updateTimeStamps();
+            validateLimits(loadbalancer);
             return TypeMappers.transform(
                 rule, com.eucalyptus.loadbalancingv2.common.msgs.Rule.class);
           }
@@ -566,8 +631,12 @@ public class Loadbalancingv2Service {
           );
 
           try (final TransactionResource tx = Entities.transactionFor(newTargetGroup)) {
+            Loadbalancingv2LimitProperties.check(Loadbalancingv2LimitProperties.Limit.target_groups,
+                targetGroups.countByOwner(ctx.getUserFullName()),
+                runtime(limitExceeded("TooManyTargetGroups")));
             final TargetGroup persisted = targetGroups.save(newTargetGroup);
             addTags(persisted, request.getTags());
+            validateLimits(persisted);
             tx.commit();
             return persisted;
           } catch (Loadbalancingv2MetadataException e) {
@@ -620,6 +689,13 @@ public class Loadbalancingv2Service {
                 loadbalancer.findListener(listenerId).getOrElseThrow(runtime(listenerNotFound()));
             Entities.delete(listener);
             loadbalancer.getListeners().remove(listener);
+            final Set<TargetGroup> updatedTargetGroups = Sets.newHashSet();
+            loadbalancer.getListeners().forEach(tgl -> {
+              updatedTargetGroups.addAll(tgl.getTargetGroups());
+              tgl.getListenerRules().forEach(tglr -> updatedTargetGroups.addAll(tglr.getTargetGroups()));
+            });
+            loadbalancer.getTargetGroups().addAll(updatedTargetGroups);
+            loadbalancer.getTargetGroups().retainAll(updatedTargetGroups);
             loadbalancer.updateTimeStamps();
             return null;
           }
@@ -696,6 +772,13 @@ public class Loadbalancingv2Service {
             Entities.delete(rule);
             listener.getListenerRules().remove(rule);
             listener.updateTimeStamps();
+            final Set<TargetGroup> updatedTargetGroups = Sets.newHashSet();
+            loadbalancer.getListeners().forEach(tgl -> {
+              updatedTargetGroups.addAll(tgl.getTargetGroups());
+              tgl.getListenerRules().forEach(tglr -> updatedTargetGroups.addAll(tglr.getTargetGroups()));
+            });
+            loadbalancer.getTargetGroups().addAll(updatedTargetGroups);
+            loadbalancer.getTargetGroups().retainAll(updatedTargetGroups);
             loadbalancer.updateTimeStamps();
             return null;
           }
@@ -1197,6 +1280,7 @@ public class Loadbalancingv2Service {
               }
             }
             group.updateTimeStamps();
+            validateLimits(group);
             return null;
           });
     } catch ( final Loadbalancingv2MetadataNotFoundException e ) {
@@ -1312,10 +1396,183 @@ public class Loadbalancingv2Service {
       throw new Loadbalancingv2ClientException("InvalidConfigurationRequest",
           "Invalid tag key (reserved prefix)");
     }
-    if ((tags.size() - reservedTags) > LoadBalancingServiceProperties.getMaxTags()) {
+    if ((tags.size() - reservedTags) > Loadbalancingv2LimitProperties.getMaxTags()) {
       throw Exceptions.toUndeclared(
           new Loadbalancingv2ClientException("TooManyTags", "Tag limit exceeded"));
     }
+  }
+
+  /**
+   * Caller must hold tx for balancer
+   */
+  private static void validateLimits(final LoadBalancer loadBalancer) {
+    final Loadbalancingv2LimitProperties.Limit listenersLimit;
+    final Loadbalancingv2LimitProperties.Limit certificatesLimit;
+    final Loadbalancingv2LimitProperties.Limit targetGroupLimit;
+    final Loadbalancingv2LimitProperties.Limit targetGroupPerActionLimit;
+    final Loadbalancingv2LimitProperties.Limit rulesLimit;
+    final Loadbalancingv2LimitProperties.Limit targetLimit;
+    final Loadbalancingv2LimitProperties.Limit targetsPerZoneLimit;
+    if ( loadBalancer.getType() == LoadBalancer.Type.application ) {
+      listenersLimit = Loadbalancingv2LimitProperties.Limit.listeners_per_application_load_balancer;
+      rulesLimit = Loadbalancingv2LimitProperties.Limit.rules_per_application_load_balancer;
+      targetGroupLimit = Loadbalancingv2LimitProperties.Limit.target_groups_per_application_load_balancer;
+      targetGroupPerActionLimit = Loadbalancingv2LimitProperties.Limit.target_groups_per_action_on_application_load_balancer;
+      targetLimit = Loadbalancingv2LimitProperties.Limit.targets_per_application_load_balancer;
+      targetsPerZoneLimit = null;
+      certificatesLimit = Loadbalancingv2LimitProperties.Limit.certificates_per_application_load_balancer;
+    } else {
+      listenersLimit = Loadbalancingv2LimitProperties.Limit.listeners_per_network_load_balancer;
+      rulesLimit = null;
+      targetGroupLimit = null;
+      targetGroupPerActionLimit = Loadbalancingv2LimitProperties.Limit.target_groups_per_action_on_network_load_balancer;
+      targetLimit = Loadbalancingv2LimitProperties.Limit.targets_per_network_load_balancer;
+      targetsPerZoneLimit = Loadbalancingv2LimitProperties.Limit.targets_per_availability_zone_per_network_load_balancer;
+      certificatesLimit = Loadbalancingv2LimitProperties.Limit.certificates_per_network_load_balancer;
+    }
+
+    Loadbalancingv2LimitProperties.check(
+        listenersLimit,
+        loadBalancer.getListeners().size(),
+        runtime(limitExceeded("TooManyListeners")));
+
+    Loadbalancingv2LimitProperties.check(
+        targetGroupLimit,
+        loadBalancer.getTargetGroups().size(),
+        runtime(limitExceeded("TooManyUniqueTargetGroupsPerLoadBalancer")));
+
+    Loadbalancingv2LimitProperties.check(
+        targetLimit,
+        Stream.ofAll(loadBalancer.getTargetGroups())
+            .map(TargetGroup::getTargets)
+            .map(List::size)
+            .sum().intValue() ,
+        runtime(limitExceeded("TooManyTargets")));
+
+    Loadbalancingv2LimitProperties.check(
+        targetLimit,
+        Stream.ofAll(
+            Stream.ofAll(loadBalancer.getTargetGroups())
+                .flatMap(TargetGroup::getTargets)
+                .foldLeft(Maps.<String,Integer>newConcurrentMap(), (counts, target) -> {
+                  counts.compute(target.getTargetId(), (key, value) -> value==null? 1 : ++value );
+                  return counts;
+                }).values())
+            .max()
+            .getOrElse(0),
+        runtime(limitExceeded("TooManyRegistrationsForTargetId")));
+
+    Loadbalancingv2LimitProperties.check(
+        rulesLimit,
+        Stream.ofAll(loadBalancer.getListeners())
+            .map(Listener::getListenerRules)
+            .map(List::size)
+            .sum().intValue() ,
+        runtime(limitExceeded("TooManyRules")));
+
+    Stream.ofAll(loadBalancer.getListeners())
+        .flatMap(Listener::getListenerRules)
+        .forEach(rule -> {
+          final Actions actions = rule.getRuleActions();
+          if (actions.getMember().size() > 100) { //TODO configurable limit?
+            throw runtime(limitExceeded("TooManyActions")).get();
+          }
+
+          final Function<RuleCondition,Stream<String>> valuesFunc = condition -> {
+            final List<ListOfString> valueLists = Lists.newArrayList();
+            Option.of(condition.getHostHeaderConfig())
+                .map(HostHeaderConditionConfig::getValues).forEach(valueLists::add);
+            Option.of(condition.getHttpHeaderConfig())
+                .map(HttpHeaderConditionConfig::getValues).forEach(valueLists::add);
+            Option.of(condition.getHttpRequestMethodConfig())
+                .map(HttpRequestMethodConditionConfig::getValues).forEach(valueLists::add);
+            Option.of(condition.getPathPatternConfig())
+                .map(PathPatternConditionConfig::getValues).forEach(valueLists::add);
+            Option.of(condition.getSourceIpConfig())
+                .map(SourceIpConditionConfig::getValues).forEach(valueLists::add);
+            valueLists.add(condition.getValues());
+            return Stream.ofAll(valueLists)
+                .filter(Objects::nonNull)
+                .flatMap(ListOfString::getMember);
+          };
+
+          final Function<String, Integer> wildcardsFunc = value -> {
+            int wildCardCount = 0;
+            if (value != null) {
+              for (final int character : Stream.of('?', '*')) {
+                int index = -1;
+                while((index = value.indexOf(character, index+1)) > -1) {
+                  if (index == 0 || value.charAt(index -1) != '\\') {
+                    wildCardCount++;
+                  }
+                }
+              }
+            }
+            return wildCardCount;
+          };
+
+          final RuleConditionList conditions = rule.getRuleConditions();
+          Loadbalancingv2LimitProperties.check(
+              Loadbalancingv2LimitProperties.Limit.condition_values_per_alb_rule,
+              Stream.ofAll(conditions.getMember())
+                  .map(condition -> {
+                    final int valueCount = valuesFunc.apply(condition).count(__ -> true);
+                    int queryValueCount = 0;
+                    if (condition.getQueryStringConfig() != null &&
+                        condition.getQueryStringConfig().getValues() != null) {
+                      queryValueCount = condition.getQueryStringConfig().getValues().getMember().size();
+                    }
+                    return valueCount + queryValueCount;
+                  })
+                  .sum().intValue(),
+              runtime(invalidAction("Too many values for rule")));
+
+          Loadbalancingv2LimitProperties.check(
+              Loadbalancingv2LimitProperties.Limit.condition_wildcards_per_alb_rule,
+              Stream.ofAll(conditions.getMember())
+                  .map(condition -> {
+                    final int valueWildcardCount =
+                        valuesFunc.apply(condition).map(wildcardsFunc).sum().intValue();
+                    int queryWildcardCount =
+                        Option.of(condition.getQueryStringConfig())
+                            .map(QueryStringConditionConfig::getValues)
+                            .map(QueryStringKeyValuePairList::getMember)
+                            .map(Stream::ofAll)
+                            .getOrElse(Stream.empty())
+                            .flatMap(pair -> Lists.newArrayList(pair.getKey(), pair.getValue()))
+                            .map(wildcardsFunc)
+                            .sum().intValue();
+                    return valueWildcardCount + queryWildcardCount;
+                  })
+                  .sum().intValue(),
+              runtime(invalidAction("Too many values for rule")));
+        });
+
+    Stream.ofAll(loadBalancer.getListeners())
+        .flatMap(Listener::getListenerRules)
+        .map(ListenerRule::getRuleActions)
+        .flatMap(Actions::getMember)
+        .forEach(action -> {
+          int targetGroupCount = 0;
+          if (action.getForwardConfig() != null &&
+              action.getForwardConfig().getTargetGroups() != null) {
+            targetGroupCount += action.getForwardConfig().getTargetGroups().getMember().size();
+          }
+          Loadbalancingv2LimitProperties.check(
+              targetGroupPerActionLimit,
+              targetGroupCount,
+              runtime(limitExceeded("TooManyTargetGroups")));
+        });
+  }
+
+  /**
+   * Caller must hold tx for target group
+   */
+  private static void validateLimits(final TargetGroup targetGroup) {
+    Loadbalancingv2LimitProperties.check(
+        Loadbalancingv2LimitProperties.Limit.targets_per_target_group,
+        targetGroup.getTargets().size(),
+        runtime(limitExceeded("TooManyTargets")));
   }
 
   private static <RT extends TagView, RTE extends AbstractPersistent & Loadbalancingv2Metadata & Taggable<RT>> void addTagsForEntity(
@@ -1393,6 +1650,14 @@ public class Loadbalancingv2Service {
 
   private static CompatSupplier<Loadbalancingv2ClientException> invalidCertificateArn() {
     return () -> new Loadbalancingv2ClientException("InvalidConfigurationRequest", "Invalid certificate ARN");
+  }
+
+  private static CompatSupplier<Loadbalancingv2ClientException> invalidAction(final String message) {
+    return () -> new Loadbalancingv2ClientException("InvalidLoadBalancerAction", message);
+  }
+
+  private static CompatSupplier<Loadbalancingv2ClientException> limitExceeded(final String code) {
+    return () -> new Loadbalancingv2ClientException(code, "Request would exceed limit");
   }
 
   private static CompatSupplier<RuntimeException> runtime(CompatSupplier<? extends Exception> supplier) {
@@ -1477,7 +1742,7 @@ public class Loadbalancingv2Service {
   ) throws Loadbalancingv2Exception {
     final AuthQuotaException quotaCause = Exceptions.findCause( e, AuthQuotaException.class );
     if ( quotaCause != null ) {
-      throw new Loadbalancingv2ClientException( quotaCode, "Request would exceed limit" );
+      throw limitExceeded(quotaCode).get();
     }
 
     return handleException(e, constraintExceptionBuilder);

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/LoadBalancers.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/LoadBalancers.java
@@ -98,6 +98,17 @@ public interface LoadBalancers {
 
   boolean delete(Loadbalancingv2Metadata.LoadbalancerMetadata metadata) throws Loadbalancingv2MetadataException;
 
+  long countByExample(LoadBalancer example) throws Loadbalancingv2MetadataException;
+
+  default long countByOwnerAndType(
+      final OwnerFullName ownerFullName,
+      final LoadBalancer.Type type
+  ) throws Loadbalancingv2MetadataException {
+    final LoadBalancer example = LoadBalancer.named(ownerFullName, null);
+    example.setType(type);
+    return countByExample(example);
+  }
+
   @TypeMapper
   enum LoadBalancerViewToLoadBalancerTransform
       implements Function<LoadBalancerView, com.eucalyptus.loadbalancingv2.common.msgs.LoadBalancer> {

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/TargetGroups.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/TargetGroups.java
@@ -54,9 +54,17 @@ public interface TargetGroups {
       Function<? super TargetGroup, T> updateTransform
   ) throws Loadbalancingv2MetadataException;
 
-  TargetGroup save(TargetGroup loadBalancer) throws Loadbalancingv2MetadataException;
+  TargetGroup save(TargetGroup targetGroup) throws Loadbalancingv2MetadataException;
 
   boolean delete(Loadbalancingv2Metadata.TargetgroupMetadata metadata) throws Loadbalancingv2MetadataException;
+
+  long countByExample(TargetGroup targetGroup) throws Loadbalancingv2MetadataException;
+
+  default long countByOwner(
+      final OwnerFullName ownerFullName
+  ) throws Loadbalancingv2MetadataException {
+    return countByExample(TargetGroup.named(ownerFullName, null));
+  }
 
   @TypeMapper
   enum TargetGroupViewToTargetGroupTransform

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/entities/Listener.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/entities/Listener.java
@@ -238,6 +238,11 @@ public class Listener extends AbstractOwnedPersistent
     return Stream.ofAll(getListenerRules()).find(rule -> naturalId.equals(rule.getNaturalId()));
   }
 
+  /**
+   * Set of target groups referenced by the default actions
+   *
+   * This does not include groups referenced by rule actions.
+   */
   public Set<TargetGroup> getTargetGroups() {
     return targetGroups;
   }

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/entities/TargetGroup.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/entities/TargetGroup.java
@@ -163,7 +163,7 @@ public class TargetGroup extends UserMetadata<TargetGroup.State>
 
   @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true, mappedBy = "targetGroup")
   @OrderBy("targetId")
-  private List<Target> targets;
+  private List<Target> targets = Lists.newArrayList();
 
   @ManyToMany(mappedBy = "targetGroups")
   private List<LoadBalancer> loadBalancers = Lists.newArrayList();


### PR DESCRIPTION
ELBv2 configurable service limits.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1323
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1324

Cloud properties for limits are added:

```
# euctl services.loadbalancingv2.limit
services.loadbalancingv2.limit.application_load_balancers = 50
services.loadbalancingv2.limit.certificates_per_application_load_balancer = 25
services.loadbalancingv2.limit.certificates_per_network_load_balancer = 25
services.loadbalancingv2.limit.condition_values_per_alb_rule = 5
services.loadbalancingv2.limit.condition_wildcards_per_alb_rule = 5
services.loadbalancingv2.limit.listeners_per_application_load_balancer = 50
services.loadbalancingv2.limit.listeners_per_network_load_balancer = 50
services.loadbalancingv2.limit.max_tags = 50
services.loadbalancingv2.limit.network_load_balancer_enis_per_vpc = 300
services.loadbalancingv2.limit.network_load_balancers = 50
services.loadbalancingv2.limit.rules_per_application_load_balancer = 100
services.loadbalancingv2.limit.target_groups = 3000
services.loadbalancingv2.limit.target_groups_per_action_on_application_load_balancer = 5
services.loadbalancingv2.limit.target_groups_per_action_on_network_load_balancer = 1
services.loadbalancingv2.limit.target_groups_per_application_load_balancer = 100
services.loadbalancingv2.limit.target_id_registrations_per_application_load_balancer = 100
services.loadbalancingv2.limit.targets_per_application_load_balancer = 1000
services.loadbalancingv2.limit.targets_per_availability_zone_per_gateway_load_balancer = 300
services.loadbalancingv2.limit.targets_per_availability_zone_per_network_load_balancer = 500
services.loadbalancingv2.limit.targets_per_network_load_balancer = 3000
services.loadbalancingv2.limit.targets_per_target_group = 1000
```

These are hard limits, quota policies can further restrict resource creation for supported resources (load balancers, target groups). These is one additional limit for tags per resource that is not present in the describe output:

```
# aws elbv2 describe-account-limits
LIMITS	50	application-load-balancers
LIMITS	25	certificates-per-application-load-balancer
LIMITS	25	certificates-per-network-load-balancer
LIMITS	5	condition-values-per-alb-rule
LIMITS	5	condition-wildcards-per-alb-rule
LIMITS	20	gateway-load-balancers
LIMITS	10	gateway-load-balancers-per-vpc
LIMITS	50	geneve-target-groups
LIMITS	50	listeners-per-application-load-balancer
LIMITS	50	listeners-per-network-load-balancer
LIMITS	300	network-load-balancer-enis-per-vpc
LIMITS	50	network-load-balancers
LIMITS	100	rules-per-application-load-balancer
LIMITS	3000	target-groups
LIMITS	5	target-groups-per-action-on-application-load-balancer
LIMITS	1	target-groups-per-action-on-network-load-balancer
LIMITS	100	target-groups-per-application-load-balancer
LIMITS	100	target-id-registrations-per-application-load-balancer
LIMITS	10	targets-per-application-load-balancer
LIMITS	300	targets-per-availability-zone-per-gateway-load-balancer
LIMITS	500	targets-per-availability-zone-per-network-load-balancer
LIMITS	3000	targets-per-network-load-balancer
LIMITS	1000	targets-per-target-group
```

Resource changes fail when a limit would be exceeded:

```
# aws elbv2 create-load-balancer --name balancer-1 --subnets ${SUBNET_ID} --security-groups ${GROUP_ID}

An error occurred (TooManyListeners) when calling the CreateLoadBalancer operation: Request would exceed limit
```

```
# aws elbv2 create-listener --port 80 --protocol HTTP --load-balancer-arn ${LOADBALANCER_ARN} --default-actions Type=forward,TargetGroupArn=${TARGETGROUP_ARN}

An error occurred (TooManyTargets) when calling the CreateListener operation: Request would exceed limit
```

Relates to corymbia/eucalyptus#271