### PR TITLE
 AutoScaling tag allow empty value (master)

### DIFF
--- a/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/AutoScalingMessageValidation.java
+++ b/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/AutoScalingMessageValidation.java
@@ -82,7 +82,7 @@ public class AutoScalingMessageValidation {
   public enum FieldRegexValue {
     // Generic
     STRING_128( "(?s).{1,128}" ),
-    STRING_256( "(?s).{1,256}" ),
+    ESTRING_256( "(?s).{0,256}" ),
     UUID_VERBOSE( "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|verbose" ),
 
     // Auto scaling

--- a/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/msgs/TagType.java
+++ b/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/msgs/TagType.java
@@ -41,7 +41,7 @@ public class TagType extends EucalyptusData {
   @Nonnull
   @AutoScalingMessageValidation.FieldRegex( AutoScalingMessageValidation.FieldRegexValue.STRING_128 )
   private String key;
-  @AutoScalingMessageValidation.FieldRegex( AutoScalingMessageValidation.FieldRegexValue.STRING_256 )
+  @AutoScalingMessageValidation.FieldRegex( AutoScalingMessageValidation.FieldRegexValue.ESTRING_256)
   private String value;
   private Boolean propagateAtLaunch;
 

--- a/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/msgs/Values.java
+++ b/clc/modules/autoscaling-common/src/main/java/com/eucalyptus/autoscaling/common/msgs/Values.java
@@ -35,7 +35,7 @@ import edu.ucsb.eucalyptus.msgs.EucalyptusData;
 
 public class Values extends EucalyptusData {
 
-  @AutoScalingMessageValidation.FieldRegex( AutoScalingMessageValidation.FieldRegexValue.STRING_256 )
+  @AutoScalingMessageValidation.FieldRegex( AutoScalingMessageValidation.FieldRegexValue.ESTRING_256)
   @HttpParameterMapping( parameter = "member" )
   private ArrayList<String> member = new ArrayList<String>( );
 


### PR DESCRIPTION
Merge to master for 5.2 fix corymbia/eucalyptus#334

> AutoScaling now allows empty for tag values.

Relates to corymbia/eucalyptus#333