### PR TITLE
ELBv2 support for multiple zones

### DIFF
--- a/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/ComputeApi.java
+++ b/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/ComputeApi.java
@@ -7,6 +7,8 @@ package com.eucalyptus.compute.common;
 
 import com.eucalyptus.component.annotation.ComponentPart;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  *
@@ -83,8 +85,20 @@ public interface ComputeApi {
   }
 
   default AllocateAddressResponseType allocateAddress(final String domain) {
+    return allocateAddress(domain, Collections.emptyMap());
+  }
+
+  default AllocateAddressResponseType allocateAddress(final String domain, final Map<String,String> tags) {
     final AllocateAddressType request = new AllocateAddressType();
     request.setDomain(domain);
+    if (tags != null && !tags.isEmpty()) {
+      final ResourceTagSpecification specification = new ResourceTagSpecification();
+      specification.setResourceType("elastic-ip");
+      for (final Map.Entry<String, String> entry : tags.entrySet()) {
+        specification.getTagSet().add(new ResourceTag(entry.getKey(), entry.getValue()));
+      }
+      request.getTagSpecification().add(specification);
+    }
     return allocateAddress(request);
   }
 

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/Loadbalancingv2Service.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/Loadbalancingv2Service.java
@@ -53,6 +53,7 @@ import com.eucalyptus.loadbalancingv2.service.persist.entities.ListenerRule;
 import com.eucalyptus.loadbalancingv2.service.persist.entities.ListenerRule_;
 import com.eucalyptus.loadbalancingv2.service.persist.entities.Listener_;
 import com.eucalyptus.loadbalancingv2.service.persist.entities.LoadBalancer;
+import com.eucalyptus.loadbalancingv2.service.persist.entities.LoadBalancerSubnet;
 import com.eucalyptus.loadbalancingv2.service.persist.entities.Target;
 import com.eucalyptus.loadbalancingv2.service.persist.entities.TargetGroup;
 import com.eucalyptus.loadbalancingv2.service.persist.views.ListenerRuleView;
