### PR TITLE
AutoScaling tag allow empty value

### DIFF
--- a/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/AutoScalingMessageValidation.java
+++ b/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/AutoScalingMessageValidation.java
@@ -82,7 +82,7 @@ public class AutoScalingMessageValidation {
   public enum FieldRegexValue {
     // Generic
     STRING_128( "(?s).{1,128}" ),
-    STRING_256( "(?s).{1,256}" ),
+    ESTRING_256( "(?s).{0,256}" ),
     UUID_VERBOSE( "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|verbose" ),
 
     // Auto scaling

--- a/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/msgs/TagType.java
+++ b/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/msgs/TagType.java
@@ -41,7 +41,7 @@ public class TagType extends EucalyptusData {
   @Nonnull
   @AutoScalingMessageValidation.FieldRegex( AutoScalingMessageValidation.FieldRegexValue.STRING_128 )
   private String key;
-  @AutoScalingMessageValidation.FieldRegex( AutoScalingMessageValidation.FieldRegexValue.STRING_256 )
+  @AutoScalingMessageValidation.FieldRegex( AutoScalingMessageValidation.FieldRegexValue.ESTRING_256)
   private String value;
   private Boolean propagateAtLaunch;
 

--- a/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/msgs/Values.java
+++ b/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/msgs/Values.java
@@ -35,7 +35,7 @@ import edu.ucsb.eucalyptus.msgs.EucalyptusData;
 
 public class Values extends EucalyptusData {
 
-  @AutoScalingMessageValidation.FieldRegex( AutoScalingMessageValidation.FieldRegexValue.STRING_256 )
+  @AutoScalingMessageValidation.FieldRegex( AutoScalingMessageValidation.FieldRegexValue.ESTRING_256)
   @HttpParameterMapping( parameter = "member" )
   private ArrayList<String> member = new ArrayList<String>( );
 


### PR DESCRIPTION
AutoScaling now allows empty for tag values.

Build: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1463
Test: https://dev.azure.com/corymbia/eucalyptus/_build/results?buildId=1464

Demo is creating a group with aws cli and an empty value:

```
# aws autoscaling create-auto-scaling-group --launch-configuration-name config-1 --min-size 0 --max-size 0 --desired-capacity 0 --vpc-zone-identifier subnet-7ea90101dac029320 --tags Key=a,Value= --auto-scaling-group-name group-1
# aws autoscaling describe-auto-scaling-groups 
AUTOSCALINGGROUPS	arn:aws:autoscaling::000364420596:autoScalingGroup:62f87b07-d292-4338-b162-3e4802538618:autoScalingGroupName/group-1	group-1	2021-07-16T04:17:41.968Z	300	0	0	EC2	config-1	0	0	False	subnet-7ea90101dac029320
AVAILABILITYZONES	cloud-1a
TAGS	a	False	group-1	auto-scaling-group	
TERMINATIONPOLICIES	Default
```

Relates to corymbia/eucalyptus#333