### PR TITLE
EC2 VPC DescribeVpcClassicLink binding and response

### DIFF
--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeVpcClassicLinkResponseType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeVpcClassicLinkResponseType.java
@@ -29,5 +29,13 @@
 package com.eucalyptus.compute.common;
 
 public class DescribeVpcClassicLinkResponseType extends VpcMessage {
+  private VpcClassicLinkSetType vpcSet = new VpcClassicLinkSetType( );
 
+  public VpcClassicLinkSetType getVpcSet( ) {
+    return vpcSet;
+  }
+
+  public void setVpcSet( VpcClassicLinkSetType vpcSet ) {
+    this.vpcSet = vpcSet;
+  }
 }

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeVpcClassicLinkType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/DescribeVpcClassicLinkType.java
@@ -28,16 +28,41 @@
  ************************************************************************/
 package com.eucalyptus.compute.common;
 
+import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import com.eucalyptus.binding.HttpEmbedded;
 import com.eucalyptus.binding.HttpParameterMapping;
+import java.util.Collection;
+import java.util.List;
 
 public class DescribeVpcClassicLinkType extends VpcMessage {
+
+  @HttpEmbedded
+  private VpcIdSetType vpcSet;
 
   @HttpParameterMapping( parameter = "Filter" )
   @HttpEmbedded( multiple = true )
   private ArrayList<Filter> filterSet = new ArrayList<Filter>( );
-  private String vpcId;
+
+  public Collection<String> vpcIds( ) {
+    List<String> vpcIds = Lists.newArrayList( );
+    if ( vpcSet != null && vpcSet.getItem( ) != null ) {
+      for ( VpcIdSetItemType item : vpcSet.getItem( ) ) {
+        if ( item != null ) {
+          vpcIds.add( item.getVpcId( ) );
+        }
+      }
+    }
+    return vpcIds;
+  }
+
+  public VpcIdSetType getVpcSet( ) {
+    return vpcSet;
+  }
+
+  public void setVpcSet( VpcIdSetType vpcSet ) {
+    this.vpcSet = vpcSet;
+  }
 
   public ArrayList<Filter> getFilterSet( ) {
     return filterSet;
@@ -45,13 +70,5 @@ public class DescribeVpcClassicLinkType extends VpcMessage {
 
   public void setFilterSet( ArrayList<Filter> filterSet ) {
     this.filterSet = filterSet;
-  }
-
-  public String getVpcId( ) {
-    return vpcId;
-  }
-
-  public void setVpcId( String vpcId ) {
-    this.vpcId = vpcId;
   }
 }

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/VpcClassicLinkSetType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/VpcClassicLinkSetType.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.compute.common;
+
+import edu.ucsb.eucalyptus.msgs.EucalyptusData;
+import java.util.ArrayList;
+
+public class VpcClassicLinkSetType extends EucalyptusData {
+
+  private ArrayList<VpcClassicLinkType> item = new ArrayList<VpcClassicLinkType>( );
+
+  public ArrayList<VpcClassicLinkType> getItem( ) {
+    return item;
+  }
+
+  public void setItem( ArrayList<VpcClassicLinkType> item ) {
+    this.item = item;
+  }
+}

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/VpcClassicLinkType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/VpcClassicLinkType.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 AppScale Systems, Inc
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+package com.eucalyptus.compute.common;
+
+import com.eucalyptus.util.CompatFunction;
+import edu.ucsb.eucalyptus.msgs.EucalyptusData;
+
+public class VpcClassicLinkType extends EucalyptusData implements ResourceTagged {
+
+  private String vpcId;
+  private Boolean classicLinkEnabled;
+  private ResourceTagSetType tagSet;
+
+  public VpcClassicLinkType( ) {
+  }
+
+  public VpcClassicLinkType( final String vpcId ) {
+    this.vpcId = vpcId;
+    this.classicLinkEnabled = false;
+  }
+
+  public static CompatFunction<VpcClassicLinkType, String> id( ) {
+    return new CompatFunction<VpcClassicLinkType, String>( ) {
+      @Override
+      public String apply( final VpcClassicLinkType vpcType ) {
+        return vpcType.getVpcId( );
+      }
+    };
+  }
+
+  public String getVpcId( ) {
+    return vpcId;
+  }
+
+  public void setVpcId( String vpcId ) {
+    this.vpcId = vpcId;
+  }
+
+  public Boolean getClassicLinkEnabled() {
+    return classicLinkEnabled;
+  }
+
+  public void setClassicLinkEnabled(Boolean classicLinkEnabled) {
+    this.classicLinkEnabled = classicLinkEnabled;
+  }
+
+  public ResourceTagSetType getTagSet( ) {
+    return tagSet;
+  }
+
+  public void setTagSet( ResourceTagSetType tagSet ) {
+    this.tagSet = tagSet;
+  }
+}

--- a/clc/modules/compute-common-msgs/src/main/resources/ec2-vpc-14-10-01.xml
+++ b/clc/modules/compute-common-msgs/src/main/resources/ec2-vpc-14-10-01.xml
@@ -1210,12 +1210,12 @@
 
   <mapping name="DescribeVpcClassicLink" class="com.eucalyptus.compute.common.DescribeVpcClassicLinkType" extends="com.eucalyptus.compute.common.ComputeMessage">
     <structure map-as="com.eucalyptus.compute.common.ComputeMessage"/>
+    <structure name="vpcSet" field="vpcSet" usage="optional" type="com.eucalyptus.compute.common.VpcIdSetType"/>
     <structure name="filterSet" usage="optional">
       <collection factory="org.jibx.runtime.Utility.arrayListFactory" field="filterSet">
         <structure name="item" map-as="com.eucalyptus.compute.common.Filter" />
       </collection>
     </structure>
-    <value name="vpcId" field="vpcId" usage="optional"/>
   </mapping>
   <mapping name="DescribeVpcClassicLinkResponse" class="com.eucalyptus.compute.common.DescribeVpcClassicLinkResponseType" extends="com.eucalyptus.compute.common.ComputeMessage">
     <structure map-as="com.eucalyptus.compute.common.ComputeMessage"/>

--- a/clc/modules/compute-common-msgs/src/main/resources/ec2-vpc-15-10-01.xml
+++ b/clc/modules/compute-common-msgs/src/main/resources/ec2-vpc-15-10-01.xml
@@ -1312,12 +1312,12 @@
 
   <mapping name="DescribeVpcClassicLink" class="com.eucalyptus.compute.common.DescribeVpcClassicLinkType" extends="com.eucalyptus.compute.common.ComputeMessage">
     <structure map-as="com.eucalyptus.compute.common.ComputeMessage"/>
+    <structure name="vpcSet" field="vpcSet" usage="optional" type="com.eucalyptus.compute.common.VpcIdSetType"/>
     <structure name="filterSet" usage="optional">
       <collection factory="org.jibx.runtime.Utility.arrayListFactory" field="filterSet">
         <structure name="item" map-as="com.eucalyptus.compute.common.Filter" />
       </collection>
     </structure>
-    <value name="vpcId" field="vpcId" usage="optional"/>
   </mapping>
   <mapping name="DescribeVpcClassicLinkResponse" class="com.eucalyptus.compute.common.DescribeVpcClassicLinkResponseType" extends="com.eucalyptus.compute.common.ComputeMessage">
     <structure map-as="com.eucalyptus.compute.common.ComputeMessage"/>

--- a/clc/modules/compute-common-msgs/src/main/resources/ec2-vpc-16-11-15.xml
+++ b/clc/modules/compute-common-msgs/src/main/resources/ec2-vpc-16-11-15.xml
@@ -1623,6 +1623,11 @@
     <value name="instanceTenancy" field="instanceTenancy" usage="optional"/>
     <value name="isDefault" field="isDefault" usage="optional"/>
   </mapping>
+  <mapping class="com.eucalyptus.compute.common.VpcClassicLinkType" abstract="true">
+    <value name="vpcId" field="vpcId" usage="required"/>
+    <value name="classicLinkEnabled" field="classicLinkEnabled" usage="optional"/>
+    <structure name="tagSet" field="tagSet" usage="optional" type="com.eucalyptus.compute.common.ResourceTagSetType"/>
+  </mapping>
   <mapping class="com.eucalyptus.compute.common.SubnetType" abstract="true">
     <value name="subnetId" field="subnetId" usage="required"/>
     <value name="state" field="state" usage="optional"/>
@@ -1652,6 +1657,11 @@
   <mapping class="com.eucalyptus.compute.common.VpcSetType" abstract="true">
     <collection field="item">
       <structure name="item" type="com.eucalyptus.compute.common.VpcType"/>
+    </collection>
+  </mapping>
+  <mapping class="com.eucalyptus.compute.common.VpcClassicLinkSetType" abstract="true">
+    <collection field="item">
+      <structure name="item" type="com.eucalyptus.compute.common.VpcClassicLinkType"/>
     </collection>
   </mapping>
   <mapping class="com.eucalyptus.compute.common.SubnetSetType" abstract="true">
@@ -2751,16 +2761,16 @@
   </mapping>
   <mapping name="DescribeVpcClassicLink" class="com.eucalyptus.compute.common.DescribeVpcClassicLinkType" extends="com.eucalyptus.compute.common.ComputeMessage">
     <structure map-as="com.eucalyptus.compute.common.ComputeMessage"/>
+    <structure name="vpcSet" field="vpcSet" usage="optional" type="com.eucalyptus.compute.common.VpcIdSetType"/>
     <structure name="filterSet" usage="optional">
       <collection factory="org.jibx.runtime.Utility.arrayListFactory" field="filterSet">
         <structure name="item" map-as="com.eucalyptus.compute.common.Filter" />
       </collection>
     </structure>
-    <value name="vpcId" field="vpcId" usage="optional"/>
   </mapping>
   <mapping name="DescribeVpcClassicLinkResponse" class="com.eucalyptus.compute.common.DescribeVpcClassicLinkResponseType" extends="com.eucalyptus.compute.common.ComputeMessage">
     <structure map-as="com.eucalyptus.compute.common.ComputeMessage"/>
-    <structure name="vpcSet"/>
+    <structure name="vpcSet" field="vpcSet" usage="required" type="com.eucalyptus.compute.common.VpcClassicLinkSetType"/>
   </mapping>
   <mapping name="DetachClassicLinkVpc" class="com.eucalyptus.compute.common.DetachClassicLinkVpcType" extends="com.eucalyptus.compute.common.ComputeMessage">
     <structure map-as="com.eucalyptus.compute.common.ComputeMessage"/>

--- a/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/vpc/Vpcs.java
+++ b/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/vpc/Vpcs.java
@@ -38,6 +38,7 @@ import javax.annotation.Nullable;
 import org.hibernate.criterion.Criterion;
 import com.eucalyptus.compute.common.CloudMetadatas;
 import com.eucalyptus.compute.common.ResourceTagSetItemType;
+import com.eucalyptus.compute.common.VpcClassicLinkType;
 import com.eucalyptus.compute.common.VpcType;
 import com.eucalyptus.entities.Entities;
 import com.eucalyptus.entities.TransactionResource;
@@ -115,6 +116,19 @@ public interface Vpcs extends Lister<Vpc> {
               vpc.getCidr( ),
               MoreObjects.firstNonNull( CloudMetadatas.toDisplayName().apply( vpc.getDhcpOptionSet() ), "default" ),
               vpc.getDefaultVpc( ) );
+    }
+  }
+
+  @TypeMapper
+  public enum VpcToVpcClassicLinkTypeTransform implements Function<Vpc, VpcClassicLinkType> {
+    INSTANCE;
+
+    @Nullable
+    @Override
+    public VpcClassicLinkType apply( @Nullable final Vpc vpc ) {
+      return vpc == null ?
+          null :
+          new VpcClassicLinkType(vpc.getDisplayName( ));
     }
   }
 

