### PR TITLE
AutoScaling group creation should not require availability zones (master)

### DIFF
--- a/clc/modules/autoscaling-common/src/main/resources/autoscaling-binding.xml
+++ b/clc/modules/autoscaling-common/src/main/resources/autoscaling-binding.xml
@@ -127,7 +127,7 @@
     <value name="MaxSize" field="maxSize" usage="optional"/>
     <value name="DesiredCapacity" field="desiredCapacity" usage="optional"/>
     <value name="DefaultCooldown" field="defaultCooldown" usage="optional"/>
-    <structure name="AvailabilityZones" field="availabilityZones" usage="required" type="com.eucalyptus.autoscaling.common.msgs.AvailabilityZones"/>
+    <structure name="AvailabilityZones" field="availabilityZones" usage="optional" type="com.eucalyptus.autoscaling.common.msgs.AvailabilityZones"/>
     <structure name="LoadBalancerNames" field="loadBalancerNames" usage="optional" type="com.eucalyptus.autoscaling.common.msgs.LoadBalancerNames"/>
     <value name="HealthCheckType" field="healthCheckType" usage="optional"/>
     <value name="HealthCheckGracePeriod" field="healthCheckGracePeriod" usage="optional"/>


### PR DESCRIPTION
Merge to master for the 5.2 pull request corymbia/eucalyptus#325

> The AvailabilityZones structure is now optional in the CreateAutoScalingGroup binding.

Relates to corymbia/eucalyptus#324
