### PR TITLE
AutoScaling group creation should not require availability zones

### DIFF
--- a/clc/modules/autoscaling-common/src/main/resources/autoscaling-binding.xml
+++ b/clc/modules/autoscaling-common/src/main/resources/autoscaling-binding.xml
@@ -127,7 +127,7 @@
     <value name="MaxSize" field="maxSize" usage="optional"/>
     <value name="DesiredCapacity" field="desiredCapacity" usage="optional"/>
     <value name="DefaultCooldown" field="defaultCooldown" usage="optional"/>
-    <structure name="AvailabilityZones" field="availabilityZones" usage="required" type="com.eucalyptus.autoscaling.common.msgs.AvailabilityZones"/>
+    <structure name="AvailabilityZones" field="availabilityZones" usage="optional" type="com.eucalyptus.autoscaling.common.msgs.AvailabilityZones"/>
     <structure name="LoadBalancerNames" field="loadBalancerNames" usage="optional" type="com.eucalyptus.autoscaling.common.msgs.LoadBalancerNames"/>
     <value name="HealthCheckType" field="healthCheckType" usage="optional"/>
     <value name="HealthCheckGracePeriod" field="healthCheckGracePeriod" usage="optional"/>


### PR DESCRIPTION
The `AvailabilityZones` structure is now optional in the `CreateAutoScalingGroup` binding.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1451
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1452

Tests were run against this pull request merged to maint-5.

Demo is to create a vpc without specifying zones:

```
# euscale-create-auto-scaling-group -l config-1 -M 0 -m 0 --desired-capacity 0 --vpc-zone-identifier subnet-7ea90101dac029320 group-1
```

Relates to corymbia/eucalyptus#324