@@ -149,7 +150,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import io.vavr.collection.Stream;
 import io.vavr.control.Option;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -434,8 +434,11 @@ public class Loadbalancingv2Service {
           hostedZoneNameAndId.map(Pair::getRight).forEach(newLoadBalancer::setCanonicalHostedZoneId);
           newLoadBalancer.setSecurityGroupIds(
               Stream.ofAll(securityGroupItems).map(SecurityGroupItemType::getGroupId).toJavaList());
-          newLoadBalancer.setSubnetIds(
-              Stream.ofAll(subnetItems).map(SubnetType::getSubnetId).toJavaList());
+          newLoadBalancer.setSubnets(Stream.ofAll(subnetItems)
+              .map(subnet -> LoadBalancerSubnet.create(
+                  subnet.getSubnetId(),
+                  subnet.getAvailabilityZone()))
+              .toJavaList());
           newLoadBalancer.setVpcId(vpcIds.iterator().next());
 
           try (final TransactionResource tx = Entities.transactionFor(newLoadBalancer)) {

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/LoadBalancers.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/LoadBalancers.java
@@ -133,9 +133,10 @@ public interface LoadBalancers {
         balancer.setVpcId(view.getVpcId());
 
         final AvailabilityZones availabilityZones = new AvailabilityZones();
-        availabilityZones.getMember().addAll(Stream.ofAll(view.getSubnetIds()).map( subnetId -> {
+        availabilityZones.getMember().addAll(Stream.ofAll(view.getSubnetViews()).map( subnetView -> {
           AvailabilityZone zone = new AvailabilityZone();
-          zone.setSubnetId(subnetId);
+          zone.setSubnetId(subnetView.getSubnetId());
+          zone.setZoneName(subnetView.getAvailabilityZone());
           return zone;
         }).toJavaList());
         balancer.setAvailabilityZones(availabilityZones);

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/entities/LoadBalancer.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/entities/LoadBalancer.java
@@ -14,7 +14,9 @@ import com.eucalyptus.loadbalancing.dns.LoadBalancerDomainName;
 import com.eucalyptus.loadbalancingv2.common.Loadbalancingv2Metadata;
 import com.eucalyptus.loadbalancingv2.common.Loadbalancingv2ResourceName;
 import com.eucalyptus.loadbalancingv2.service.persist.Taggable;
+import com.eucalyptus.loadbalancingv2.service.persist.views.LoadBalancerSubnetView;
 import com.eucalyptus.loadbalancingv2.service.persist.views.LoadBalancerView;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.vavr.collection.Stream;
@@ -127,9 +129,8 @@ public class LoadBalancer extends UserMetadata<LoadBalancer.State>
 
   @ElementCollection
   @CollectionTable( name = "metadata_v2_loadbalancer_subnets", joinColumns = @JoinColumn( name = "metadata_loadbalancer_id" ) )
-  @Column( name = "metadata_subnet_id" )
   @OrderColumn( name = "metadata_subnet_index")
-  private List<String> subnetIds = Lists.newArrayList();
+  private List<LoadBalancerSubnet> subnets = Lists.newArrayList();
 
   @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true, mappedBy = "loadbalancer")
   @OrderBy( "port" )
@@ -264,12 +265,16 @@ public class LoadBalancer extends UserMetadata<LoadBalancer.State>
     this.securityGroupIds = securityGroupIds;
   }
 
-  public List<String> getSubnetIds() {
-    return subnetIds;
+  public List<LoadBalancerSubnetView> getSubnetViews() {
+    return ImmutableList.copyOf(getSubnets());
   }
 
-  public void setSubnetIds(List<String> subnetIds) {
-    this.subnetIds = subnetIds;
+  public List<LoadBalancerSubnet> getSubnets() {
+    return subnets;
+  }
+
+  public void setSubnets(List<LoadBalancerSubnet> subnets) {
+    this.subnets = subnets;
   }
 
   public List<Listener> getListeners() {

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/entities/LoadBalancerSubnet.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/entities/LoadBalancerSubnet.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.loadbalancingv2.service.persist.entities;
+
+import com.eucalyptus.loadbalancingv2.service.persist.views.LoadBalancerSubnetView;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class LoadBalancerSubnet implements LoadBalancerSubnetView {
+
+  @Column(name = "metadata_subnet_id", nullable = false, updatable = false)
+  private String subnetId;
+
+  @Column(name = "metadata_availability_zone", nullable = false, updatable = false)
+  private String availabilityZone;
+
+  public static LoadBalancerSubnet create(
+      final String subnetId,
+      final String availabilityZone
+  ) {
+    final LoadBalancerSubnet subnet = new LoadBalancerSubnet();
+    subnet.setSubnetId(subnetId);
+    subnet.setAvailabilityZone(availabilityZone);
+    return subnet;
+  }
+
+  public String getSubnetId() {
+    return subnetId;
+  }
+
+  public void setSubnetId(String subnetId) {
+    this.subnetId = subnetId;
+  }
+
+  public String getAvailabilityZone() {
+    return availabilityZone;
+  }
+
+  public void setAvailabilityZone(String availabilityZone) {
+    this.availabilityZone = availabilityZone;
+  }
+}

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/views/LoadBalancerSubnetView.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/views/LoadBalancerSubnetView.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.loadbalancingv2.service.persist.views;
+
+import org.immutables.value.Value;
+
+
+@Value.Immutable
+public interface LoadBalancerSubnetView {
+
+  String getSubnetId();
+
+  String getAvailabilityZone();
+
+}

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/views/LoadBalancerView.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/views/LoadBalancerView.java
@@ -6,6 +6,8 @@
 package com.eucalyptus.loadbalancingv2.service.persist.views;
 
 import com.eucalyptus.loadbalancingv2.service.persist.entities.LoadBalancer;
+import io.vavr.collection.Stream;
+import io.vavr.control.Option;
 import java.util.Date;
 import java.util.List;
 import org.immutables.value.Value;
@@ -45,7 +47,13 @@ public interface LoadBalancerView {
 
   List<String> getSecurityGroupIds();
 
-  List<String> getSubnetIds();
+  List<LoadBalancerSubnetView> getSubnetViews();
 
   String getVpcId();
+
+  default Option<LoadBalancerSubnetView> findSubnetView(final String availabilityZone) {
+    return Stream.ofAll(getSubnetViews())
+        .filter(view -> availabilityZone.equals(view.getAvailabilityZone()))
+        .headOption();
+  }
 }


### PR DESCRIPTION
ELBv2 support for load balancers in multiple zones.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1326
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1327

Demo is that the zone is now displayed (`cloud-1a`):

```
# aws elbv2 describe-load-balancers
LOADBALANCERS	ZAAHYUWFUZQSVF	2021-06-04T23:16:51.688Z	balancer-1-000132709131.lb.qa64.eucalyptuscloud.net	ipv4	arn:aws:elasticloadbalancing::000132709131:loadbalancer/app/balancer-1/56f824cd0e9f40d3	balancer-1	internet-facing	application	vpc-d861259f7b9434256
AVAILABILITYZONES	subnet-bca8d02b764312d45	cloud-1a
SECURITYGROUPS	sg-4d2a20839896708d9
STATE	active
```

and that deployed stacks include the zone name, e.g. `loadbalancer-app-000132709131-cloud-1a-balancer-1`.

Relates to corymbia/eucalyptus#271