### PR TITLE
EC2 VPC cidr association information for main cidr (master)

### DIFF
--- a/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/VpcType.java
+++ b/clc/modules/compute-common-msgs/src/main/java/com/eucalyptus/compute/common/VpcType.java
@@ -36,6 +36,7 @@ public class VpcType extends EucalyptusData implements ResourceTagged {
   private String vpcId;
   private String state;
   private String cidrBlock;
+  private String cidrBlockAssociationId;
   private String dhcpOptionsId;
   private ResourceTagSetType tagSet;
   private String instanceTenancy;
@@ -48,6 +49,7 @@ public class VpcType extends EucalyptusData implements ResourceTagged {
     this.vpcId = vpcId;
     this.state = state;
     this.cidrBlock = cidrBlock;
+    this.cidrBlockAssociationId = vpcId == null ? null : vpcId.replace("vpc-", "vpc-cidr-assoc-");
     this.dhcpOptionsId = dhcpOptionsId;
     this.instanceTenancy = "default";
     this.isDefault = isDefault;
@@ -84,6 +86,14 @@ public class VpcType extends EucalyptusData implements ResourceTagged {
 
   public void setCidrBlock( String cidrBlock ) {
     this.cidrBlock = cidrBlock;
+  }
+
+  public String getCidrBlockAssociationId() {
+    return cidrBlockAssociationId;
+  }
+
+  public void setCidrBlockAssociationId(String cidrBlockAssociationId) {
+    this.cidrBlockAssociationId = cidrBlockAssociationId;
   }
 
   public String getDhcpOptionsId( ) {

--- a/clc/modules/compute-common-msgs/src/main/resources/ec2-vpc-16-11-15.xml
+++ b/clc/modules/compute-common-msgs/src/main/resources/ec2-vpc-16-11-15.xml
@@ -1618,6 +1618,15 @@
     <value name="vpcId" field="vpcId" usage="required"/>
     <value name="state" field="state" usage="optional"/>
     <value name="cidrBlock" field="cidrBlock" usage="optional"/>
+    <structure name="cidrBlockAssociationSet" usage="optional">
+      <structure name="item" usage="optional">
+        <value name="cidrBlock" field="cidrBlock" usage="optional"/>
+        <value name="associationId" field="cidrBlockAssociationId" usage="optional"/>
+        <structure name="cidrBlockState" usage="optional">
+          <value name="state" constant="associated"/>
+        </structure>
+      </structure>
+    </structure>
     <value name="dhcpOptionsId" field="dhcpOptionsId" usage="optional"/>
     <structure name="tagSet" field="tagSet" usage="optional" type="com.eucalyptus.compute.common.ResourceTagSetType"/>
     <value name="instanceTenancy" field="instanceTenancy" usage="optional"/>

--- a/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/vpc/Vpcs.java
+++ b/clc/modules/compute-common/src/main/java/com/eucalyptus/compute/common/internal/vpc/Vpcs.java
@@ -32,6 +32,7 @@ import static com.eucalyptus.compute.common.CloudMetadata.VpcMetadata;
 
 import com.eucalyptus.compute.common.internal.blockstorage.Snapshot;
 import com.eucalyptus.compute.common.internal.blockstorage.Snapshots;
+import com.eucalyptus.util.Strings;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -145,6 +146,9 @@ public interface Vpcs extends Lister<Vpc> {
           .withStringProperty( "owner-id", FilterStringFunctions.ACCOUNT_ID )
           .withStringProperty( "state", FilterStringFunctions.STATE )
           .withStringProperty( "vpc-id", FilterStringFunctions.VPC_ID )
+          .withStringProperty("cidr-block-association.cidr-block", FilterStringFunctions.CIDR )
+          .withStringProperty("cidr-block-association.association-id", FilterStringFunctions.CIDR_BLOCK_ASSOCIATION_ID )
+          .withConstantProperty("cidr-block-association.state", "associated")
           .withPersistenceAlias( "dhcpOptionSet", "dhcpOptionSet" )
           .withPersistenceFilter( "cidr" )
           .withPersistenceFilter( "cidrBlock", "cidr" )
@@ -154,9 +158,6 @@ public interface Vpcs extends Lister<Vpc> {
           .withPersistenceFilter( "owner-id", "ownerAccountNumber" )
           .withPersistenceFilter( "state", "state", FUtils.valueOfFunction( Vpc.State.class ) )
           .withPersistenceFilter( "vpc-id", "displayName" )
-          .withUnsupportedProperty("cidr-block-association.cidr-block")
-          .withUnsupportedProperty("cidr-block-association.association-id")
-          .withUnsupportedProperty("cidr-block-association.state")
           .withUnsupportedProperty("ipv6-cidr-block-association.ipv6-cidr-block")
           .withUnsupportedProperty("ipv6-cidr-block-association.ipv6-pool")
           .withUnsupportedProperty("ipv6-cidr-block-association.association-id")
@@ -176,6 +177,12 @@ public interface Vpcs extends Lister<Vpc> {
       @Override
       public String apply( final Vpc vpc ){
         return vpc.getCidr( );
+      }
+    },
+    CIDR_BLOCK_ASSOCIATION_ID {
+      @Override
+      public String apply( final Vpc vpc ){
+        return "vpc-cidr-assoc-" + Strings.trimPrefix("vpc-", vpc.getDisplayName( ));
       }
     },
     DHCP_OPTIONS_ID {


### PR DESCRIPTION
Merge to master for 5.2 pull request corymbia/eucalyptus#331

> EC2 VPC cidr association is now stubbed in describe vpc responses and can be used for filtering when describing vpcs.

Relates to corymbia/eucalyptus#330