### PR TITLE
ELBv2 load balancer and target group attributes

### DIFF
--- a/clc/modules/loadbalancingv2-common/src/main/java/com/eucalyptus/loadbalancingv2/common/msgs/LoadBalancerAttribute.java
+++ b/clc/modules/loadbalancingv2-common/src/main/java/com/eucalyptus/loadbalancingv2/common/msgs/LoadBalancerAttribute.java
@@ -17,6 +17,13 @@ public class LoadBalancerAttribute extends EucalyptusData {
   @FieldRange(max = 1024)
   private String value;
 
+  public static LoadBalancerAttribute of(final String key, final String value) {
+    final LoadBalancerAttribute attribute = new LoadBalancerAttribute();
+    attribute.setKey(key);
+    attribute.setValue(value);
+    return attribute;
+  }
+
   public String getKey() {
     return key;
   }

--- a/clc/modules/loadbalancingv2-common/src/main/java/com/eucalyptus/loadbalancingv2/common/msgs/TargetGroupAttribute.java
+++ b/clc/modules/loadbalancingv2-common/src/main/java/com/eucalyptus/loadbalancingv2/common/msgs/TargetGroupAttribute.java
@@ -14,7 +14,15 @@ public class TargetGroupAttribute extends EucalyptusData {
   @FieldRange(max = 256)
   private String key;
 
+  @FieldRange(max = 1024)
   private String value;
+
+  public static TargetGroupAttribute of(final String key, final String value) {
+    final TargetGroupAttribute attribute = new TargetGroupAttribute();
+    attribute.setKey(key);
+    attribute.setValue(value);
+    return attribute;
+  }
 
   public String getKey() {
     return key;

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/Loadbalancingv2Service.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/Loadbalancingv2Service.java
@@ -31,6 +31,8 @@ import com.eucalyptus.loadbalancingv2.common.msgs.Action;
 import com.eucalyptus.loadbalancingv2.common.msgs.CertificateList;
 import com.eucalyptus.loadbalancingv2.common.msgs.ForwardActionConfig;
 import com.eucalyptus.loadbalancingv2.common.msgs.Listeners;
+import com.eucalyptus.loadbalancingv2.common.msgs.LoadBalancerAttribute;
+import com.eucalyptus.loadbalancingv2.common.msgs.LoadBalancerAttributes;
 import com.eucalyptus.loadbalancingv2.common.msgs.Rules;
 import com.eucalyptus.loadbalancingv2.common.msgs.SubnetMapping;
 import com.eucalyptus.loadbalancingv2.common.msgs.Tag;
@@ -39,10 +41,13 @@ import com.eucalyptus.loadbalancingv2.common.msgs.TagDescriptions;
 import com.eucalyptus.loadbalancingv2.common.msgs.TagList;
 import com.eucalyptus.loadbalancingv2.common.msgs.TargetDescription;
 import com.eucalyptus.loadbalancingv2.common.msgs.TargetDescriptions;
+import com.eucalyptus.loadbalancingv2.common.msgs.TargetGroupAttribute;
+import com.eucalyptus.loadbalancingv2.common.msgs.TargetGroupAttributes;
 import com.eucalyptus.loadbalancingv2.common.msgs.TargetGroupList;
 import com.eucalyptus.loadbalancingv2.common.msgs.TargetGroupTuple;
 import com.eucalyptus.loadbalancingv2.service.persist.JsonEncoding;
 import com.eucalyptus.loadbalancingv2.service.persist.LoadBalancers;
+import com.eucalyptus.loadbalancingv2.service.persist.LoadBalancingAttribute;
 import com.eucalyptus.loadbalancingv2.service.persist.Loadbalancingv2MetadataException;
 import com.eucalyptus.loadbalancingv2.service.persist.Loadbalancingv2MetadataNotFoundException;
 import com.eucalyptus.loadbalancingv2.service.persist.Taggable;
@@ -149,7 +154,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import io.vavr.collection.Stream;
 import io.vavr.control.Option;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -219,7 +223,7 @@ public class Loadbalancingv2Service {
               addTagsForEntity(loadbalancerNotFound(), LoadBalancer.class, arn.getId(), request.getTags());
               break;
             case targetgroup:
-              addTagsForEntity(targetNotFound(), TargetGroup.class, arn.getId(), request.getTags());
+              addTagsForEntity(targetGroupNotFound(), TargetGroup.class, arn.getId(), request.getTags());
               break;
             default:
               throw invalidArn().get();
@@ -284,7 +288,7 @@ public class Loadbalancingv2Service {
     }
     final Set<String> targetGroupIds = ids(targetGroupArns,
         Loadbalancingv2ResourceName.Type.targetgroup, arn.getNamespace(),
-        targetNotFound());
+        targetGroupNotFound());
 
     final com.eucalyptus.loadbalancingv2.common.msgs.Listener resultListener;
     try {
@@ -313,7 +317,7 @@ public class Loadbalancingv2Service {
                   Loadbalancingv2Metadatas.filterPrivileged(),
                   Functions.identity());
               if (targetGroupList.size() != targetGroupIds.size()) {
-                throw targetNotFound().get();
+                throw targetGroupNotFound().get();
               }
               targetGroupList.forEach(group -> group.getTargets().forEach(target -> {
                 if (target.getTargetHealthState() == Target.State.unused) {
@@ -726,7 +730,7 @@ public class Loadbalancingv2Service {
               Functions.identity());
       targetGroups.delete( targetGroup );
     } catch ( final Loadbalancingv2MetadataNotFoundException e ) {
-      throw targetNotFound().get();
+      throw targetGroupNotFound().get();
     } catch ( final Exception e ) {
       handleException( e, __ -> new Loadbalancingv2ClientException("ResourceInUse", "Target group in use") );
     }
@@ -765,7 +769,7 @@ public class Loadbalancingv2Service {
             return null;
           });
     } catch ( final Loadbalancingv2MetadataNotFoundException e ) {
-      throw targetNotFound().get();
+      throw targetGroupNotFound().get();
     } catch ( final Exception e ) {
       throw handleException( e );
     }
@@ -850,8 +854,38 @@ public class Loadbalancingv2Service {
     return reply;
   }
 
-  public DescribeLoadBalancerAttributesResponseType describeLoadBalancerAttributes(final DescribeLoadBalancerAttributesType request) {
-    return request.getReply();
+  public DescribeLoadBalancerAttributesResponseType describeLoadBalancerAttributes(
+      final DescribeLoadBalancerAttributesType request
+  ) throws Loadbalancingv2Exception {
+    final DescribeLoadBalancerAttributesResponseType reply = request.getReply();
+    final Context ctx = Contexts.lookup( );
+
+    final Loadbalancingv2ResourceName loadbalancerArn;
+    try {
+      loadbalancerArn = Loadbalancingv2ResourceName.parse(
+          request.getLoadBalancerArn(), Loadbalancingv2ResourceName.Type.loadbalancer);
+    } catch (final Loadbalancingv2ResourceName.InvalidResourceNameException ex) {
+      throw new Loadbalancingv2ClientException("InvalidParameterValue", "Invalid loadbalancer ARN");
+    }
+
+    final OwnerFullName ownerFullName = ctx.isAdministrator() ?
+        AccountFullName.getInstance(loadbalancerArn.getNamespace()) :
+        ctx.getAccount();
+
+    try {
+      reply.getDescribeLoadBalancerAttributesResult().setAttributes(
+          loadBalancers.lookupByName(
+              ownerFullName,
+              loadbalancerArn.getName(),
+              Loadbalancingv2Metadatas.filterPrivileged(),
+              TypeMappers.lookup(LoadBalancer.class, LoadBalancerAttributes.class))
+      );
+    } catch (final Loadbalancingv2MetadataNotFoundException ex) {
+      throw loadbalancerNotFound().get();
+    } catch ( Exception e ) {
+      throw handleException( e );
+    }
+    return reply;
   }
 
   public DescribeLoadBalancersResponseType describeLoadBalancers(final DescribeLoadBalancersType request) throws Loadbalancingv2Exception {
@@ -990,8 +1024,38 @@ public class Loadbalancingv2Service {
     return reply;
   }
 
-  public DescribeTargetGroupAttributesResponseType describeTargetGroupAttributes(final DescribeTargetGroupAttributesType request) {
-    return request.getReply();
+  public DescribeTargetGroupAttributesResponseType describeTargetGroupAttributes(
+      final DescribeTargetGroupAttributesType request
+  ) throws Loadbalancingv2Exception {
+    final DescribeTargetGroupAttributesResponseType reply = request.getReply();
+    final Context ctx = Contexts.lookup( );
+
+    final Loadbalancingv2ResourceName targetGroupArn;
+    try {
+      targetGroupArn = Loadbalancingv2ResourceName.parse(
+          request.getTargetGroupArn(), Loadbalancingv2ResourceName.Type.targetgroup);
+    } catch (final Loadbalancingv2ResourceName.InvalidResourceNameException ex) {
+      throw new Loadbalancingv2ClientException("InvalidParameterValue", "Invalid target group ARN");
+    }
+
+    final OwnerFullName ownerFullName = ctx.isAdministrator() ?
+        AccountFullName.getInstance(targetGroupArn.getNamespace()) :
+        ctx.getAccount();
+
+    try {
+      reply.getDescribeTargetGroupAttributesResult().setAttributes(
+          targetGroups.lookupByName(
+              ownerFullName,
+              targetGroupArn.getName(),
+              Loadbalancingv2Metadatas.filterPrivileged(),
+              TypeMappers.lookup(TargetGroup.class, TargetGroupAttributes.class))
+      );
+    } catch (final Loadbalancingv2MetadataNotFoundException ex) {
+      throw targetGroupNotFound().get();
+    } catch ( Exception e ) {
+      throw handleException( e );
+    }
+    return reply;
   }
 
   public DescribeTargetGroupsResponseType describeTargetGroups(final DescribeTargetGroupsType request) throws Loadbalancingv2Exception {
@@ -1101,8 +1165,58 @@ public class Loadbalancingv2Service {
     return request.getReply();
   }
 
-  public ModifyLoadBalancerAttributesResponseType modifyLoadBalancerAttributes(final ModifyLoadBalancerAttributesType request) {
-    return request.getReply();
+  public ModifyLoadBalancerAttributesResponseType modifyLoadBalancerAttributes(
+      final ModifyLoadBalancerAttributesType request
+  ) throws Loadbalancingv2Exception {
+    final ModifyLoadBalancerAttributesResponseType reply = request.getReply();
+    final Context ctx = Contexts.lookup();
+
+    final Loadbalancingv2ResourceName arn;
+    try {
+      arn = Loadbalancingv2ResourceName.parse(
+          request.getLoadBalancerArn(), Loadbalancingv2ResourceName.Type.loadbalancer);
+    } catch (final Loadbalancingv2ResourceName.InvalidResourceNameException ex) {
+      throw new Loadbalancingv2ClientException("InvalidParameterValue", "Invalid loadbalancer ARN");
+    }
+
+    final OwnerFullName ownerFullName =
+        ctx.isAdministrator( ) ?
+            AccountFullName.getInstance(arn.getNamespace()) :
+            ctx.getAccount();
+
+    final Map<String,String> modifiedAttributes = Maps.newHashMap();
+    for (final LoadBalancerAttribute attribute : request.getAttributes().getMember()) {
+      final String key = attribute.getKey();
+      final String value = attribute.getValue();
+      if (modifiedAttributes.put(key, value) != null) {
+        throw invalidConfiguration().apply("Duplicate attribute key");
+      }
+    }
+
+    try {
+      LoadBalancerAttributes attributes = loadBalancers.updateByExample(
+          LoadBalancer.named(ownerFullName, arn.getName()),
+          ownerFullName,
+          arn.getName(),
+          Loadbalancingv2Metadatas.filterPrivileged(),
+          loadbalancer -> {
+            loadbalancer.getAttributes().putAll(modifiedAttributes);
+            LoadBalancingAttribute.validate(
+                runtime(invalidConfiguration()),
+                Loadbalancingv2Metadata.LoadbalancerMetadata.class,
+                loadbalancer.getType(),
+                loadbalancer.getAttributes());
+            loadbalancer.updateTimeStamps();
+            return TypeMappers.transform(loadbalancer, LoadBalancerAttributes.class);
+          }
+      );
+      reply.getModifyLoadBalancerAttributesResult().setAttributes(attributes);
+    } catch (final Loadbalancingv2MetadataNotFoundException ex) {
+      throw loadbalancerNotFound().get();
+    } catch (final Exception ex) {
+      throw handleException(ex);
+    }
+    return reply;
   }
 
   public ModifyRuleResponseType modifyRule(final ModifyRuleType request) {
@@ -1113,9 +1227,58 @@ public class Loadbalancingv2Service {
     return request.getReply();
   }
 
-  public ModifyTargetGroupAttributesResponseType modifyTargetGroupAttributes(final ModifyTargetGroupAttributesType request) {
-    return request.getReply();
-  }
+  public ModifyTargetGroupAttributesResponseType modifyTargetGroupAttributes(
+      final ModifyTargetGroupAttributesType request
+  ) throws Loadbalancingv2Exception {
+    final ModifyTargetGroupAttributesResponseType reply = request.getReply();
+    final Context ctx = Contexts.lookup();
+
+    final Loadbalancingv2ResourceName arn;
+    try {
+      arn = Loadbalancingv2ResourceName.parse(
+          request.getTargetGroupArn(), Loadbalancingv2ResourceName.Type.targetgroup);
+    } catch (final Loadbalancingv2ResourceName.InvalidResourceNameException ex) {
+      throw new Loadbalancingv2ClientException("InvalidParameterValue", "Invalid target group ARN");
+    }
+
+    final OwnerFullName ownerFullName =
+        ctx.isAdministrator( ) ?
+            AccountFullName.getInstance(arn.getNamespace()) :
+            ctx.getAccount();
+
+    final Map<String,String> modifiedAttributes = Maps.newHashMap();
+    for (final TargetGroupAttribute attribute : request.getAttributes().getMember()) {
+      final String key = attribute.getKey();
+      final String value = attribute.getValue();
+      if (modifiedAttributes.put(key, value) != null) {
+        throw invalidConfiguration().apply("Duplicate attribute key");
+      }
+    }
+
+    try {
+      TargetGroupAttributes attributes = targetGroups.updateByExample(
+          TargetGroup.named(ownerFullName, arn.getName()),
+          ownerFullName,
+          arn.getName(),
+          Loadbalancingv2Metadatas.filterPrivileged(),
+          targetGroup -> {
+            targetGroup.getAttributes().putAll(modifiedAttributes);
+            LoadBalancingAttribute.validate(
+                runtime(invalidConfiguration()),
+                Loadbalancingv2Metadata.TargetgroupMetadata.class,
+                null,
+                targetGroup.getAttributes());
+            targetGroup.updateTimeStamps();
+            return TypeMappers.transform(targetGroup, TargetGroupAttributes.class);
+          }
+      );
+      reply.getModifyTargetGroupAttributesResult().setAttributes(attributes);
+    } catch (final Loadbalancingv2MetadataNotFoundException ex) {
+      throw loadbalancerNotFound().get();
+    } catch (final Exception ex) {
+      throw handleException(ex);
+    }
+    return reply;  }
 
   public RegisterTargetsResponseType registerTargets(final RegisterTargetsType request) throws Loadbalancingv2Exception {
     final RegisterTargetsResponseType reply = request.getReply();
@@ -1188,7 +1351,7 @@ public class Loadbalancingv2Service {
             return null;
           });
     } catch ( final Loadbalancingv2MetadataNotFoundException e ) {
-      throw targetNotFound().get();
+      throw targetGroupNotFound().get();
     } catch ( final Exception e ) {
       throw handleException( e );
     }
@@ -1363,7 +1526,7 @@ public class Loadbalancingv2Service {
     return () -> new Loadbalancingv2ClientException("RuleNotFound", "Listener rule not found");
   }
 
-  private static CompatSupplier<Loadbalancingv2ClientException> targetNotFound() {
+  private static CompatSupplier<Loadbalancingv2ClientException> targetGroupNotFound() {
     return () -> new Loadbalancingv2ClientException("TargetGroupNotFound", "Target group not found");
   }
 
@@ -1383,6 +1546,13 @@ public class Loadbalancingv2Service {
     return () -> new Loadbalancingv2ClientException("InvalidConfigurationRequest", "Invalid certificate ARN");
   }
 
+  private static CompatFunction<String, Loadbalancingv2ClientException> invalidConfiguration() {
+    return message -> new Loadbalancingv2ClientException("InvalidConfigurationRequest", message);
+  }
+
+  private static CompatFunction<String, RuntimeException> runtime(CompatFunction<String, ? extends Exception> function) {
+    return message -> Exceptions.toUndeclared(function.apply(message));
+  }
   private static CompatSupplier<RuntimeException> runtime(CompatSupplier<? extends Exception> supplier) {
     return () -> Exceptions.toUndeclared(supplier.get());
   }

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/LoadBalancingAttribute.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/LoadBalancingAttribute.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.loadbalancingv2.service.persist;
+
+import com.eucalyptus.loadbalancingv2.common.Loadbalancingv2Metadata;
+import com.eucalyptus.loadbalancingv2.service.persist.entities.LoadBalancer;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class LoadBalancingAttribute {
+
+  private static final EnumSet<LoadBalancer.Type> ANY = EnumSet.allOf(LoadBalancer.Type.class);
+  private static final EnumSet<LoadBalancer.Type> APP = EnumSet.of(LoadBalancer.Type.application);
+  private static final EnumSet<LoadBalancer.Type> NET = EnumSet.of(LoadBalancer.Type.network);
+  private static final Set<String> VALUES_BOOLEAN = ImmutableSet.of("true", "false");
+
+  public enum Attribute {
+    //
+    // Load balancer attributes
+    //
+    LoadBalancerAccessLogsS3Enabled(ANY, "access_logs.s3.enabled", "false", VALUES_BOOLEAN){
+      @Override
+      public void validate(
+          final String value,
+          final Map<String, String> attributes
+      ) throws IllegalArgumentException {
+        super.validate(value, attributes);
+        if("true".equals(value)) {
+          if (!attributes.containsKey(LoadBalancerAccessLogsS3Bucket.key()) ||
+              attributes.get(LoadBalancerAccessLogsS3Bucket.key()).isEmpty() ) {
+            throw new IllegalArgumentException("Bucket required when access logging enabled");
+          }
+        }
+      }
+    },
+    LoadBalancerAccessLogsS3Bucket(ANY, "access_logs.s3.bucket"),
+    LoadBalancerAccessLogsS3Prefix(ANY, "access_logs.s3.prefix"),
+    LoadBalancerDeletionProtectionEnabled(ANY, "deletion_protection.enabled", "false", VALUES_BOOLEAN),
+    LoadBalancerIdleTimeoutSeconds(APP, "idle_timeout.timeout_seconds", "60", 0, 86400),
+    LoadBalancerCrossZoneEnabled(NET, "load_balancing.cross_zone.enabled", "false", VALUES_BOOLEAN),
+    LoadBalancerRoutingHttpDesyncMode(APP, "routing.http.desync_mitigation_mode", "defensive", ImmutableSet.of("monitor", "defensive", "strictest")),
+    LoadBalancerRoutingHttpDropHeaders(APP, "routing.http.drop_invalid_header_fields.enabled", "false", VALUES_BOOLEAN),
+    LoadBalancerRoutingHttp2Enabled(APP, "routing.http2.enabled", "true", VALUES_BOOLEAN),
+    LoadBalancerWafFailOpenEnabled(APP, "waf.fail_open.enabled", "false", VALUES_BOOLEAN),
+
+    //
+    // Target group attributes
+    //
+    TargetGroupDeregDelayTimeoutSeconds(ANY, "deregistration_delay.timeout_seconds", "300", 0, 3600),
+    TargetGroupDeregDelayConnTermEnabled(NET, "deregistration_delay.connection_termination.enabled", "false", VALUES_BOOLEAN),
+    TargetGroupBalancingAlgorithmType(APP, "load_balancing.algorithm.type", "round_robin", ImmutableSet.of("round_robin", "least_outstanding_requests")),
+    TargetGroupPreserveClientIpEnabled(NET, "preserve_client_ip.enabled", "false", VALUES_BOOLEAN),
+    TargetGroupProxyProtocolV2Enabled(NET, "proxy_protocol_v2.enabled", "false", VALUES_BOOLEAN),
+    TargetGroupSlowStartDurationSeconds(APP, "slow_start.duration_seconds", "0", 0, 900),
+    TargetGroupStickinessEnabled(ANY, "stickiness.enabled", "false", VALUES_BOOLEAN),
+    TargetGroupStickinessAppCookieName(APP, "stickiness.app_cookie.cookie_name") {
+      @Override
+      public void validate(
+          final String value,
+          final Map<String, String> attributes
+      ) throws IllegalArgumentException {
+        super.validate(value, attributes);
+        final String upperValue = Objects.toString(value, "").toUpperCase();
+        if (upperValue.startsWith("AWSALB") ||
+            upperValue.startsWith("AWSALBAPP") ||
+            upperValue.startsWith("AWSALBTG")) {
+          throw new IllegalArgumentException("Reserved cookie name prefix");
+        }
+      }
+    },
+    TargetGroupStickinessAppCookieSeconds(APP, "stickiness.app_cookie.duration_seconds", "86400", 1, 604800),
+    TargetGroupStickinessLbCookieSeconds(APP, "stickiness.lb_cookie.duration_seconds", "86400", 1, 604800),
+    TargetGroupAppStickinessType(ANY, "stickiness.type", null, ImmutableSet.of("app_cookie", "lb_cookie", "source_ip")),
+    ;
+
+    private final Class<? extends Loadbalancingv2Metadata> resourceClass;
+    private final EnumSet<LoadBalancer.Type> types;
+    private final String key;
+    private final String defaultValue;
+    private final Predicate<String> validator;
+
+    Attribute(final EnumSet<LoadBalancer.Type> types, final String key) {
+      this(types, key, null, __ -> true);
+    }
+
+    Attribute(
+        final EnumSet<LoadBalancer.Type> types,
+        final String key,
+        final String defaultValue,
+        final Set<String> permittedValues
+    ) {
+      this(types, key, defaultValue, value -> permittedValues.isEmpty() || permittedValues.contains(value));
+    }
+
+    Attribute(
+        final EnumSet<LoadBalancer.Type> types,
+        final String key,
+        final String defaultValue,
+        final long minValue,
+        final long maxValue
+    ) {
+      this(types, key, defaultValue, value -> {
+        long longValue = Long.parseLong(value);
+        return longValue >= minValue && longValue <= maxValue;
+      });
+    }
+
+    Attribute(
+        final EnumSet<LoadBalancer.Type> types,
+        final String key,
+        final String defaultValue,
+        final Predicate<String> validator
+    ) {
+      this.resourceClass = name().startsWith("LoadBalancer") ?
+          Loadbalancingv2Metadata.LoadbalancerMetadata.class :
+          Loadbalancingv2Metadata.TargetgroupMetadata.class;
+      this.types = types;
+      this.key = key;
+      this.defaultValue = defaultValue;
+      this.validator = validator;
+    }
+
+    public String key() {
+      return key;
+    }
+
+    public String defaultValue() {
+      return defaultValue;
+    }
+
+    public Boolean booleanValue(final Map<String,String> attributes) {
+      final String stringValue = stringValue(attributes);
+      return Boolean.parseBoolean(stringValue);
+    }
+
+    public Integer integerValue(final Map<String,String> attributes) {
+      final String stringValue = stringValue(attributes);
+      try {
+        return Integer.parseUnsignedInt(stringValue);
+      } catch (NumberFormatException ignore){}
+      return null;
+    }
+
+    public String stringValue(final Map<String,String> attributes) {
+      return attributes.getOrDefault(key(), defaultValue());
+    }
+
+    public void validate(final String value, final Map<String,String> attributes) throws IllegalArgumentException {
+      if (value.length() > 1024) throw new IllegalArgumentException("Value too large");
+      if (!validator.test(value)) throw new IllegalArgumentException("Invalid value for " + key());
+    }
+  }
+
+  public static Set<Attribute> attributes(
+      final Class<? extends Loadbalancingv2Metadata> resourceClass,
+      final LoadBalancer.Type type
+  ) {
+    final Set<Attribute> attributes = Sets.newLinkedHashSet();
+    for (final Attribute attribute : Attribute.values()) {
+      if ((type == null || attribute.types.contains(type)) &&
+          resourceClass.equals(attribute.resourceClass)) {
+        attributes.add(attribute);
+      }
+    }
+    return attributes;
+  }
+
+  public static Map<String, String> defaults(
+      @Nonnull final Class<? extends Loadbalancingv2Metadata> resourceClass
+  ) {
+    return defaults(resourceClass, null);
+  }
+
+  public static Map<String, String> defaults(
+      @Nonnull  final Class<? extends Loadbalancingv2Metadata> resourceClass,
+      @Nullable final LoadBalancer.Type type
+  ) {
+    final Map<String,String> attributeMap = Maps.newLinkedHashMap();
+    for (final Attribute attribute : Attribute.values()) {
+      if ((type == null || attribute.types.contains(type)) &&
+          resourceClass.equals(attribute.resourceClass)) {
+        attributeMap.put(attribute.key(), attribute.defaultValue());
+      }
+    }
+    return attributeMap;
+  }
+
+  public static <T extends Throwable> void validate(
+      @Nonnull  final Function<String, T> onFail,
+      @Nonnull  final Class<? extends Loadbalancingv2Metadata> resourceClass,
+      @Nullable final LoadBalancer.Type type,
+      @Nonnull  final Map<String,String> attributeMap
+  ) throws T {
+    try {
+      final Set<String> allowedKeys = Sets.newHashSet();
+      for (final Attribute attribute : attributes(resourceClass, type)) {
+        allowedKeys.add(attribute.key());
+        if (attributeMap.containsKey(attribute.key())) {
+          attribute.validate(attributeMap.get(attribute.key()), attributeMap);
+        }
+      }
+      if (!allowedKeys.containsAll(attributeMap.keySet())) {
+        throw onFail.apply("Unknown attribute key(s)");
+      }
+    } catch(final IllegalArgumentException e) {
+      throw onFail.apply(e.getMessage());
+    }
+  }
+}

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/entities/LoadBalancer.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/entities/LoadBalancer.java
@@ -16,10 +16,12 @@ import com.eucalyptus.loadbalancingv2.common.Loadbalancingv2ResourceName;
 import com.eucalyptus.loadbalancingv2.service.persist.Taggable;
 import com.eucalyptus.loadbalancingv2.service.persist.views.LoadBalancerView;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import io.vavr.collection.Stream;
 import io.vavr.control.Option;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.persistence.CascadeType;
 import javax.persistence.CollectionTable;
@@ -32,6 +34,7 @@ import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
+import javax.persistence.MapKeyColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 import javax.persistence.OrderColumn;
@@ -130,6 +133,13 @@ public class LoadBalancer extends UserMetadata<LoadBalancer.State>
   @Column( name = "metadata_subnet_id" )
   @OrderColumn( name = "metadata_subnet_index")
   private List<String> subnetIds = Lists.newArrayList();
+
+  @ElementCollection
+  @CollectionTable(name = "metadata_v2_loadbalancer_attribute")
+  @MapKeyColumn(name = "metadata_key")
+  @Column(name = "metadata_value", length = 1024)
+  @JoinColumn(name = "loadbalancer_id")
+  private Map<String, String> attributes = Maps.newHashMap();
 
   @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true, mappedBy = "loadbalancer")
   @OrderBy( "port" )
@@ -270,6 +280,14 @@ public class LoadBalancer extends UserMetadata<LoadBalancer.State>
 
   public void setSubnetIds(List<String> subnetIds) {
     this.subnetIds = subnetIds;
+  }
+
+  public Map<String, String> getAttributes() {
+    return attributes;
+  }
+
+  public void setAttributes(Map<String, String> attributes) {
+    this.attributes = attributes;
   }
 
   public List<Listener> getListeners() {

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/entities/TargetGroup.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/entities/TargetGroup.java
@@ -15,17 +15,23 @@ import com.eucalyptus.loadbalancingv2.service.persist.views.TargetGroupView;
 import com.eucalyptus.loadbalancingv2.common.Loadbalancingv2Metadata;
 import com.eucalyptus.loadbalancingv2.common.Loadbalancingv2ResourceName;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import io.vavr.collection.Stream;
 import io.vavr.control.Option;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 import javax.persistence.CascadeType;
+import javax.persistence.CollectionTable;
 import javax.persistence.Column;
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
 import javax.persistence.ManyToMany;
+import javax.persistence.MapKeyColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 import javax.persistence.PersistenceContext;
@@ -160,6 +166,13 @@ public class TargetGroup extends UserMetadata<TargetGroup.State>
 
   @Column(name = "targetgroup_unhealthy_threshold_count")
   private Integer unhealthyThresholdCount;
+
+  @ElementCollection
+  @CollectionTable(name = "metadata_v2_targetgroup_attribute")
+  @MapKeyColumn(name = "metadata_key")
+  @Column(name = "metadata_value", length = 1024)
+  @JoinColumn(name = "targetgroup_id")
+  private Map<String, String> attributes = Maps.newHashMap();
 
   @OneToMany(cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true, mappedBy = "targetGroup")
   @OrderBy("targetId")
@@ -336,6 +349,14 @@ public class TargetGroup extends UserMetadata<TargetGroup.State>
 
   public void setUnhealthyThresholdCount(Integer unhealthyThresholdCount) {
     this.unhealthyThresholdCount = unhealthyThresholdCount;
+  }
+
+  public Map<String, String> getAttributes() {
+    return attributes;
+  }
+
+  public void setAttributes(Map<String, String> attributes) {
+    this.attributes = attributes;
   }
 
   public List<Target> getTargets() {


### PR DESCRIPTION
ELBv2 attributes for load balancers and target groups.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1338
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1339

Demo is that attributes can be described and modified:

```
#
# aws elbv2 modify-load-balancer-attributes --load-balancer-arn ${LOADBALANCER_ARN} --attributes Key=access_logs.s3.enabled,Value=true Key=access_logs.s3.bucket,Value=elblogs Key=access_logs.s3.prefix,Value=logs
ATTRIBUTES	access_logs.s3.enabled	true
ATTRIBUTES	access_logs.s3.bucket	elblogs
ATTRIBUTES	access_logs.s3.prefix	logs
ATTRIBUTES	deletion_protection.enabled	false
ATTRIBUTES	idle_timeout.timeout_seconds	60
ATTRIBUTES	routing.http.desync_mitigation_mode	defensive
ATTRIBUTES	routing.http.drop_invalid_header_fields.enabled	false
ATTRIBUTES	routing.http2.enabled	true
ATTRIBUTES	waf.fail_open.enabled	false
#
#
# aws elbv2 modify-target-group-attributes --target-group-arn ${TARGETGROUP_ARN} --attributes Key=stickiness.enabled,Value=true Key=stickiness.type,Value=lb_cookie Key=stickiness.lb_cookie.duration_seconds,Value=30
ATTRIBUTES	deregistration_delay.timeout_seconds	300
ATTRIBUTES	deregistration_delay.connection_termination.enabled	false
ATTRIBUTES	load_balancing.algorithm.type	round_robin
ATTRIBUTES	preserve_client_ip.enabled	false
ATTRIBUTES	proxy_protocol_v2.enabled	false
ATTRIBUTES	slow_start.duration_seconds	0
ATTRIBUTES	stickiness.enabled	true
ATTRIBUTES	stickiness.app_cookie.duration_seconds	86400
ATTRIBUTES	stickiness.lb_cookie.duration_seconds	30
ATTRIBUTES	stickiness.type	lb_cookie
#
#
```

Supported attributes are those permitted by the existing backend:

* Application stickiness
* Load balancer stickiness
* Connection settings
* Access logging to s3 bucket
* Cross zone load balancing

Relates to corymbia/eucalyptus#271