### PR TITLE
RDS service request validation

### DIFF
--- a/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/RdsMessageValidation.java
+++ b/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/RdsMessageValidation.java
@@ -22,10 +22,28 @@ public class RdsMessageValidation {
 
   public enum FieldRegexValue {
     // Generic
+    STRING_64("(?s).{1,64}"),
     STRING_128("(?s).{1,128}"),
+    STRING_255("(?s).{1,255}"),
     STRING_256("(?s).{1,256}"),
 
-    // Enums
+    ESTRING_1024("(?s).{0,1024}"),
+
+    // RDS
+
+    RDS_DB_CLUSTER_ID("[a-zA-Z](?:([a-zA-Z0-9]|[-](?=[a-zA-Z0-9])){0,62})?"),
+    RDS_DB_ENGINE("[a-z0-9.-]{1,128}"),
+    RDS_DB_ENGINE_VERION("[a-zA-Z0-9.-]{1,128}"),
+    RDS_DB_INSTANCE_ID("[a-zA-Z](?:([a-zA-Z0-9]|[-](?=[a-zA-Z0-9])){0,62})?"),
+    RDS_DB_MASTERPASSWORD("(?:[ !]|[#-.]|[0-?]|[A-~]){8,128}"),
+    RDS_DB_MASTERUSERNAME("[a-zA-Z0-9]{1,128}"),
+    RDS_DB_OPTION_GROUP_NAME("[a-z0-9._ -]{1,255}"),
+    RDS_DB_SNAPSHOT_ID("[a-zA-Z](?:([a-zA-Z0-9]|[-](?=[a-zA-Z0-9])){0,254})?"),
+    RDS_DB_SECURITY_GROUP_NAME("[a-z0-9._ -]{1,255}"),
+    RDS_DB_SUBNET_GROUP_NAME("[a-z0-9._ -]{1,255}"),
+    RDS_DB_PARAMETER_GROUP_NAME("[a-zA-Z](?:([a-zA-Z0-9]|[-](?=[a-zA-Z0-9])){0,254})?"),
+
+    // RDS Enums
     ENUM_ACTIVITYSTREAMMODE("sync|async"),
     ENUM_ACTIVITYSTREAMSTATUS("stopped|starting|started|stopping"),
     ENUM_APPLYMETHOD("immediate|pending-reboot"),
@@ -33,13 +51,25 @@ public class RdsMessageValidation {
     ENUM_DBPROXYSTATUS("available|modifying|incompatible-network|insufficient-resource-limits|creating|deleting"),
     ENUM_ENGINEFAMILY("MYSQL"),
     ENUM_IAMAUTHMODE("DISABLED|REQUIRED"),
+    ENUM_LICENSEMODEL("license-included|bring-your-own-license|general-public-license"),
     ENUM_SOURCETYPE("db-instance|db-parameter-group|db-security-group|db-snapshot|db-cluster|db-cluster-snapshot"),
+    ENUM_STORAGETYPE("standard|gp2|io1"),
     ENUM_TARGETTYPE("RDS_INSTANCE|RDS_SERVERLESS_ENDPOINT|TRACKED_CLUSTER"),
+
+    // EC2
+    EC2_SECURITYGROUP_ID( "sg-[0-9a-fA-F]{8}(?:[0-9a-fA-F]{9})?" ),
+    EC2_SUBNET_ID( "subnet-[0-9a-fA-F]{8}(?:[0-9a-fA-F]{9})?" ),
+
+    // IAM
+    IAM_NAME_OR_ARN( "[a-zA-Z0-9+=,.@-]{1,128}|arn:aws:iam:[!-~]{1,1588}" ),
+
+    // KMS
+    KMS_NAME_OR_ARN( "[a-zA-Z0-9+=,.@-]{1,128}|arn:aws:kms:[!-~]{1,1588}" ),
     ;
 
     private final Pattern pattern;
 
-    private FieldRegexValue(final String regex) {
+    FieldRegexValue(final String regex) {
       this.pattern = Pattern.compile(regex);
     }
 

--- a/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/CreateDBInstanceType.java
+++ b/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/CreateDBInstanceType.java
@@ -5,43 +5,57 @@
  */
 package com.eucalyptus.rds.common.msgs;
 
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRange;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegex;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegexValue;
 import javax.annotation.Nonnull;
 
 
 public class CreateDBInstanceType extends RdsMessage {
 
+  @FieldRange(min=1, max=65536)
   private Integer allocatedStorage;
 
   private Boolean autoMinorVersionUpgrade;
 
+  @FieldRegex(FieldRegexValue.STRING_128)
   private String availabilityZone;
 
+  @FieldRange(min=0, max=35)
   private Integer backupRetentionPeriod;
 
   private String characterSetName;
 
   private Boolean copyTagsToSnapshot;
 
+  @FieldRegex(FieldRegexValue.RDS_DB_CLUSTER_ID)
   private String dBClusterIdentifier;
 
   @Nonnull
+  @FieldRegex(FieldRegexValue.STRING_128)
   private String dBInstanceClass;
 
   @Nonnull
+  @FieldRegex(FieldRegexValue.RDS_DB_INSTANCE_ID)
   private String dBInstanceIdentifier;
 
+  @FieldRegex(FieldRegexValue.STRING_64)
   private String dBName;
 
+  @FieldRegex(FieldRegexValue.RDS_DB_PARAMETER_GROUP_NAME)
   private String dBParameterGroupName;
 
   private DBSecurityGroupNameList dBSecurityGroups;
 
+  @FieldRegex(FieldRegexValue.RDS_DB_SUBNET_GROUP_NAME)
   private String dBSubnetGroupName;
 
   private Boolean deletionProtection;
 
+  @FieldRegex(FieldRegexValue.STRING_256)
   private String domain;
 
+  @FieldRegex(FieldRegexValue.STRING_256)
   private String domainIAMRoleName;
 
   private LogTypeList enableCloudwatchLogsExports;
@@ -51,56 +65,77 @@ public class CreateDBInstanceType extends RdsMessage {
   private Boolean enablePerformanceInsights;
 
   @Nonnull
+  @FieldRegex(FieldRegexValue.RDS_DB_ENGINE)
   private String engine;
 
+  @FieldRegex(FieldRegexValue.RDS_DB_ENGINE_VERION)
   private String engineVersion;
 
+  @FieldRange(min=100, max=1_000_000)
   private Integer iops;
 
+  @FieldRegex(FieldRegexValue.KMS_NAME_OR_ARN)
   private String kmsKeyId;
 
+  @FieldRegex(FieldRegexValue.ENUM_LICENSEMODEL)
   private String licenseModel;
 
+  @FieldRegex(FieldRegexValue.RDS_DB_MASTERPASSWORD)
   private String masterUserPassword;
 
+  @FieldRegex(FieldRegexValue.RDS_DB_MASTERUSERNAME)
   private String masterUsername;
 
+  @FieldRange(min=0, max=1_000_000)
   private Integer maxAllocatedStorage;
 
+  @FieldRange(max=60)
   private Integer monitoringInterval;
 
+  @FieldRegex(FieldRegexValue.IAM_NAME_OR_ARN)
   private String monitoringRoleArn;
 
   private Boolean multiAZ;
 
+  @FieldRegex(FieldRegexValue.RDS_DB_OPTION_GROUP_NAME)
   private String optionGroupName;
 
+  @FieldRegex(FieldRegexValue.KMS_NAME_OR_ARN)
   private String performanceInsightsKMSKeyId;
 
+  @FieldRange(max=1000)
   private Integer performanceInsightsRetentionPeriod;
 
+  @FieldRange(min=1150, max=65535)
   private Integer port;
 
+  @FieldRegex(FieldRegexValue.STRING_64)
   private String preferredBackupWindow;
 
+  @FieldRegex(FieldRegexValue.STRING_64)
   private String preferredMaintenanceWindow;
 
   private ProcessorFeatureList processorFeatures;
 
+  @FieldRange(min=0, max=15)
   private Integer promotionTier;
 
   private Boolean publiclyAccessible;
 
   private Boolean storageEncrypted;
 
+  @FieldRegex(FieldRegexValue.ENUM_STORAGETYPE)
   private String storageType;
 
   private TagList tags;
 
+  @FieldRegex(FieldRegexValue.KMS_NAME_OR_ARN)
   private String tdeCredentialArn;
 
+  @FieldRegex(FieldRegexValue.ESTRING_1024)
   private String tdeCredentialPassword;
 
+  @FieldRegex(FieldRegexValue.ESTRING_1024)
   private String timezone;
 
   private VpcSecurityGroupIdList vpcSecurityGroupIds;

--- a/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/CreateDBSubnetGroupType.java
+++ b/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/CreateDBSubnetGroupType.java
@@ -5,15 +5,18 @@
  */
 package com.eucalyptus.rds.common.msgs;
 
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegex;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegexValue;
 import javax.annotation.Nonnull;
-
 
 public class CreateDBSubnetGroupType extends RdsMessage {
 
   @Nonnull
+  @FieldRegex(FieldRegexValue.ESTRING_1024)
   private String dBSubnetGroupDescription;
 
   @Nonnull
+  @FieldRegex(FieldRegexValue.RDS_DB_SUBNET_GROUP_NAME)
   private String dBSubnetGroupName;
 
   @Nonnull

--- a/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/DBSecurityGroupNameList.java
+++ b/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/DBSecurityGroupNameList.java
@@ -7,12 +7,15 @@ package com.eucalyptus.rds.common.msgs;
 
 import java.util.ArrayList;
 import com.eucalyptus.binding.HttpParameterMapping;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegex;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegexValue;
 import edu.ucsb.eucalyptus.msgs.EucalyptusData;
 
 
 public class DBSecurityGroupNameList extends EucalyptusData {
 
   @HttpParameterMapping(parameter = "DBSecurityGroupName")
+  @FieldRegex(FieldRegexValue.RDS_DB_SECURITY_GROUP_NAME)
   private ArrayList<String> member = new ArrayList<>();
 
   public ArrayList<String> getMember() {

--- a/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/DeleteDBInstanceType.java
+++ b/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/DeleteDBInstanceType.java
@@ -5,6 +5,8 @@
  */
 package com.eucalyptus.rds.common.msgs;
 
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegex;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegexValue;
 import javax.annotation.Nonnull;
 
 
@@ -15,6 +17,7 @@ public class DeleteDBInstanceType extends RdsMessage {
 
   private Boolean deleteAutomatedBackups;
 
+  @FieldRegex(FieldRegexValue.RDS_DB_SNAPSHOT_ID)
   private String finalDBSnapshotIdentifier;
 
   private Boolean skipFinalSnapshot;

--- a/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/DeleteDBSubnetGroupType.java
+++ b/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/DeleteDBSubnetGroupType.java
@@ -5,12 +5,15 @@
  */
 package com.eucalyptus.rds.common.msgs;
 
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegex;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegexValue;
 import javax.annotation.Nonnull;
 
 
 public class DeleteDBSubnetGroupType extends RdsMessage {
 
   @Nonnull
+  @FieldRegex(FieldRegexValue.STRING_255)
   private String dBSubnetGroupName;
 
   public String getDBSubnetGroupName() {

--- a/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/DescribeDBEngineVersionsType.java
+++ b/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/DescribeDBEngineVersionsType.java
@@ -5,14 +5,22 @@
  */
 package com.eucalyptus.rds.common.msgs;
 
+import com.eucalyptus.rds.common.RdsMessageValidation;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRange;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegex;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegexValue;
+
 public class DescribeDBEngineVersionsType extends RdsMessage {
 
+  @FieldRegex(FieldRegexValue.STRING_128)
   private String dBParameterGroupFamily;
 
   private Boolean defaultOnly;
 
+  @FieldRegex(FieldRegexValue.RDS_DB_ENGINE)
   private String engine;
 
+  @FieldRegex(FieldRegexValue.RDS_DB_ENGINE_VERION)
   private String engineVersion;
 
   private FilterList filters;
@@ -23,8 +31,10 @@ public class DescribeDBEngineVersionsType extends RdsMessage {
 
   private Boolean listSupportedTimezones;
 
+  @FieldRegex(FieldRegexValue.STRING_128)
   private String marker;
 
+  @FieldRange(min = 20, max = 100)
   private Integer maxRecords;
 
   public String getDBParameterGroupFamily() {

--- a/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/DescribeDBInstancesType.java
+++ b/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/DescribeDBInstancesType.java
@@ -5,14 +5,22 @@
  */
 package com.eucalyptus.rds.common.msgs;
 
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRange;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegex;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegexValue;
+
+
 public class DescribeDBInstancesType extends RdsMessage {
 
+  @FieldRegex(FieldRegexValue.RDS_DB_INSTANCE_ID)
   private String dBInstanceIdentifier;
 
   private FilterList filters;
 
+  @FieldRegex(FieldRegexValue.STRING_128)
   private String marker;
 
+  @FieldRange(min = 20, max = 100)
   private Integer maxRecords;
 
   public String getDBInstanceIdentifier() {

--- a/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/DescribeDBSubnetGroupsType.java
+++ b/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/DescribeDBSubnetGroupsType.java
@@ -5,14 +5,21 @@
  */
 package com.eucalyptus.rds.common.msgs;
 
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRange;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegex;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegexValue;
+
 public class DescribeDBSubnetGroupsType extends RdsMessage {
 
+  @FieldRegex(FieldRegexValue.STRING_255)
   private String dBSubnetGroupName;
 
   private FilterList filters;
 
+  @FieldRegex(FieldRegexValue.STRING_128)
   private String marker;
 
+  @FieldRange(min = 20, max = 100)
   private Integer maxRecords;
 
   public String getDBSubnetGroupName() {

--- a/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/Filter.java
+++ b/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/Filter.java
@@ -5,13 +5,16 @@
  */
 package com.eucalyptus.rds.common.msgs;
 
-import javax.annotation.Nonnull;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegex;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegexValue;
 import edu.ucsb.eucalyptus.msgs.EucalyptusData;
+import javax.annotation.Nonnull;
 
 
 public class Filter extends EucalyptusData {
 
   @Nonnull
+  @FieldRegex(FieldRegexValue.STRING_128)
   private String name;
 
   @Nonnull

--- a/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/FilterValueList.java
+++ b/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/FilterValueList.java
@@ -5,14 +5,17 @@
  */
 package com.eucalyptus.rds.common.msgs;
 
-import java.util.ArrayList;
 import com.eucalyptus.binding.HttpParameterMapping;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegex;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegexValue;
 import edu.ucsb.eucalyptus.msgs.EucalyptusData;
+import java.util.ArrayList;
 
 
 public class FilterValueList extends EucalyptusData {
 
   @HttpParameterMapping(parameter = "Value")
+  @FieldRegex(FieldRegexValue.ESTRING_1024)
   private ArrayList<String> member = new ArrayList<>();
 
   public ArrayList<String> getMember() {

--- a/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/LogTypeList.java
+++ b/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/LogTypeList.java
@@ -5,6 +5,9 @@
  */
 package com.eucalyptus.rds.common.msgs;
 
+import com.eucalyptus.rds.common.RdsMessageValidation;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegex;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegexValue;
 import java.util.ArrayList;
 import com.eucalyptus.binding.HttpParameterMapping;
 import edu.ucsb.eucalyptus.msgs.EucalyptusData;
@@ -13,6 +16,7 @@ import edu.ucsb.eucalyptus.msgs.EucalyptusData;
 public class LogTypeList extends EucalyptusData {
 
   @HttpParameterMapping(parameter = "member")
+  @FieldRegex(FieldRegexValue.STRING_64)
   private ArrayList<String> member = new ArrayList<>();
 
   public ArrayList<String> getMember() {

--- a/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/ProcessorFeature.java
+++ b/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/ProcessorFeature.java
@@ -5,13 +5,17 @@
  */
 package com.eucalyptus.rds.common.msgs;
 
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegex;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegexValue;
 import edu.ucsb.eucalyptus.msgs.EucalyptusData;
 
 
 public class ProcessorFeature extends EucalyptusData {
 
+  @FieldRegex(FieldRegexValue.STRING_128)
   private String name;
 
+  @FieldRegex(FieldRegexValue.ESTRING_1024)
   private String value;
 
   public String getName() {

--- a/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/SubnetIdentifierList.java
+++ b/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/SubnetIdentifierList.java
@@ -7,12 +7,15 @@ package com.eucalyptus.rds.common.msgs;
 
 import java.util.ArrayList;
 import com.eucalyptus.binding.HttpParameterMapping;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegex;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegexValue;
 import edu.ucsb.eucalyptus.msgs.EucalyptusData;
 
 
 public class SubnetIdentifierList extends EucalyptusData {
 
   @HttpParameterMapping(parameter = "SubnetIdentifier")
+  @FieldRegex(FieldRegexValue.EC2_SUBNET_ID)
   private ArrayList<String> member = new ArrayList<>();
 
   public ArrayList<String> getMember() {

--- a/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/Tag.java
+++ b/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/Tag.java
@@ -5,13 +5,17 @@
  */
 package com.eucalyptus.rds.common.msgs;
 
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegex;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegexValue;
 import edu.ucsb.eucalyptus.msgs.EucalyptusData;
 
 
 public class Tag extends EucalyptusData {
 
+  @FieldRegex(FieldRegexValue.STRING_128)
   private String key;
 
+  @FieldRegex(FieldRegexValue.STRING_256)
   private String value;
 
   public String getKey() {

--- a/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/VpcSecurityGroupIdList.java
+++ b/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/msgs/VpcSecurityGroupIdList.java
@@ -7,12 +7,15 @@ package com.eucalyptus.rds.common.msgs;
 
 import java.util.ArrayList;
 import com.eucalyptus.binding.HttpParameterMapping;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegex;
+import com.eucalyptus.rds.common.RdsMessageValidation.FieldRegexValue;
 import edu.ucsb.eucalyptus.msgs.EucalyptusData;
 
 
 public class VpcSecurityGroupIdList extends EucalyptusData {
 
   @HttpParameterMapping(parameter = "VpcSecurityGroupId")
+  @FieldRegex(FieldRegexValue.EC2_SECURITYGROUP_ID)
   private ArrayList<String> member = new ArrayList<>();
 
   public ArrayList<String> getMember() {

--- a/clc/modules/rds-common/src/test/java/com/eucalyptus/rds/common/RdsMessageValidationSpecification.groovy
+++ b/clc/modules/rds-common/src/test/java/com/eucalyptus/rds/common/RdsMessageValidationSpecification.groovy
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.rds.common
+
+import spock.lang.Specification
+
+/**
+ *
+ */
+class RdsMessageValidationSpecification extends Specification {
+
+  def 'should accept valid database instance identifiers'() {
+    expect: 'database instance identifier matches validation regex'
+    RdsMessageValidation.
+            FieldRegexValue.RDS_DB_INSTANCE_ID.
+            pattern().
+            matcher(id).
+            matches()
+
+    where:
+    _ | id
+    _ | 'a'
+    _ | 'ab'
+    _ | 'abc'
+    _ | 'abcd'
+    _ | 'abcde'
+    _ | 'abcdef'
+    _ | 'abcdefghijklmnopqrstuvwzyz012'
+    _ | 'abcdefghijklmnopqrstuvwzyz0123'
+    _ | 'abcdefghijklmnopqrstuvwzyz01234'
+    _ | 'abcdefghijklmnopqrstuvwzyz012345'
+    _ | 'a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p1'
+    _ | 'a-b'
+    _ | 'ainternal-a'
+    _ | 'a-internal-a'
+  }
+
+  def 'should reject invalid database instance identifiers'() {
+    expect: 'database instance identifier does not match validation regex'
+    !RdsMessageValidation.
+            FieldRegexValue.RDS_DB_INSTANCE_ID.
+            pattern().
+            matcher(id).
+            matches()
+
+    where:
+    _ | id
+    _ | ''
+    _ | '1'
+    _ | '-'
+    _ | '-a'
+    _ | 'a-'
+    _ | '-aaaaa'
+    _ | 'aaaaa-'
+    _ | 'a--b'
+    _ | 'a---b'
+  }
+
+  def 'should accept valid database cluster identifiers'() {
+    expect: 'database instance cluster matches validation regex'
+    RdsMessageValidation.
+            FieldRegexValue.RDS_DB_CLUSTER_ID.
+            pattern().
+            matcher(id).
+            matches()
+
+    where:
+    _ | id
+    _ | 'a'
+    _ | 'ab'
+    _ | 'abc'
+    _ | 'abcd'
+    _ | 'abcde'
+    _ | 'abcdef'
+    _ | 'abcdefghijklmnopqrstuvwzyz012'
+    _ | 'abcdefghijklmnopqrstuvwzyz0123'
+    _ | 'abcdefghijklmnopqrstuvwzyz01234'
+    _ | 'abcdefghijklmnopqrstuvwzyz012345'
+    _ | 'a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p1'
+    _ | 'a-b'
+    _ | 'ainternal-a'
+    _ | 'a-internal-a'
+  }
+
+  def 'should reject invalid database cluster identifiers'() {
+    expect: 'database instance cluster does not match validation regex'
+    !RdsMessageValidation.
+            FieldRegexValue.RDS_DB_CLUSTER_ID.
+            pattern().
+            matcher(id).
+            matches()
+
+    where:
+    _ | id
+    _ | ''
+    _ | '1'
+    _ | '-'
+    _ | '-a'
+    _ | 'a-'
+    _ | '-aaaaa'
+    _ | 'aaaaa-'
+    _ | 'a--b'
+    _ | 'a---b'
+  }
+
+  def 'should accept valid database snaphot identifiers'() {
+    expect: 'database snaphot identifier matches validation regex'
+    RdsMessageValidation.
+            FieldRegexValue.RDS_DB_SNAPSHOT_ID.
+            pattern().
+            matcher(id).
+            matches()
+
+    where:
+    _ | id
+    _ | 'a'
+    _ | 'ab'
+    _ | 'abc'
+    _ | 'abcd'
+    _ | 'abcde'
+    _ | 'abcdef'
+    _ | 'abcdefghijklmnopqrstuvwzyz012'
+    _ | 'abcdefghijklmnopqrstuvwzyz0123'
+    _ | 'abcdefghijklmnopqrstuvwzyz01234'
+    _ | 'abcdefghijklmnopqrstuvwzyz012345'
+    _ | 'a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p1'
+    _ | 'a-b'
+    _ | 'ainternal-a'
+    _ | 'a-internal-a'
+  }
+
+  def 'should reject invalid database snaphot identifiers'() {
+    expect: 'database snaphot identifier does not match validation regex'
+    !RdsMessageValidation.
+            FieldRegexValue.RDS_DB_SNAPSHOT_ID.
+            pattern().
+            matcher(id).
+            matches()
+
+    where:
+    _ | id
+    _ | ''
+    _ | '1'
+    _ | '-'
+    _ | '-a'
+    _ | 'a-'
+    _ | '-aaaaa'
+    _ | 'aaaaa-'
+    _ | 'a--b'
+    _ | 'a---b'
+  }
+
+  def 'should accept valid database parameter group names'() {
+    expect: 'database parameter group name matches validation regex'
+    RdsMessageValidation.
+            FieldRegexValue.RDS_DB_PARAMETER_GROUP_NAME.
+            pattern().
+            matcher(name).
+            matches()
+
+    where:
+    _ | name
+    _ | 'a'
+    _ | 'ab'
+    _ | 'a-b-c'
+    _ | 'abcdefghijklmnopqrstuvwzyz0'
+    _ | 'abcdefghijklmnopqrstuvwzyz012345'
+  }
+
+  def 'should reject invalid database parameter group names'() {
+    expect: 'database parameter group name does not match validation regex'
+    !RdsMessageValidation.
+            FieldRegexValue.RDS_DB_PARAMETER_GROUP_NAME.
+            pattern().
+            matcher(name).
+            matches()
+
+    where:
+    _ | name
+    _ | ''
+    _ | '?'
+    _ | '-a'
+    _ | 'a-'
+    _ | '-aaaaa'
+    _ | 'aaaaa-'
+    _ | 'a--b'
+    _ | 'a---b'
+    _ | 'a b c'
+    _ | 'a.b.c'
+    _ | 'a_b_c'
+  }
+
+  def 'should accept valid database subnet group names'() {
+    expect: 'database subnet group name matches validation regex'
+    RdsMessageValidation.
+            FieldRegexValue.RDS_DB_SUBNET_GROUP_NAME.
+            pattern().
+            matcher(name).
+            matches()
+
+    where:
+    _ | name
+    _ | 'a'
+    _ | 'ab'
+    _ | 'a b c'
+    _ | 'a.b.c'
+    _ | 'a_b_c'
+    _ | 'a-b-c'
+    _ | 'abcdefghijklmnopqrstuvwzyz0'
+    _ | 'abcdefghijklmnopqrstuvwzyz012345'
+  }
+
+  def 'should reject invalid database subnet group names'() {
+    expect: 'database subnet group name does not match validation regex'
+    !RdsMessageValidation.
+            FieldRegexValue.RDS_DB_SUBNET_GROUP_NAME.
+            pattern().
+            matcher(name).
+            matches()
+
+    where:
+    _ | name
+    _ | ''
+    _ | '?'
+  }
+
+  def 'should accept valid database master username'() {
+    expect: 'database master username matches validation regex'
+    RdsMessageValidation.
+            FieldRegexValue.RDS_DB_MASTERUSERNAME.
+            pattern().
+            matcher(name).
+            matches()
+
+    where:
+    _ | name
+    _ | 'a'
+    _ | 'A'
+    _ | '1'
+    _ | 'abcdefghijklmnopqrstuvwzyzABCDEFGHIJKLMNOPQRSTUVWZYZ0123456789'
+  }
+
+  def 'should reject invalid database master username'() {
+    expect: 'database master username does not match validation regex'
+    !RdsMessageValidation.
+            FieldRegexValue.RDS_DB_MASTERUSERNAME.
+            pattern().
+            matcher(name).
+            matches()
+
+    where:
+    _ | name
+    _ | ''
+    _ | ' '
+    _ | '?'
+    _ | '?a'
+    _ | 'a?'
+    _ | '.'
+  }
+
+  def 'should accept valid database master password'() {
+    expect: 'database master password matches validation regex'
+    RdsMessageValidation.
+            FieldRegexValue.RDS_DB_MASTERPASSWORD.
+            pattern().
+            matcher(password).
+            matches()
+
+    where:
+    _ | password
+    _ | 'abcdefgh'
+    _ | '12345678'
+    _ | '12345678a'
+    _ | '#$525!_\\<>,.'
+    _ | 'this is a passphrase'
+  }
+
+  def 'should reject invalid database master password'() {
+    expect: 'database master password does not match validation regex'
+    !RdsMessageValidation.
+            FieldRegexValue.RDS_DB_MASTERPASSWORD.
+            pattern().
+            matcher(password).
+            matches()
+
+    where:
+    _ | password
+    _ | ''
+    _ | 'a'
+    _ | '1'
+    _ | '1234567'
+    _ | 'abcdef'
+    _ | '12345678/'
+    _ | '/12345678'
+    _ | '1234/5678'
+    _ | '12345678@'
+    _ | '@12345678'
+    _ | '1234@5678'
+    _ | '12345678"'
+    _ | '"12345678'
+    _ | '1234"5678'
+  }
+
+}

--- a/clc/modules/rds/src/main/java/com/eucalyptus/rds/service/RdsService.java
+++ b/clc/modules/rds/src/main/java/com/eucalyptus/rds/service/RdsService.java
@@ -222,6 +222,9 @@ public class RdsService {
       final String desc = request.getDBSubnetGroupDescription();
       final Collection<String> subnetIds = request.getSubnetIds().getMember();
 
+      if ("default".equals(name)) {
+        throw new RdsClientException("InvalidParameterValue", "Invalid name");
+      }
       if (subnetIds.isEmpty()) {
         throw new RdsClientException("DBSubnetGroupDoesNotCoverEnoughAZs", "No subnets");
       }

--- a/clc/modules/rds/src/main/java/com/eucalyptus/rds/service/RdsWorkflow.java
+++ b/clc/modules/rds/src/main/java/com/eucalyptus/rds/service/RdsWorkflow.java
@@ -6,6 +6,7 @@
 package com.eucalyptus.rds.service;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -53,7 +54,7 @@ import com.eucalyptus.rds.service.persist.views.ImmutableDBInstanceRuntimeView;
 import com.eucalyptus.rds.service.persist.views.ImmutableDBInstanceView;
 import com.eucalyptus.util.Exceptions;
 import com.eucalyptus.util.Strings;
-import com.google.common.base.Charsets;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -66,7 +67,7 @@ import io.vavr.Tuple3;
 /**
  *
  */
-@SuppressWarnings("Guava")
+@SuppressWarnings({"UnstableApiUsage", "unused"})
 public class RdsWorkflow {
 
   private static final Logger logger = Logger.getLogger(RdsWorkflow.class);
@@ -165,7 +166,7 @@ public class RdsWorkflow {
       final String userSubnetId = subnetViewOptional.get().getSubnetId();
       final Tuple3<String,String,String> vpcInfo = RdsSystemVpcs.getSystemVpcSubnetId(userSubnetId);
       final String dbIdentifier = dbInstance.getDisplayName();
-      final int dbAllocatedStorage = dbInstance.getAllocatedStorage();
+      final int dbAllocatedStorage = MoreObjects.firstNonNull(dbInstance.getAllocatedStorage(), 1);
       final String dbVpcId = vpcInfo._1();
       final String dbSubnetId = vpcInfo._2();
       final String dbAvailablityZone = vpcInfo._3();
@@ -321,7 +322,7 @@ public class RdsWorkflow {
     try {
       return Resources.toString(
           Resources.getResource( RdsWorkflow.class, name + ".yaml" ),
-          Charsets.UTF_8 );
+          StandardCharsets.UTF_8 );
     } catch (IOException e) {
       throw Exceptions.toUndeclared(e);
     }
@@ -376,7 +377,8 @@ public class RdsWorkflow {
         networkInterfaceId = dbInstanceRuntime.getUserNetworkInterfaceId();
       }
 
-      if (dbInstance.getPubliclyAccessible() && dbInstanceRuntime.getPublicIp()==null) {
+      if (dbInstance.getPubliclyAccessible() != null && dbInstance.getPubliclyAccessible() &&
+          dbInstanceRuntime.getPublicIp() == null) {
         final String allocationId;
         String publicIp;
         if (dbInstanceRuntime.getPublicIpAllocationId() == null) {
@@ -710,6 +712,7 @@ public class RdsWorkflow {
     }
 
     protected final void perhapsWork() throws Exception {
+      //noinspection NonAtomicOperationOnVolatileField
       if (++count % calcFactor() == 0) {
         logger.trace("Running RDS workflow task: " + task);
         doWork();

--- a/clc/modules/rds/src/main/java/com/eucalyptus/rds/service/RdsWorkflow.java
+++ b/clc/modules/rds/src/main/java/com/eucalyptus/rds/service/RdsWorkflow.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 import org.apache.log4j.Logger;
 import org.hibernate.criterion.Example;
 import org.hibernate.criterion.Restrictions;
@@ -53,8 +54,6 @@ import com.eucalyptus.rds.service.persist.views.ImmutableDBInstanceView;
 import com.eucalyptus.util.Exceptions;
 import com.eucalyptus.util.Strings;
 import com.google.common.base.Charsets;
-import com.google.common.base.Function;
-import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -112,7 +111,7 @@ public class RdsWorkflow {
     try {
       dbInstanceUuids = dbInstances.listByExample(
           DBInstance.exampleWithStatus(status),
-          Predicates.alwaysTrue(),
+          __ -> true,
           DBInstance::getNaturalId);
     } catch (final RdsMetadataException e) {
       logger.error("Error listing db instances", e);
@@ -129,7 +128,7 @@ public class RdsWorkflow {
         DBInstance.exampleWithUuid(dbInstanceUuid),
         null,
         dbInstanceUuid,
-        Predicates.alwaysTrue(),
+        __ -> true,
         transform );
   }
 
@@ -473,7 +472,7 @@ public class RdsWorkflow {
               Restrictions.isNotNull( "dbInstanceRuntime.systemVolumeId" )
           ),
           Collections.emptyMap( ),
-          Predicates.alwaysTrue( ),
+          __ -> true,
           DBInstances.COMPOSITE_RUNTIME
       );
     } catch ( final Exception e ) {
@@ -599,7 +598,7 @@ public class RdsWorkflow {
               Restrictions.lt( "lastUpdateTimestamp", new Date( System.currentTimeMillis( ) - DBInstances.EXPIRY_AGE ) )
           ),
           Collections.emptyMap( ),
-          Predicates.alwaysTrue( ),
+          __ -> true,
           ImmutableDBInstanceView::copyOf
       );
     } catch ( final Exception e ) {

--- a/clc/modules/rds/src/main/java/com/eucalyptus/rds/service/dns/RdsDnsResolver.java
+++ b/clc/modules/rds/src/main/java/com/eucalyptus/rds/service/dns/RdsDnsResolver.java
@@ -106,7 +106,7 @@ public class RdsDnsResolver  extends DnsResolvers.DnsResolver {
           DBInstance.exampleWithName(ownerName, dbIdentifer),
           ownerName,
           dbIdentifer,
-          Predicates.alwaysTrue(),
+          __ -> true,
           instance ->
               instance.getPubliclyAccessible() && instance.getDbInstanceRuntime().getPublicIp()!=null ?
               instance.getDbInstanceRuntime().getPublicIp() :

--- a/clc/modules/rds/src/main/java/com/eucalyptus/rds/service/persist/DBInstances.java
+++ b/clc/modules/rds/src/main/java/com/eucalyptus/rds/service/persist/DBInstances.java
@@ -5,9 +5,12 @@
  */
 package com.eucalyptus.rds.service.persist;
 
+import com.eucalyptus.util.CompatFunction;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import org.hibernate.criterion.Criterion;
 import org.xbill.DNS.Name;
 import org.xbill.DNS.NameTooLongException;
@@ -33,8 +36,7 @@ import com.eucalyptus.rds.service.persist.views.ImmutableDBInstanceView;
 import com.eucalyptus.util.TypeMapper;
 import com.eucalyptus.util.TypeMappers;
 import com.eucalyptus.util.dns.DomainNames;
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
+
 
 /**
  *
@@ -107,7 +109,7 @@ public interface DBInstances {
   AbstractPersistentSupport<DBInstanceMetadata, DBInstance, RdsMetadataException> withRetries();
 
   @TypeMapper
-  enum DBInstanceTransform implements Function<DBInstance, com.eucalyptus.rds.common.msgs.DBInstance> {
+  enum DBInstanceTransform implements CompatFunction<DBInstance, com.eucalyptus.rds.common.msgs.DBInstance> {
     INSTANCE;
 
     @Override

--- a/clc/modules/rds/src/main/java/com/eucalyptus/rds/service/persist/DBSubnetGroups.java
+++ b/clc/modules/rds/src/main/java/com/eucalyptus/rds/service/persist/DBSubnetGroups.java
@@ -5,7 +5,10 @@
  */
 package com.eucalyptus.rds.service.persist;
 
+import com.eucalyptus.util.CompatFunction;
 import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import com.eucalyptus.auth.principal.OwnerFullName;
 import com.eucalyptus.entities.AbstractPersistentSupport;
@@ -18,8 +21,6 @@ import com.eucalyptus.rds.service.persist.entities.DBSubnet;
 import com.eucalyptus.rds.service.persist.entities.DBSubnetGroup;
 import com.eucalyptus.util.TypeMapper;
 import com.eucalyptus.util.TypeMappers;
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
 
 /**
  *
@@ -52,7 +53,7 @@ public interface DBSubnetGroups {
   AbstractPersistentSupport<RdsMetadata.DBSubnetGroupMetadata,DBSubnetGroup,RdsMetadataException> withRetries( );
 
   @TypeMapper
-  public enum DBSubnetTransform implements Function<DBSubnet, com.eucalyptus.rds.common.msgs.Subnet> {
+  enum DBSubnetTransform implements CompatFunction<DBSubnet, com.eucalyptus.rds.common.msgs.Subnet> {
     INSTANCE;
 
     @Override
@@ -68,7 +69,7 @@ public interface DBSubnetGroups {
   }
 
   @TypeMapper
-  public enum DBSubnetGroupTransform implements Function<DBSubnetGroup, com.eucalyptus.rds.common.msgs.DBSubnetGroup> {
+  enum DBSubnetGroupTransform implements CompatFunction<DBSubnetGroup, com.eucalyptus.rds.common.msgs.DBSubnetGroup> {
     INSTANCE;
 
     @Override

--- a/clc/modules/rds/src/main/java/com/eucalyptus/rds/service/persist/entities/RdsPersistenceSupport.java
+++ b/clc/modules/rds/src/main/java/com/eucalyptus/rds/service/persist/entities/RdsPersistenceSupport.java
@@ -5,12 +5,20 @@
  */
 package com.eucalyptus.rds.service.persist.entities;
 
+import com.eucalyptus.auth.principal.OwnerFullName;
 import com.eucalyptus.auth.type.RestrictedType;
 import com.eucalyptus.entities.AbstractPersistent;
 import com.eucalyptus.entities.AbstractPersistentSupport;
 import com.eucalyptus.rds.service.persist.RdsMetadataException;
 import com.eucalyptus.rds.service.persist.RdsMetadataNotFoundException;
+import com.eucalyptus.util.CompatFunction;
+import com.eucalyptus.util.CompatPredicate;
 import com.eucalyptus.util.Exceptions;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import org.hibernate.criterion.Criterion;
 
 /**
  *
@@ -25,6 +33,60 @@ public abstract class RdsPersistenceSupport<RT extends RestrictedType, AP extend
   @Override
   public AbstractPersistentSupport<RT, AP, RdsMetadataException> withRetries( ) {
     return super.withRetries( 50 );
+  }
+
+  public <T> List<T> list(
+      final OwnerFullName ownerFullName,
+      final Predicate<? super AP> filter,
+      final Function<? super AP, T> transform
+  ) throws RdsMetadataException {
+    return super.list(ownerFullName, gpredicate(filter), gfunction(transform));
+  }
+
+  public <T> List<T> list(
+      final OwnerFullName ownerFullName,
+      final Criterion criterion,
+      final Map<String, String> aliases,
+      final Predicate<? super AP> filter,
+      final Function<? super AP, T> transform
+  ) throws RdsMetadataException {
+    return super.list(ownerFullName, criterion, aliases, gpredicate(filter), gfunction(transform));
+  }
+
+  public <T> List<T> listByExample(
+      final AP example,
+      final Predicate<? super AP> filter,
+      final Function<? super AP, T> transform
+  ) throws RdsMetadataException {
+    return super.listByExample(example, gpredicate(filter), gfunction(transform));
+  }
+
+  public <T> T lookupByName(
+      final OwnerFullName ownerFullName,
+      final String name,
+      final Predicate<? super AP> filter,
+      final Function<? super AP, T> transform
+  ) throws RdsMetadataException {
+    return super.lookupByName(ownerFullName, name, gpredicate(filter), gfunction(transform));
+  }
+
+  public <T> T lookupByExample(
+      final AP example,
+      final OwnerFullName ownerFullName,
+      final String name,
+      final Predicate<? super AP> filter,
+      final Function<? super AP, T> transform
+  ) throws RdsMetadataException {
+    return super.lookupByExample(example, ownerFullName, name, gpredicate(filter), gfunction(transform));
+  }
+
+  public <T> T updateByExample(
+      final AP example,
+      final OwnerFullName ownerFullName,
+      final String desc,
+      final Function<? super AP, T> updateTransform
+  ) throws RdsMetadataException {
+    return super.updateByExample(example, ownerFullName, desc, gfunction(updateTransform));
   }
 
   @Override
@@ -47,5 +109,13 @@ public abstract class RdsPersistenceSupport<RT extends RestrictedType, AP extend
     } else {
       return new RdsMetadataException( message, cause );
     }
+  }
+
+  private static <F, T> com.google.common.base.Function<F, T> gfunction(final Function<F, T> function) {
+    return function == null ? null : CompatFunction.of(function);
+  }
+
+  private static <T> com.google.common.base.Predicate<T> gpredicate(final Predicate<T> predicate) {
+    return predicate == null ? null : CompatPredicate.of(predicate);
   }
 }


### PR DESCRIPTION
RDS service request validation as per api.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1375
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1376

Verified that existing manual rds tests pass with changes in place:

```
# euca-authorize -P tcp -p 5432 default
...
...
# euform-create-stack --template-file rds.yaml -p SecurityGroupId=sg-44fd450ab677ef6e3 -p SubnetId=subnet-72bee31afbbfcc9f6 rds-1
...
...
# aws rds describe-db-instances 
DBINSTANCES	1	False	cloud-1a	0	False	arn:aws:rds::000340531378:db/database-1	db.t2.small	database-1	available	postgres	postgres	11	False	2021-06-22T05:18:36.529Z	username	False	False	True	False
DBSUBNETGROUP	arn:aws:rds::000340531378:subgrp/subnet-group-1	A subnet group description	subnet-group-1	Complete	vpc-547b1fdf520a27975
SUBNETS	subnet-72bee31afbbfcc9f6	Active
SUBNETAVAILABILITYZONE	cloud-1a
ENDPOINT	database-1.s5afpqfhme5h.rds.qa64.eucalyptuscloud.net	5432
VPCSECURITYGROUPS	active	sg-44fd450ab677ef6e3
#
#
# podman run -it --rm docker.io/library/postgres:11-alpine psql -h database-1.s5afpqfhme5h.rds.qa64.eucalyptuscloud.net -U username postgres
^C

Password for user username: 
psql (11.12)
Type "help" for help.

postgres=# 
...
```

Relates to corymbia/eucalyptus#257