### PR TITLE
ELBv2 s3 access logging permissions

### DIFF
--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/Loadbalancingv2Service.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/Loadbalancingv2Service.java
@@ -1306,7 +1306,7 @@ public class Loadbalancingv2Service {
                 Loadbalancingv2Metadata.LoadbalancerMetadata.class,
                 loadbalancer.getType(),
                 loadbalancer.getAttributes());
-            loadbalancer.updateTimeStamps();
+            loadbalancer.setUpdateRequired(true);
             return TypeMappers.transform(loadbalancer, LoadBalancerAttributes.class);
           }
       );

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/LoadBalancers.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/LoadBalancers.java
@@ -43,6 +43,7 @@ public interface LoadBalancers {
   CompatFunction<LoadBalancer, LoadBalancerListenersView> LISTENERS_VIEW =
       loadBalancer -> ImmutableLoadBalancerListenersView.builder()
           .loadBalancer(ImmutableLoadBalancerView.copyOf(loadBalancer))
+          .loadBalancerAttributes(loadBalancer.getAttributes())
           .listeners(Stream.ofAll(loadBalancer.getListeners()).map(ImmutableListenerView::copyOf))
           .build();
 

--- a/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/views/LoadBalancerListenersView.java
+++ b/clc/modules/loadbalancingv2/src/main/java/com/eucalyptus/loadbalancingv2/service/persist/views/LoadBalancerListenersView.java
@@ -6,12 +6,15 @@
 package com.eucalyptus.loadbalancingv2.service.persist.views;
 
 import java.util.List;
+import java.util.Map;
 import org.immutables.value.Value;
 
 @Value.Immutable
 public interface LoadBalancerListenersView {
 
   LoadBalancerView getLoadBalancer();
+
+  Map<String,String> getLoadBalancerAttributes();
 
   List<ListenerView> getListeners();
 }

--- a/clc/modules/loadbalancingv2/src/main/resources/com/eucalyptus/loadbalancingv2/service/loadbalancer-app-zone.yaml
+++ b/clc/modules/loadbalancingv2/src/main/resources/com/eucalyptus/loadbalancingv2/service/loadbalancer-app-zone.yaml
@@ -52,6 +52,11 @@ Parameters:
     Description: The subnet to use
     Type: String
 
+  S3BucketArns:
+    Description: The objects the loadbalancer is authorized to write access logs
+    Type: List<String>
+    Default: ''
+
   ServoEucalyptusHost:
     Description: The services ip
     Type: String
@@ -90,6 +95,13 @@ Conditions:
       - !Join
         - ''
         - !Ref ServerCertificateArns
+      - ''
+
+  UseS3BucketArnsParameter: !Not
+    - !Equals
+      - !Join
+        - ''
+        - !Ref S3BucketArns
       - ''
 
 Resources:
@@ -133,6 +145,15 @@ Resources:
             Resource: !If
               - UseServerCertificateArnsParameter
               - !Ref ServerCertificateArns
+              - '*'
+          - Effect: !If
+              - UseS3BucketArnsParameter
+              - Allow
+              - Deny
+            Action: s3:PutObject
+            Resource: !If
+              - UseS3BucketArnsParameter
+              - !Ref S3BucketArns
               - '*'
 
   InstanceProfile:

--- a/clc/modules/loadbalancingv2/src/main/resources/com/eucalyptus/loadbalancingv2/service/loadbalancer-net-zone.yaml
+++ b/clc/modules/loadbalancingv2/src/main/resources/com/eucalyptus/loadbalancingv2/service/loadbalancer-net-zone.yaml
@@ -52,6 +52,11 @@ Parameters:
     Description: The subnet to use
     Type: String
 
+  S3BucketArns:
+    Description: The objects the loadbalancer is authorized to write access logs
+    Type: List<String>
+    Default: ''
+
   ServoEucalyptusHost:
     Description: The services ip
     Type: String
@@ -90,6 +95,13 @@ Conditions:
       - !Join
         - ''
         - !Ref ServerCertificateArns
+      - ''
+
+  UseS3BucketArnsParameter: !Not
+    - !Equals
+      - !Join
+        - ''
+        - !Ref S3BucketArns
       - ''
 
 Resources:
@@ -133,6 +145,15 @@ Resources:
             Resource: !If
               - UseServerCertificateArnsParameter
               - !Ref ServerCertificateArns
+              - '*'
+          - Effect: !If
+              - UseS3BucketArnsParameter
+              - Allow
+              - Deny
+            Action: s3:PutObject
+            Resource: !If
+              - UseS3BucketArnsParameter
+              - !Ref S3BucketArns
               - '*'
 
   InstanceProfile:


### PR DESCRIPTION
ELBv2 servo instances are now deployed with an iam instance profile permitting s3 object puts for access logging.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1354 
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1355

Manually tested by verifying that access logs are present in the expected s3 location when logging is enabled and there is traffic to the load balancer.

Relates to corymbia/eucalyptus#271