### PR TITLE
eucanetd packaging updated to require nginx-mod-http-perl

### DIFF
--- a/rpm/eucalyptus.spec
+++ b/rpm/eucalyptus.spec
@@ -373,8 +373,8 @@ Requires:       ebtables
 Requires:       eucalyptus-selinux >= %{version_selinux}
 Requires:       ipset
 Requires:       iptables
-# nginx 1.9.13 added perl as a loadable module (EUCA-12734)
 Requires:       nginx >= 1.9.13
+Requires:       nginx-mod-http-perl >= 1.9.13
 Requires:       /usr/bin/which
 %{?systemd_requires}
 


### PR DESCRIPTION
Update to the rpm packaging for `eucanetd` to require `nginx-mod-http-perl` which used to be a transitive dependency of `nginx` via `nginx-all-modules`.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1382
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1385

Fixes corymbia/eucalyptus#311