### PR TITLE
RDS DescribeDBInstances filtering

### DIFF
--- a/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/policy/RdsErnBuilder.java
+++ b/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/policy/RdsErnBuilder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.rds.common.policy;
+
+import com.eucalyptus.auth.policy.ern.Ern;
+import com.eucalyptus.auth.policy.ern.ServiceErnBuilder;
+import java.util.Collections;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.sf.json.JSONException;
+
+public class RdsErnBuilder extends ServiceErnBuilder {
+
+  public static final Pattern RESOURCE_PATTERN = Pattern.compile( "([a-z0-9_-]+):(\\S+)" );
+
+  public static final int ARN_PATTERNGROUP_RDS_TYPE = 1;
+  public static final int ARN_PATTERNGROUP_RDS_ID = 2;
+
+  public RdsErnBuilder( ) {
+    super(Collections.singleton(RdsPolicySpec.VENDOR_RDS));
+  }
+
+  @Override
+  public Ern build(final String ern,
+      final String service,
+      final String region,
+      final String account,
+      final String resource ) throws JSONException {
+    final Matcher matcher = RESOURCE_PATTERN.matcher( resource );
+    if ( matcher.matches( ) ) {
+      String type = matcher.group( ARN_PATTERNGROUP_RDS_TYPE ).toLowerCase( );
+      String id = matcher.group( ARN_PATTERNGROUP_RDS_ID );
+      return new RdsResourceName(region, account, type, id);
+    }
+    throw new JSONException( "'" + ern + "' is not a valid ARN" );
+  }
+}

--- a/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/policy/RdsResourceName.java
+++ b/clc/modules/rds-common/src/main/java/com/eucalyptus/rds/common/policy/RdsResourceName.java
@@ -6,6 +6,7 @@
 package com.eucalyptus.rds.common.policy;
 
 import com.eucalyptus.auth.policy.ern.ResourceNameSupport;
+import com.google.common.base.Strings;
 
 /**
  *
@@ -21,4 +22,14 @@ public class RdsResourceName extends ResourceNameSupport {
     super( RdsPolicySpec.VENDOR_RDS, region, account, resourceType, resourceName );
   }
 
+  @Override
+  public String toString( ) {
+    return new StringBuilder( )
+        .append( ARN_PREFIX )
+        .append( getService( ) ).append( ':' )
+        .append( Strings.nullToEmpty( getRegion( ) ) ).append( ':' )
+        .append( Strings.nullToEmpty( getAccount( ) ) ).append( ':' )
+        .append( getType( ) ).append( ':' )
+        .append( getResourceName( ) ).toString( );
+  }
 }


### PR DESCRIPTION
Filtering support for DescribeDBInstances and correct the arn format / parsing.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1392
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1393

Demo is that filters can now be used:

```
# aws rds describe-db-instances --filter Name=engine,Values=postgres Name=db-instance-id,Values=arn:aws:rds::000328023357:db:database-1
DBINSTANCES	1	False	cloud-1a	0	False	arn:aws:rds::000328023357:db:database-1	db.t2.small	database-1	available	postgres	postgres	11	False	2021-06-23T20:52:40.913Z	username	False	False	True	False
DBSUBNETGROUP	arn:aws:rds::000328023357:subgrp:subnet-group-1	A subnet group description	subnet-group-1	Complete	vpc-2d23a9de2fd65a890
SUBNETS	subnet-9d104ca1f40f41874	Active
SUBNETAVAILABILITYZONE	cloud-1a
ENDPOINT	database-1.qzquzxvpj1wx.rds.qa64.eucalyptuscloud.net	5432
VPCSECURITYGROUPS	active	sg-9ed2dfa280ced0144
```

Relates to corymbia/eucalyptus#257