--- a/clc/modules/compute-service/src/main/java/com/eucalyptus/compute/service/ComputeService.java
+++ b/clc/modules/compute-service/src/main/java/com/eucalyptus/compute/service/ComputeService.java
@@ -1337,8 +1337,18 @@ public class ComputeService {
     return request.getReply( );
   }
 
-  public DescribeVpcClassicLinkResponseType describeVpcClassicLink( DescribeVpcClassicLinkType request ) {
-    return request.getReply( );
+  public DescribeVpcClassicLinkResponseType describeVpcClassicLink( DescribeVpcClassicLinkType request ) throws EucalyptusCloudException {
+    final DescribeVpcClassicLinkResponseType reply = request.getReply( );
+    describe(
+        Identifier.vpc,
+        request.vpcIds( ),
+        request.getFilterSet( ),
+        Vpc.class,
+        VpcClassicLinkType.class,
+        reply.getVpcSet( ).getItem( ),
+        VpcClassicLinkType.id( ),
+        vpcs );
+    return reply;
   }
 
   public DetachClassicLinkVpcResponseType detachClassicLinkVpc( DetachClassicLinkVpcType request ) {


### PR DESCRIPTION
Fix the query request binding for the ec2 vpc `DescribeVpcClassicLink` action and add a hard-coded false response for the classic link status of all vpcs.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1446
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1447

Test was run against this fix merged to maint-5.

Demo is that the action now binds the request and returns a hard-coded response:

```
# aws ec2 describe-vpc-classic-link --vpc-id vpc-bcf46a40cb2d2e859
VPCS	False	vpc-bcf46a40cb2d2e859
```

Relates to corymbia/eucalyptus#321