### PR TITLE
Indent correctly the instance-libvirt.xml

### DIFF
--- a/tools/libvirt.xsl
+++ b/tools/libvirt.xsl
@@ -50,6 +50,7 @@ that describes a Eucalyptus instance to be launched.
 -->
 <xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
     <xsl:output encoding="UTF-8" indent="yes" method="xml"/>
+    <xsl:strip-space elements="*"/>
 
     <xsl:template match="/instance">
         <!-- sanity check on the hypervisor type - we only know 'kvm' and 'xen' -->


### PR DESCRIPTION
Before the output would have lines like:

  <devices><rng model="virtio"><backend model="random">/dev/urandom</backend></rng><disk type="file" device="floppy"><driver cache="none"/><source file="/home/eucalyptus/instances/work/xxxxxx/yyyy/floppy"/><target dev="fda"/></disk><disk type="block">

After:
  <devices>
    <rng model="virtio">
      <backend model="random">/dev/urandom</backend>
    </rng>
    <disk type="file" device="floppy">
      <driver cache="none"/>
      <source file="/home/eucalyptus/instances/work/AIDAAPBBFTSG4COXVGU7Q/i-35cc9e3f2db173cae/floppy"/>
      <target dev="fda"/>
    </disk>
