### PR TITLE
EC2 VPC subnet attribute stubs for customer and ipv6 ip addresses (master)

### DIFF
--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifySubnetAttributeType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/ModifySubnetAttributeType.java
@@ -31,6 +31,8 @@ package com.eucalyptus.compute.common;
 public class ModifySubnetAttributeType extends VpcMessage {
 
   private String subnetId;
+  private AttributeBooleanValueType assignIpv6AddressOnCreation;
+  private AttributeBooleanValueType mapCustomerOwnedIpOnLaunch;
   private AttributeBooleanValueType mapPublicIpOnLaunch;
 
   public String getSubnetId( ) {
@@ -39,6 +41,24 @@ public class ModifySubnetAttributeType extends VpcMessage {
 
   public void setSubnetId( String subnetId ) {
     this.subnetId = subnetId;
+  }
+
+  public AttributeBooleanValueType getAssignIpv6AddressOnCreation() {
+    return assignIpv6AddressOnCreation;
+  }
+
+  public void setAssignIpv6AddressOnCreation(
+      AttributeBooleanValueType assignIpv6AddressOnCreation) {
+    this.assignIpv6AddressOnCreation = assignIpv6AddressOnCreation;
+  }
+
+  public AttributeBooleanValueType getMapCustomerOwnedIpOnLaunch() {
+    return mapCustomerOwnedIpOnLaunch;
+  }
+
+  public void setMapCustomerOwnedIpOnLaunch(
+      AttributeBooleanValueType mapCustomerOwnedIpOnLaunch) {
+    this.mapCustomerOwnedIpOnLaunch = mapCustomerOwnedIpOnLaunch;
   }
 
   public AttributeBooleanValueType getMapPublicIpOnLaunch( ) {

--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/SubnetType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/SubnetType.java
@@ -41,6 +41,8 @@ public class SubnetType extends EucalyptusData implements ResourceTagged {
   private String availabilityZone;
   private Boolean defaultForAz;
   private Boolean mapPublicIpOnLaunch;
+  private Boolean mapCustomerOwnedIpOnLaunch;
+  private Boolean assignIpv6AddressOnCreation;
   private ResourceTagSetType tagSet;
 
   public SubnetType( ) {
@@ -55,6 +57,8 @@ public class SubnetType extends EucalyptusData implements ResourceTagged {
     this.availabilityZone = availabilityZone;
     this.defaultForAz = defaultForAz;
     this.mapPublicIpOnLaunch = mapPublicIpOnLaunch;
+    this.mapCustomerOwnedIpOnLaunch = false;
+    this.assignIpv6AddressOnCreation = false;
   }
 
   public static CompatFunction<SubnetType, String> id( ) {
@@ -137,6 +141,22 @@ public class SubnetType extends EucalyptusData implements ResourceTagged {
 
   public void setMapPublicIpOnLaunch( Boolean mapPublicIpOnLaunch ) {
     this.mapPublicIpOnLaunch = mapPublicIpOnLaunch;
+  }
+
+  public Boolean getMapCustomerOwnedIpOnLaunch() {
+    return mapCustomerOwnedIpOnLaunch;
+  }
+
+  public void setMapCustomerOwnedIpOnLaunch(Boolean mapCustomerOwnedIpOnLaunch) {
+    this.mapCustomerOwnedIpOnLaunch = mapCustomerOwnedIpOnLaunch;
+  }
+
+  public Boolean getAssignIpv6AddressOnCreation() {
+    return assignIpv6AddressOnCreation;
+  }
+
+  public void setAssignIpv6AddressOnCreation(Boolean assignIpv6AddressOnCreation) {
+    this.assignIpv6AddressOnCreation = assignIpv6AddressOnCreation;
   }
 
   public ResourceTagSetType getTagSet( ) {

--- a/clc/modules/compute-common-msgs/src/main/resources/ec2-vpc-16-11-15.xml
+++ b/clc/modules/compute-common-msgs/src/main/resources/ec2-vpc-16-11-15.xml
@@ -1628,11 +1628,14 @@
     <value name="state" field="state" usage="optional"/>
     <value name="vpcId" field="vpcId" usage="optional"/>
     <value name="cidrBlock" field="cidrBlock" usage="optional"/>
+    <structure name="ipv6CidrBlockAssociationSet" usage="required"/>
     <value name="availableIpAddressCount" field="availableIpAddressCount" usage="optional"/>
     <value name="availabilityZone" field="availabilityZone" usage="optional"/>
     <value name="defaultForAz" field="defaultForAz" usage="optional"/>
     <value name="mapPublicIpOnLaunch" field="mapPublicIpOnLaunch" usage="optional"/>
     <structure name="tagSet" field="tagSet" usage="optional" type="com.eucalyptus.compute.common.ResourceTagSetType"/>
+    <value name="assignIpv6AddressOnCreation" field="assignIpv6AddressOnCreation" usage="optional"/>
+    <value name="mapCustomerOwnedIpOnLaunch" field="mapCustomerOwnedIpOnLaunch" usage="optional"/>
   </mapping>
   <mapping class="com.eucalyptus.compute.common.CustomerGatewaySetType" abstract="true">
     <collection field="item">
@@ -1922,6 +1925,8 @@
   <mapping name="ModifySubnetAttribute" class="com.eucalyptus.compute.common.ModifySubnetAttributeType" extends="com.eucalyptus.compute.common.ComputeMessage">
     <structure map-as="com.eucalyptus.compute.common.ComputeMessage"/>
     <value name="subnetId" field="subnetId" usage="required"/>
+    <structure name="assignIpv6AddressOnCreation" field="assignIpv6AddressOnCreation" usage="optional" type="com.eucalyptus.compute.common.AttributeBooleanValueType"/>
+    <structure name="mapCustomerOwnedIpOnLaunch" field="mapCustomerOwnedIpOnLaunch" usage="optional" type="com.eucalyptus.compute.common.AttributeBooleanValueType"/>
     <structure name="mapPublicIpOnLaunch" field="mapPublicIpOnLaunch" usage="optional" type="com.eucalyptus.compute.common.AttributeBooleanValueType"/>
   </mapping>
   <mapping name="ModifySubnetAttributeResponse" class="com.eucalyptus.compute.common.ModifySubnetAttributeResponseType" extends="com.eucalyptus.compute.common.ComputeMessage">


### PR DESCRIPTION
Merge to master for 5.2 fix corymbia/eucalyptus#328

> EC2 vpc subnet attribute stub implementations for assignIpv6AddressOnCreation and mapCustomerOwnedIpOnLaunch.

Relates to corymbia/eucalyptus#327